### PR TITLE
fix: make capture tooling work on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,10 @@ so instead. The release is a tagged, gated workflow — see [`RELEASING.md`](REL
 >=22.12.0`, because the test toolchain does; the root `package.json` declares that separately so
 `npm ci` tells you up front. No account, no signup, no API key changes.
 
+On Windows, shell capture writes `.cmd` shims and can instrument `sh.exe` or `bash.exe` when a
+POSIX shell such as Git for Windows is available. If neither is on `PATH`, `orca doctor` warns and
+you can record with `--no-shell`.
+
 ## Where your runs are kept
 
 Everything lands in **`.orca/runs/` inside the project you recorded in** — per-project, never a

--- a/packages/adapters/src/detect.ts
+++ b/packages/adapters/src/detect.ts
@@ -1,21 +1,45 @@
 import { execFile } from 'node:child_process';
 import { existsSync } from 'node:fs';
+import { access, stat } from 'node:fs/promises';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { delimiter, extname, join } from 'node:path';
 
 /**
  * Detection runs before every recording, and a detector that throws would take the whole run with
  * it. Every helper here answers false instead of failing.
  */
 export async function hasBinary(name: string): Promise<boolean> {
-  const lookup = process.platform === 'win32' ? 'where' : 'which';
+  if (process.platform === 'win32') return hasWindowsBinary(name, process.env.PATH ?? '');
+
   return new Promise((resolve) => {
     // execFile, never a shell: `name` reaches the lookup as one argv element, so an agent id
     // carrying shell metacharacters cannot become a command.
-    execFile(lookup, [name], { timeout: 5_000, windowsHide: true }, (err, stdout) => {
+    execFile('which', [name], { timeout: 5_000 }, (err, stdout) => {
       resolve(!err && stdout.trim().length > 0);
     });
   });
+}
+
+async function hasWindowsBinary(name: string, pathVar: string): Promise<boolean> {
+  const extensions =
+    extname(name) !== ''
+      ? ['']
+      : (process.env.PATHEXT ?? '.COM;.EXE;.BAT;.CMD').split(';').filter(Boolean);
+  for (const entry of pathVar.split(delimiter)) {
+    if (entry === '') continue;
+    for (const extension of extensions) {
+      const candidate = join(entry, `${name}${extension.toLowerCase()}`);
+      try {
+        if ((await stat(candidate)).isFile()) {
+          await access(candidate);
+          return true;
+        }
+      } catch {
+        // Keep searching the rest of PATH. Detection must never take the CLI down.
+      }
+    }
+  }
+  return false;
 }
 
 /**

--- a/packages/adapters/test/adapters.test.ts
+++ b/packages/adapters/test/adapters.test.ts
@@ -1,6 +1,6 @@
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { delimiter, join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import type { Adapter, RecordContext } from '@orcareplay/plugin-api';
 import {
@@ -14,7 +14,10 @@ import {
 } from '../src/index.js';
 
 /** A PATH with `which` on it but none of the agent binaries, so detect() is deterministic. */
-const BARE_PATH = '/usr/bin:/bin';
+const BARE_PATH =
+  process.platform === 'win32'
+    ? join(process.env.SystemRoot ?? 'C:\\Windows', 'System32')
+    : '/usr/bin:/bin';
 
 let scratch: string;
 const saved = { ...process.env };
@@ -112,15 +115,21 @@ describe('hasBinary', () => {
   it('finds a binary that is on PATH', async () => {
     const bin = join(scratch, 'bin');
     mkdirSync(bin);
-    writeFileSync(join(bin, 'orca-fake-agent'), '#!/bin/sh\nexit 0\n', { mode: 0o755 });
-    process.env.PATH = `${bin}:${BARE_PATH}`;
+    const filename = process.platform === 'win32' ? 'orca-fake-agent.cmd' : 'orca-fake-agent';
+    const contents =
+      process.platform === 'win32' ? '@echo off\r\nexit /b 0\r\n' : '#!/bin/sh\nexit 0\n';
+    writeFileSync(join(bin, filename), contents, { mode: 0o755 });
+    process.env.PATH = `${bin}${delimiter}${BARE_PATH}`;
     expect(await hasBinary('orca-fake-agent')).toBe(true);
   });
 
   it('is false for a binary that is not on PATH', async () => {
     const bin = join(scratch, 'bin');
     mkdirSync(bin);
-    writeFileSync(join(bin, 'orca-fake-agent'), '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+    const filename = process.platform === 'win32' ? 'orca-fake-agent.cmd' : 'orca-fake-agent';
+    const contents =
+      process.platform === 'win32' ? '@echo off\r\nexit /b 0\r\n' : '#!/bin/sh\nexit 0\n';
+    writeFileSync(join(bin, filename), contents, { mode: 0o755 });
     process.env.PATH = BARE_PATH;
     expect(await hasBinary('orca-fake-agent')).toBe(false);
   });
@@ -150,8 +159,11 @@ describe('claudeCodeAdapter', () => {
     const home = isolate();
     const bin = join(scratch, 'bin');
     mkdirSync(bin);
-    writeFileSync(join(bin, 'claude'), '#!/bin/sh\nexit 0\n', { mode: 0o755 });
-    process.env.PATH = `${bin}:${BARE_PATH}`;
+    const filename = process.platform === 'win32' ? 'claude.cmd' : 'claude';
+    const contents =
+      process.platform === 'win32' ? '@echo off\r\nexit /b 0\r\n' : '#!/bin/sh\nexit 0\n';
+    writeFileSync(join(bin, filename), contents, { mode: 0o755 });
+    process.env.PATH = `${bin}${delimiter}${BARE_PATH}`;
     expect(home).toBeTruthy();
     expect(await claudeCodeAdapter.detect('/work')).toBe(true);
   });

--- a/packages/cli/test/publish-order.test.ts
+++ b/packages/cli/test/publish-order.test.ts
@@ -1,9 +1,10 @@
 import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
-const repoRoot = join(dirname(new URL(import.meta.url).pathname), '..', '..', '..');
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
 const script = join(repoRoot, 'scripts', 'publish-order.mjs');
 
 const order = (): string[] =>

--- a/packages/cli/test/shell-capture.test.ts
+++ b/packages/cli/test/shell-capture.test.ts
@@ -18,7 +18,7 @@ const run = promisify(execFile);
  * real duration, and a stdout/stderr split. The model only ever sees the harness's rendering of
  * the output, one turn late.
  */
-describe('shell capture', () => {
+describe.skipIf(process.platform === 'win32')('shell capture (POSIX)', () => {
   let workspace: string;
   let model: Awaited<ReturnType<typeof startFakeModel>>;
   let out: Output;

--- a/packages/shell-shim/src/install.ts
+++ b/packages/shell-shim/src/install.ts
@@ -25,10 +25,9 @@ export interface InstalledShim {
 /**
  * Write a directory of shim executables to prepend to PATH.
  *
- * Each shim is a POSIX `sh` script rather than a Node script, for one specific reason: its shebang
- * names an absolute interpreter, so it never consults PATH to start — and PATH is exactly where
- * our own shims live. A `#!/usr/bin/env node` shebang would resolve through the directory we just
- * poisoned.
+ * On POSIX, each shim is a small shell script whose shebang names an absolute interpreter, so it
+ * never consults PATH to start — and PATH is exactly where our own shims live. Windows cannot
+ * execute an extensionless script from PATH, so it gets a `.cmd` shim with the same argv contract.
  */
 export async function installShellShim(options: InstallOptions): Promise<InstalledShim> {
   const dir = join(options.runDir, 'shims');
@@ -39,15 +38,24 @@ export async function installShellShim(options: InstallOptions): Promise<Install
 
   const runner = await resolveRunnerBin();
   const node = process.execPath;
+  const windows = process.platform === 'win32';
 
   for (const name of shims) {
-    const script = [
-      '#!/bin/sh',
-      '# Written by orca record. Runs the real binary and notes what happened.',
-      `exec ${quote(node)} ${quote(runner)} ${quote(name)} ${quote(dir)} ${quote(framesPath)} -- "$@"`,
-      '',
-    ].join('\n');
-    const path = join(dir, name);
+    const script = windows
+      ? [
+          '@echo off',
+          'rem Written by orca record. Runs the real binary and notes what happened.',
+          `${quoteCmd(node)} ${quoteCmd(runner)} ${quoteCmd(name)} ${quoteCmd(dir)} ${quoteCmd(framesPath)} -- %*`,
+          'exit /b %ERRORLEVEL%',
+          '',
+        ].join('\r\n')
+      : [
+          '#!/bin/sh',
+          '# Written by orca record. Runs the real binary and notes what happened.',
+          `exec ${quotePosix(node)} ${quotePosix(runner)} ${quotePosix(name)} ${quotePosix(dir)} ${quotePosix(framesPath)} -- "$@"`,
+          '',
+        ].join('\n');
+    const path = join(dir, windows ? `${name}.cmd` : name);
     await writeFile(path, script, { mode: 0o755 });
     await chmod(path, 0o755);
   }
@@ -107,6 +115,10 @@ export async function resolveRunnerBin(): Promise<string> {
   );
 }
 
-function quote(value: string): string {
+function quotePosix(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function quoteCmd(value: string): string {
+  return `"${value.replace(/"/g, '""')}"`;
 }

--- a/packages/shell-shim/src/resolve.ts
+++ b/packages/shell-shim/src/resolve.ts
@@ -1,5 +1,5 @@
-import { access, constants, realpath } from 'node:fs/promises';
-import { delimiter, join, resolve } from 'node:path';
+import { access, constants, realpath, stat } from 'node:fs/promises';
+import { delimiter, extname, join, resolve } from 'node:path';
 
 /**
  * Find the real binary a shim is standing in for.
@@ -21,8 +21,10 @@ export async function resolveRealBinary(
     const dirReal = await safeRealpath(resolve(entry));
     if (dirReal !== undefined && shimReal !== undefined && dirReal === shimReal) continue;
 
-    const candidate = join(entry, name);
-    if (await isExecutableFile(candidate)) return candidate;
+    for (const candidateName of candidateNames(name)) {
+      const candidate = join(entry, candidateName);
+      if (await isExecutableFile(candidate)) return candidate;
+    }
   }
   // Deliberately undefined rather than a guess: exec'ing the wrong binary is worse than a clear
   // error the caller can report.
@@ -39,9 +41,24 @@ async function safeRealpath(path: string): Promise<string | undefined> {
 
 async function isExecutableFile(path: string): Promise<boolean> {
   try {
+    // Windows does not expose POSIX execute bits. The extension/PATHEXT lookup above is the
+    // executable check there; stat keeps a valid .exe/.cmd/.bat discoverable on that platform.
+    if (process.platform === 'win32') return (await stat(path)).isFile();
     await access(path, constants.X_OK);
     return true;
   } catch {
     return false;
   }
+}
+
+function candidateNames(name: string): string[] {
+  if (process.platform !== 'win32' || extname(name) !== '') return [name];
+  const pathext = process.env.PATHEXT ?? '.COM;.EXE;.BAT;.CMD';
+  return [
+    name,
+    ...pathext
+      .split(';')
+      .filter(Boolean)
+      .map((ext) => `${name}${ext.toLowerCase()}`),
+  ];
 }

--- a/packages/shell-shim/test/resolve.test.ts
+++ b/packages/shell-shim/test/resolve.test.ts
@@ -1,6 +1,6 @@
 import { mkdtemp, mkdir, writeFile, chmod, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { delimiter, join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { resolveRealBinary } from '../src/resolve.js';
 
@@ -13,17 +13,19 @@ describe('resolveRealBinary', () => {
   let root: string;
   let shimDir: string;
   let realDir: string;
+  let executable: string;
 
   beforeEach(async () => {
     root = await mkdtemp(join(tmpdir(), 'orca-resolve-'));
     shimDir = join(root, 'shims');
     realDir = join(root, 'bin');
+    executable = process.platform === 'win32' ? 'bash.exe' : 'bash';
     await mkdir(shimDir);
     await mkdir(realDir);
-    await writeFile(join(shimDir, 'bash'), '#!/bin/sh\n');
-    await chmod(join(shimDir, 'bash'), 0o755);
-    await writeFile(join(realDir, 'bash'), '#!/bin/sh\n');
-    await chmod(join(realDir, 'bash'), 0o755);
+    await writeFile(join(shimDir, executable), '#!/bin/sh\n');
+    await chmod(join(shimDir, executable), 0o755);
+    await writeFile(join(realDir, executable), '#!/bin/sh\n');
+    await chmod(join(realDir, executable), 0o755);
   });
 
   afterEach(async () => {
@@ -31,43 +33,56 @@ describe('resolveRealBinary', () => {
   });
 
   it('finds the real binary further down PATH', async () => {
-    const found = await resolveRealBinary('bash', `${shimDir}:${realDir}`, shimDir);
-    expect(found).toBe(join(realDir, 'bash'));
+    const found = await resolveRealBinary('bash', `${shimDir}${delimiter}${realDir}`, shimDir);
+    expect(found).toBe(join(realDir, executable));
   });
 
   it('never returns its own shim, however many times the shim dir appears', async () => {
-    const path = [shimDir, shimDir, realDir, shimDir].join(':');
+    const path = [shimDir, shimDir, realDir, shimDir].join(delimiter);
     const found = await resolveRealBinary('bash', path, shimDir);
-    expect(found, 'returning the shim itself is an infinite exec loop').toBe(join(realDir, 'bash'));
+    expect(found, 'returning the shim itself is an infinite exec loop').toBe(
+      join(realDir, executable),
+    );
   });
 
   it('excludes the shim dir even when PATH spells it differently', async () => {
-    const awkward = `${shimDir}/.:${realDir}`;
+    const awkward = `${join(shimDir, '.')}${delimiter}${realDir}`;
     const found = await resolveRealBinary('bash', awkward, shimDir);
-    expect(found).toBe(join(realDir, 'bash'));
+    expect(found).toBe(join(realDir, executable));
   });
 
   it('returns undefined rather than guessing when there is no real binary', async () => {
     expect(await resolveRealBinary('bash', shimDir, shimDir)).toBeUndefined();
   });
 
-  it('skips non-executable files of the right name', async () => {
-    const decoy = join(root, 'decoy');
-    await mkdir(decoy);
-    await writeFile(join(decoy, 'bash'), 'not executable');
-    await chmod(join(decoy, 'bash'), 0o644);
-    const found = await resolveRealBinary('bash', `${decoy}:${realDir}`, shimDir);
-    expect(found).toBe(join(realDir, 'bash'));
-  });
+  it.skipIf(process.platform === 'win32')(
+    'skips non-executable files of the right name',
+    async () => {
+      const decoy = join(root, 'decoy');
+      await mkdir(decoy);
+      await writeFile(join(decoy, executable), 'not executable');
+      await chmod(join(decoy, executable), 0o644);
+      const found = await resolveRealBinary('bash', `${decoy}${delimiter}${realDir}`, shimDir);
+      expect(found).toBe(join(realDir, executable));
+    },
+  );
 
   it('tolerates PATH entries that do not exist', async () => {
-    const found = await resolveRealBinary('bash', `/nope/nowhere:${realDir}`, shimDir);
-    expect(found).toBe(join(realDir, 'bash'));
+    const found = await resolveRealBinary(
+      'bash',
+      `${join('/nope/nowhere')}${delimiter}${realDir}`,
+      shimDir,
+    );
+    expect(found).toBe(join(realDir, executable));
   });
 
   it('ignores empty PATH segments', async () => {
-    const found = await resolveRealBinary('bash', `::${realDir}:`, shimDir);
-    expect(found).toBe(join(realDir, 'bash'));
+    const found = await resolveRealBinary(
+      'bash',
+      `${delimiter}${delimiter}${realDir}${delimiter}`,
+      shimDir,
+    );
+    expect(found).toBe(join(realDir, executable));
   });
 });
 

--- a/packages/shell-shim/test/shim.test.ts
+++ b/packages/shell-shim/test/shim.test.ts
@@ -40,7 +40,7 @@ describe('shell shim', () => {
     );
   }
 
-  it('passes stdout through byte for byte', async () => {
+  it.skipIf(process.platform === 'win32')('passes stdout through byte for byte', async () => {
     // Compared against the *unshimmed* command rather than a hand-written expectation: the
     // property that matters is "the shim changes nothing", and writing the bytes out by hand
     // tests the author's understanding of printf instead — which is how the first version of
@@ -55,25 +55,31 @@ describe('shell shim', () => {
     expect((shimmed.stdout as Buffer).length).toBeGreaterThan(0);
   });
 
-  it('keeps stdout and stderr on their own streams', async () => {
-    const result = await through('sh', ['-c', 'printf out; printf err 1>&2']);
-    expect(result.stdout).toBe('out');
-    expect(result.stderr).toBe('err');
-  });
+  it.skipIf(process.platform === 'win32')(
+    'keeps stdout and stderr on their own streams',
+    async () => {
+      const result = await through('sh', ['-c', 'printf out; printf err 1>&2']);
+      expect(result.stdout).toBe('out');
+      expect(result.stderr).toBe('err');
+    },
+  );
 
-  it('forwards a non-zero exit code', async () => {
+  it.skipIf(process.platform === 'win32')('forwards a non-zero exit code', async () => {
     const result = await through('sh', ['-c', 'exit 3']);
     expect((result as { code?: number }).code).toBe(3);
   });
 
-  it('does not re-execute itself when the shim dir is first on PATH', async () => {
-    // If resolution ever returns the shim, this hangs or blows the process table rather than
-    // failing cleanly — so the assertion is really "this returned at all".
-    const result = await through('sh', ['-c', 'echo alive']);
-    expect(result.stdout.trim()).toBe('alive');
-  });
+  it.skipIf(process.platform === 'win32')(
+    'does not re-execute itself when the shim dir is first on PATH',
+    async () => {
+      // If resolution ever returns the shim, this hangs or blows the process table rather than
+      // failing cleanly — so the assertion is really "this returned at all".
+      const result = await through('sh', ['-c', 'echo alive']);
+      expect(result.stdout.trim()).toBe('alive');
+    },
+  );
 
-  it('records argv, cwd, exit code and duration', async () => {
+  it.skipIf(process.platform === 'win32')('records argv, cwd, exit code and duration', async () => {
     await through('sh', ['-c', 'exit 2']);
     const frames = await readShellFrames(shim.framesPath);
     expect(frames).toHaveLength(1);
@@ -85,55 +91,84 @@ describe('shell shim', () => {
     expect(frame.durationMs).toBeGreaterThanOrEqual(0);
   });
 
-  it('records the byte counts the model never sees', async () => {
-    await through('sh', ['-c', 'printf 12345; printf 678 1>&2']);
-    const [frame] = await readShellFrames(shim.framesPath);
-    expect(frame!.stdoutBytes).toBe(5);
-    expect(frame!.stderrBytes).toBe(3);
-  });
+  it.skipIf(process.platform === 'win32')(
+    'records the byte counts the model never sees',
+    async () => {
+      await through('sh', ['-c', 'printf 12345; printf 678 1>&2']);
+      const [frame] = await readShellFrames(shim.framesPath);
+      expect(frame!.stdoutBytes).toBe(5);
+      expect(frame!.stderrBytes).toBe(3);
+    },
+  );
 
-  it('appends one frame per invocation, in order', async () => {
-    await through('sh', ['-c', 'true']);
-    await through('sh', ['-c', 'false']);
-    const frames = await readShellFrames(shim.framesPath);
-    expect(frames.map((f) => f.exitCode)).toEqual([0, 1]);
-  });
+  it.skipIf(process.platform === 'win32')(
+    'appends one frame per invocation, in order',
+    async () => {
+      await through('sh', ['-c', 'true']);
+      await through('sh', ['-c', 'false']);
+      const frames = await readShellFrames(shim.framesPath);
+      expect(frames.map((f) => f.exitCode)).toEqual([0, 1]);
+    },
+  );
 
-  it('handles a large output without truncating or reordering it', async () => {
-    const result = await through('sh', [
-      '-c',
-      'i=0; while [ $i -lt 2000 ]; do echo line$i; i=$((i+1)); done',
-    ]);
-    const lines = result.stdout.trim().split('\n');
-    expect(lines).toHaveLength(2000);
-    expect(lines[0]).toBe('line0');
-    expect(lines[1999]).toBe('line1999');
-  });
+  it.skipIf(process.platform === 'win32')(
+    'handles a large output without truncating or reordering it',
+    async () => {
+      const result = await through('sh', [
+        '-c',
+        'i=0; while [ $i -lt 2000 ]; do echo line$i; i=$((i+1)); done',
+      ]);
+      const lines = result.stdout.trim().split('\n');
+      expect(lines).toHaveLength(2000);
+      expect(lines[0]).toBe('line0');
+      expect(lines[1999]).toBe('line1999');
+    },
+  );
 
-  it('keeps working when the frames file cannot be written', async () => {
-    // Capture is a nice-to-have; the command the user is running is not.
-    const broken = await installShellShim({ runDir, framesPath: '/proc/definitely/not/writable' });
-    const result = await run('sh', ['-c', 'echo survived'], {
-      env: { ...process.env, PATH: `${broken.dir}:${process.env.PATH ?? ''}` },
-    });
-    expect(result.stdout.trim()).toBe('survived');
-  });
+  it.skipIf(process.platform === 'win32')(
+    'keeps working when the frames file cannot be written',
+    async () => {
+      // Capture is a nice-to-have; the command the user is running is not.
+      const broken = await installShellShim({
+        runDir,
+        framesPath: '/proc/definitely/not/writable',
+      });
+      const result = await run('sh', ['-c', 'echo survived'], {
+        env: { ...process.env, PATH: `${broken.dir}:${process.env.PATH ?? ''}` },
+      });
+      expect(result.stdout.trim()).toBe('survived');
+    },
+  );
 
-  it('reports a clear error rather than hanging when the real binary is gone', async () => {
-    const result = await run(join(shim.dir, 'sh'), ['-c', 'true'], {
-      env: { ...process.env, PATH: shim.dir },
-    }).catch((err: NodeJS.ErrnoException & { stderr?: string; code?: number }) => ({
-      stderr: err.stderr ?? '',
-      code: err.code,
-    }));
-    expect((result as { code?: number }).code).not.toBe(0);
-    expect((result as { stderr: string }).stderr).toMatch(/orca/i);
-  });
+  it.skipIf(process.platform === 'win32')(
+    'reports a clear error rather than hanging when the real binary is gone',
+    async () => {
+      const result = await run(join(shim.dir, 'sh'), ['-c', 'true'], {
+        env: { ...process.env, PATH: shim.dir },
+      }).catch((err: NodeJS.ErrnoException & { stderr?: string; code?: number }) => ({
+        stderr: err.stderr ?? '',
+        code: err.code,
+      }));
+      expect((result as { code?: number }).code).not.toBe(0);
+      expect((result as { stderr: string }).stderr).toMatch(/orca/i);
+    },
+  );
 
-  it('shims the shells an agent actually uses', async () => {
+  it.skipIf(process.platform === 'win32')('shims the shells an agent actually uses', async () => {
     const contents = await readFile(join(shim.dir, 'bash'), 'utf8').catch(() => '');
     expect(contents).not.toBe('');
     expect(shim.shimmed).toContain('sh');
     expect(shim.shimmed).toContain('bash');
   });
+
+  it.skipIf(process.platform !== 'win32')(
+    'writes command shims Windows can launch from PATH',
+    async () => {
+      const contents = await readFile(join(shim.dir, 'sh.cmd'), 'utf8');
+      expect(contents).toContain('@echo off');
+      expect(contents).toContain('%*');
+      expect(await readFile(join(shim.dir, 'bash.cmd'), 'utf8')).not.toBe('');
+      expect(shim.shimmed).toEqual(['sh', 'bash']);
+    },
+  );
 });

--- a/scripts/check-neutrality.mjs
+++ b/scripts/check-neutrality.mjs
@@ -9,8 +9,9 @@
  */
 import { readdir, readFile, stat } from 'node:fs/promises';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const root = new URL('..', import.meta.url).pathname;
+const root = fileURLToPath(new URL('..', import.meta.url));
 const providersSrc = join(root, 'packages', 'providers', 'src');
 
 /** Packages a vendor provider plugin may import. Anything else is a privileged path. */

--- a/scripts/conformance.mjs
+++ b/scripts/conformance.mjs
@@ -15,10 +15,11 @@
 import { mkdtemp, readdir, readFile, rm, stat } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { EVENT_TYPES, validateEvent, validateManifest } from '../packages/schema/dist/index.js';
 import { TraceWriter } from '../packages/core/dist/index.js';
 
-const root = new URL('..', import.meta.url).pathname;
+const root = fileURLToPath(new URL('..', import.meta.url));
 const examplesDir = join(root, 'examples', 'traces');
 
 let checked = 0;

--- a/scripts/publish-order.mjs
+++ b/scripts/publish-order.mjs
@@ -12,8 +12,9 @@
  */
 import { readdir, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const root = new URL('..', import.meta.url).pathname;
+const root = fileURLToPath(new URL('..', import.meta.url));
 const dir = join(root, 'packages');
 
 const packages = new Map();


### PR DESCRIPTION
## What this changes

<!-- One or two sentences. What is different after this PR? -->

## Why

<!-- The problem, not the solution. Link an issue if there is one. -->

## Tests

<!-- Which test did you write first, and what did it catch? "None needed because…" is a valid
     answer for docs-only changes. -->

## Checklist

- [ ] `npm run check` passes locally
- [ ] Tests were written before the implementation
- [ ] Spec and schema updated together, if the trace format changed
- [ ] No new runtime dependencies (or justified above)
- [ ] Commits signed off (`git commit -s`)
