### PR TITLE
launch, capture and replay a run driven by hand on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,6 +480,7 @@ Early. `v0` is the walking skeleton of the three commands above. Everything belo
 | Shareable cards | working — `orca export --card` draws one causal chain, `--graph-card` draws the whole run with that chain lit, and `compare --share` draws the verdict table. `.svg` always; `.png` and `.gif` when the optional render toolchain is installed, which `orca doctor` reports and `npm ci` never pulls in |
 | MCP server (`orca mcp`) | working — six tools over stdio, so an agent can read, explain and replay its own runs |
 | Programmatic API (`Orca`) | working — the commands render what it returns, so the terminal is a view of one source of truth |
+| Replaying a session you typed into | working, and approximate — [what that means](#replaying-a-session-you-typed-into) |
 | Exact replay with divergence reporting | working — restores the recorded filesystem over your working tree, then puts it back; `--worktree` for a scratch copy, `--in-place` to restore nothing. Writes a run of its own recording what the replay *discovered* — divergences, unmatched requests — and points at the parent for what it merely repeated; `--no-trace` to skip |
 | Fork replay from a checkpoint | working — a fork records its own filesystem snapshots, so it is a run you can fork again |
 | Compare across models | working — `orca setup` stores a gateway (OrcaRouter by default, any URL you name otherwise), key and model list, so `orca compare` needs no flags |
@@ -492,6 +493,27 @@ Early. `v0` is the walking skeleton of the three commands above. Everything belo
 | Codex subscription model capture/replay | working — recognizes the `/backend-api/codex/responses` HTTPS fallback, decodes zstd request bodies for matching, and serves the recorded SSE response without opening the origin during replay |
 | Validated against a real agent | Claude Code, recording a real fix to a real bug: recorded, replayed offline end to end, forked from a checkpoint and exported. It broke four things no fixture could have produced, all since fixed — [what a real agent found](docs/validation.md) |
 | Subscription-auth harnesses | Claude Code works. A Codex CLI signed in with a ChatGPT subscription talks to its own backend, so there is no origin to rewrite: it needs `--tls-intercept`. With an API key it needs nothing special |
+
+## Replaying a session you typed into
+
+A run started as `orca record claude` and driven by hand has its prompts nowhere on the wire. Orca
+recovers them from the harness's own transcript and replays the session by handing them back
+without a terminal — which reproduces the conversation, and does not reproduce the run byte for
+byte. Two differences are inherent rather than defects, and orca names both rather than papering
+over them:
+
+- **The harness makes calls for itself.** A quota probe before the first turn, a request to name
+  the session, a delegation prompt written fresh for a sub-agent. A replay does not repeat them.
+  The matcher steps over them onto the next real match and reports how many, so `reused=3/5` on an
+  interactive recording is a complete replay of what you asked, not a partial one.
+- **A terminal session is offered tools a replay cannot have.** `AskUserQuestion`, `EnterPlanMode`,
+  `ExitPlanMode`, `EndConversation` all need a person in front of them, so they are absent when the
+  same agent is driven without one. Their schemas are large, so a request carrying them can differ
+  from the recorded one by enough to halt; the halt says which tools are missing and why.
+
+Recording with a prompt in argv — `orca record claude -- -p "…"` — has neither problem, because the
+replay is started exactly the way the recording was. Use that for a run you intend to replay
+exactly. Reading a run is unaffected either way: `orca show` and the viewer are complete for both.
 
 ## Install
 

--- a/packages/adapters/fixtures/harness/claude-code.json
+++ b/packages/adapters/fixtures/harness/claude-code.json
@@ -1,10 +1,10 @@
 {
   "adapter": "claude-code",
   "harness_versions": ">=1.0.0",
-  "verified_at": "2026-08-29",
+  "verified_at": "2026-08-31",
   "command": "claude",
-  "env_vars": ["ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL"],
+  "env_vars": ["ANTHROPIC_BASE_URL"],
   "base_urls": { "ANTHROPIC_BASE_URL": "" },
-  "optional_env_vars": ["ANTHROPIC_AUTH_TOKEN"],
-  "note": "Claude Code appends its own /v1 paths, so the origin goes in bare. A subscription login sends its own authorization header and ignores ANTHROPIC_API_KEY; the proxy relays that header rather than recording it."
+  "optional_env_vars": ["ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN"],
+  "note": "Claude Code appends its own /v1 paths, so the origin goes in bare. It carries its own credential store, so ANTHROPIC_API_KEY is passed through when set and never invented: a subscription login has none, and supplying the placeholder stops the launch on an interactive 'detected a custom API key' prompt and then authenticates with a key that is not real. With no key set, Claude Code sends its own authorization header and the proxy relays it."
 }

--- a/packages/adapters/fixtures/harness/codex.json
+++ b/packages/adapters/fixtures/harness/codex.json
@@ -1,10 +1,10 @@
 {
   "adapter": "codex",
   "harness_versions": null,
-  "verified_at": "2026-08-29",
+  "verified_at": "2026-08-31",
   "command": "codex",
-  "env_vars": ["OPENAI_API_KEY", "OPENAI_BASE_URL"],
+  "env_vars": ["OPENAI_BASE_URL"],
   "base_urls": { "OPENAI_BASE_URL": "/v1" },
-  "optional_env_vars": [],
-  "note": "OpenAI SDK clients expect the version segment in the base url. A Codex signed in with a ChatGPT subscription talks to its own backend, which base-url redirection does not capture."
+  "optional_env_vars": ["OPENAI_API_KEY"],
+  "note": "OPENAI_BASE_URL alone does not capture a Codex that has a config.toml: it resolves its origin from model_providers.<name>.base_url, so the adapter also passes -c model_providers.<selected>.base_url=<proxy>/v1, reading the provider name from config.toml (CODEX_HOME honoured). No placeholder key — Codex authenticates from its own auth.json. A Codex signed in with a ChatGPT subscription talks to its own backend, which base-url redirection does not capture."
 }

--- a/packages/adapters/src/claude-code.ts
+++ b/packages/adapters/src/claude-code.ts
@@ -1,10 +1,77 @@
-import type { Adapter, Launch, RecordContext } from '@orcareplay/plugin-api';
-import { detectAgent } from './detect.js';
-import { passKey, passThrough, proxyBase } from './env.js';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import type { Adapter, Launch, RecordContext, SessionSupport } from '@orcareplay/plugin-api';
+import { detectAgent, homeDir } from './detect.js';
+import { passThrough, proxyBase, readEnv } from './env.js';
+import { contentText, parseJsonl } from './session.js';
+
+/**
+ * Claude Code names a project directory after the working directory, with every character that is
+ * not a letter, a digit or a hyphen replaced by one.
+ *
+ * Checked against a real install rather than inferred: a directory called `slug_test.dir v2`
+ * becomes `slug-test-dir-v2`, so underscores, dots and spaces all fold the same way the path
+ * separators do. An earlier version replaced only `\`, `/` and `:`, which was right for every
+ * path it happened to be tested against and wrong for the first one with an underscore in it —
+ * the computed name missed the real directory by one character, and the session capture then
+ * found nothing and said nothing. Hence {@link claudeSession}'s fallback: a guess about someone
+ * else's naming should not be the only thing holding the capture up.
+ */
+export function claudeProjectSlug(cwd: string): string {
+  return cwd.replace(/[^A-Za-z0-9-]/g, '-');
+}
+
+/**
+ * Claude Code's transcript.
+ *
+ * `user` entries carry what the person typed, which is the half of a run orca cannot see from the
+ * wire. Entries the harness generates for itself — tool results, the attachments it splices in —
+ * arrive with the same `user` role, so they are filtered out: a replay driven by a tool result
+ * would ask the model something the recording never asked.
+ */
+export const claudeSession: SessionSupport = {
+  dir(cwd, env) {
+    const home = readEnv(env, 'CLAUDE_CONFIG_DIR') ?? join(homeDir(), '.claude');
+    const projects = join(home, 'projects');
+    const named = join(projects, claudeProjectSlug(cwd));
+    // The slug is a guess about someone else's naming, and a wrong guess loses the capture in
+    // silence. When the directory it names is not there, watch the whole projects tree instead:
+    // the file that changed during this run is still this run's, whatever it ended up called.
+    return existsSync(named) ? named : projects;
+  },
+
+  parse(bytes) {
+    const prompts: string[] = [];
+    let id: string | undefined;
+    for (const entry of parseJsonl(bytes)) {
+      if (typeof entry['sessionId'] === 'string') id ??= entry['sessionId'];
+      if (entry['type'] !== 'user') continue;
+      const message = entry['message'];
+      if (message === null || typeof message !== 'object') continue;
+      const text = contentText((message as { content?: unknown }).content).trim();
+      // A turn the harness synthesised, not one a person typed.
+      if (text === '' || text.startsWith('<')) continue;
+      prompts.push(text);
+    }
+    return { id, prompts };
+  },
+
+  resumeArgs(id) {
+    return ['--resume', id];
+  },
+};
 
 /**
  * Claude Code reads `ANTHROPIC_BASE_URL` for the API origin and appends its own `/v1/...` paths,
  * so the proxy url goes in bare.
+ *
+ * No placeholder key. The placeholder exists for SDK clients that refuse to construct without one,
+ * and Claude Code is not one: it carries its own credential store, and most installations sign in
+ * to claude.ai rather than setting `ANTHROPIC_API_KEY` at all. Inventing the variable for those
+ * costs the recording twice over — Claude Code stops on an interactive "detected a custom API key"
+ * prompt before it will start, and answering yes switches it off the subscription credential it
+ * was going to authenticate with and onto a key that is not real. Passing the variable through
+ * when it is genuinely set keeps the API-key path exactly as it was.
  */
 export const claudeCodeAdapter: Adapter = {
   id: 'claude-code',
@@ -18,8 +85,25 @@ export const claudeCodeAdapter: Adapter = {
 
   async prepare(ctx: RecordContext): Promise<Launch> {
     const env: Record<string, string> = { ANTHROPIC_BASE_URL: proxyBase(ctx.proxyUrl) };
-    passKey(env, ctx.env, 'ANTHROPIC_API_KEY');
+    passThrough(env, ctx.env, 'ANTHROPIC_API_KEY');
     passThrough(env, ctx.env, 'ANTHROPIC_AUTH_TOKEN');
     return { command: 'claude', args: [...ctx.userArgs], env };
+  },
+
+  session: claudeSession,
+
+  /**
+   * `--strict-mcp-config` alongside it, so the run uses the instrumented copy *instead of* the
+   * user's own servers rather than as well as them. Without it a project `.mcp.json` is still
+   * loaded, the same server is registered twice, and half its calls go round the shim.
+   */
+  mcpConfigArgs(path) {
+    return ['--mcp-config', path, '--strict-mcp-config'];
+  },
+
+  /** `-p` is how Claude Code takes a prompt without a terminal, which a replay never has. */
+  driveArgs(prompts, recorded) {
+    const first = prompts[0];
+    return first === undefined ? undefined : [...recorded, '-p', first];
   },
 };

--- a/packages/adapters/src/codex.ts
+++ b/packages/adapters/src/codex.ts
@@ -1,8 +1,94 @@
-import type { Adapter, Launch, RecordContext } from '@orcareplay/plugin-api';
-import { detectAgent } from './detect.js';
-import { passKey, proxyBase } from './env.js';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { Adapter, Launch, RecordContext, SessionSupport } from '@orcareplay/plugin-api';
+import { detectAgent, homeDir } from './detect.js';
+import { passThrough, proxyBase, readEnv } from './env.js';
+import { contentText, parseJsonl } from './session.js';
 
-/** OpenAI SDK clients expect the version segment to be part of the base url. */
+/** Where the Codex CLI keeps `config.toml`, honouring its own override. */
+function codexHome(env: Record<string, string | undefined>): string {
+  return readEnv(env, 'CODEX_HOME') ?? join(homeDir(), '.codex');
+}
+
+/**
+ * Which provider `config.toml` selects, defaulting to the built-in `openai`.
+ *
+ * A hand-rolled read of one key rather than a TOML parser: this is a top-level assignment in a
+ * file Codex writes itself, and a dependency for it would be the only one in this package.
+ * Anything unparseable falls back to the default, because a malformed config must degrade the
+ * capture rather than stop the run.
+ */
+export function selectedProvider(configToml: string): string {
+  for (const line of configToml.split(/\r?\n/)) {
+    const text = line.trim();
+    // Stop at the first table header: `model_provider` is a top-level key, and a same-named key
+    // inside `[model_providers.x]` is a different setting entirely.
+    if (text.startsWith('[')) break;
+    const match = /^model_provider\s*=\s*["']([^"']+)["']/.exec(text);
+    if (match?.[1]) return match[1];
+  }
+  return 'openai';
+}
+
+/**
+ * Codex's rollout.
+ *
+ * The user's turns arrive as `response_item` messages whose content is `input_text`. The harness
+ * puts its own preamble through the same channel — skills, environment context, multi-agent
+ * instructions — and those are wrapped in a tag, which is what separates them from a typed turn.
+ */
+export const codexSession: SessionSupport = {
+  dir(_cwd, env) {
+    return join(codexHome(env), 'sessions');
+  },
+
+  parse(bytes) {
+    const prompts: string[] = [];
+    let id: string | undefined;
+    for (const entry of parseJsonl(bytes)) {
+      const payload = entry['payload'];
+      if (payload === null || typeof payload !== 'object') continue;
+      const p = payload as Record<string, unknown>;
+      if (entry['type'] === 'session_meta' && typeof p['id'] === 'string') id ??= p['id'];
+      if (entry['type'] !== 'response_item' || p['type'] !== 'message') continue;
+      if (p['role'] !== undefined && p['role'] !== 'user') continue;
+      const content = p['content'];
+      if (!Array.isArray(content)) continue;
+      const text = content
+        .filter(
+          (b) =>
+            b !== null && typeof b === 'object' && (b as { type?: string }).type === 'input_text',
+        )
+        .map((b) => String((b as { text?: unknown }).text ?? ''))
+        .join('')
+        .trim();
+      if (text === '' || text.startsWith('<')) continue;
+      prompts.push(text);
+    }
+    return { id, prompts };
+  },
+
+  resumeArgs(id) {
+    return ['exec', 'resume', id];
+  },
+};
+
+/**
+ * Codex CLI.
+ *
+ * `OPENAI_BASE_URL` is set for the built-in provider, but it is not enough on its own and never
+ * was: Codex resolves its origin from `model_providers.<name>.base_url` in `config.toml`, so an
+ * installation pointed at a gateway — which is the reason most people have a `config.toml` at all
+ * — ignores the variable completely and talks straight to its own endpoint. The recording then
+ * ends with `capture.empty` and nothing to replay, having cost a full run of real tokens.
+ *
+ * `-c` is Codex's own flag for overriding exactly one config value for one invocation, so the
+ * override is scoped to the run and the user's file is never touched. The provider name has to be
+ * read from that file, because the key to override is named after whichever provider is selected.
+ *
+ * No placeholder key: Codex carries its own credential store in `auth.json`, and inventing
+ * `OPENAI_API_KEY` overrides it with something that is not real.
+ */
 export const codexAdapter: Adapter = {
   id: 'codex',
 
@@ -11,8 +97,36 @@ export const codexAdapter: Adapter = {
   },
 
   async prepare(ctx: RecordContext): Promise<Launch> {
-    const env: Record<string, string> = { OPENAI_BASE_URL: proxyBase(ctx.proxyUrl, 'v1') };
-    passKey(env, ctx.env, 'OPENAI_API_KEY');
-    return { command: 'codex', args: [...ctx.userArgs], env };
+    const base = proxyBase(ctx.proxyUrl, 'v1');
+    const env: Record<string, string> = { OPENAI_BASE_URL: base };
+    passThrough(env, ctx.env, 'OPENAI_API_KEY');
+
+    let provider = 'openai';
+    try {
+      provider = selectedProvider(await readFile(join(codexHome(ctx.env), 'config.toml'), 'utf8'));
+    } catch {
+      // No config, or unreadable: the built-in provider is the right guess, and `OPENAI_BASE_URL`
+      // covers it as well. Capture must never depend on a file existing.
+    }
+
+    // Ahead of the user's own arguments so that anything they pass explicitly still wins.
+    const args = ['-c', `model_providers.${provider}.base_url=${base}`, ...ctx.userArgs];
+    return { command: 'codex', args, env };
+  },
+
+  session: codexSession,
+
+  /**
+   * `exec` is Codex's non-interactive form and takes the prompt as its positional argument.
+   *
+   * A run recorded as `codex exec` with the prompt on stdin already carries the subcommand and its
+   * flags, so the prompt is appended to what was recorded; a run recorded bare needs the whole
+   * form. `--skip-git-repo-check` because a replay runs in a scratch directory that is not one.
+   */
+  driveArgs(prompts, recorded) {
+    const first = prompts[0];
+    if (first === undefined) return undefined;
+    if (recorded.includes('exec')) return [...recorded, first];
+    return ['exec', '--skip-git-repo-check', first];
   },
 };

--- a/packages/adapters/src/detect.ts
+++ b/packages/adapters/src/detect.ts
@@ -9,7 +9,9 @@ import { delimiter, extname, join } from 'node:path';
  * it. Every helper here answers false instead of failing.
  */
 export async function hasBinary(name: string): Promise<boolean> {
-  if (process.platform === 'win32') return hasWindowsBinary(name, process.env.PATH ?? '');
+  if (process.platform === 'win32') {
+    return (await resolveWindowsBinary(name, process.env.PATH ?? '')) !== undefined;
+  }
 
   return new Promise((resolve) => {
     // execFile, never a shell: `name` reaches the lookup as one argv element, so an agent id
@@ -20,7 +22,67 @@ export async function hasBinary(name: string): Promise<boolean> {
   });
 }
 
-async function hasWindowsBinary(name: string, pathVar: string): Promise<boolean> {
+/**
+ * The path a launcher must actually spawn, or undefined when the name is not on PATH.
+ *
+ * Detection and launching have to agree. On Windows an npm-installed agent is three shims —
+ * `claude`, `claude.cmd`, `claude.ps1` — and only the `.cmd` is something `CreateProcess` will
+ * run. `spawn` does no PATHEXT resolution of its own, so a launcher handed the bare name finds
+ * the extensionless shell script, cannot execute it, and reports ENOENT for an agent that
+ * `orca doctor` had just called present. Resolving here, against the same PATHEXT walk detection
+ * uses, is what keeps the two answers the same.
+ *
+ * Not `shell: true`: that would hand the agent's own arguments to a command interpreter.
+ */
+export async function resolveBinary(name: string): Promise<string | undefined> {
+  if (process.platform !== 'win32') return name;
+  // An explicit path is already the answer; PATH does not enter into it.
+  if (name.includes('/') || name.includes('\\')) return name;
+  return resolveWindowsBinary(name, process.env.PATH ?? '');
+}
+
+/** What `spawn` must actually be given to launch `command` with `args`. */
+export interface LaunchTarget {
+  file: string;
+  args: string[];
+  /** True only for a Windows batch shim, which `spawn` refuses to run any other way. */
+  shell: boolean;
+}
+
+/** cmd.exe reads these before the program does, so they have to be escaped for it first. */
+const CMD_META = /([()\][%!^"`<>&|;, *?])/g;
+
+/**
+ * Quote one argument so that cmd.exe hands the program back exactly the string we started with.
+ *
+ * Two parsers run in sequence: cmd.exe strips `^` escapes, then the program's own CommandLineToArgv
+ * splits what is left. So the backslash-before-quote doubling has to happen first, and the `^`
+ * escaping of everything — the quotes we just added included — second.
+ */
+function quoteForCmd(arg: string): string {
+  let quoted = arg.replace(/(\\*)"/g, '$1$1\\"');
+  quoted = quoted.replace(/(\\*)$/, '$1$1');
+  return `"${quoted}"`.replace(CMD_META, '^$&');
+}
+
+/**
+ * Resolve a command to something `spawn` can launch on this platform.
+ *
+ * Windows makes this three cases rather than one. An npm-installed agent is a set of shims —
+ * `claude`, `claude.cmd`, `claude.ps1` — and `spawn` does no PATHEXT resolution, so the bare name
+ * finds the extensionless shell script and fails ENOENT. Resolving to the `.cmd` then hits the
+ * second wall: since the batch-injection fix, Node refuses to spawn `.cmd` or `.bat` without a
+ * shell and answers EINVAL. Only a batch shim needs that shell, and only then do the arguments
+ * have to survive cmd.exe, which is what the quoting is for. A real `.exe` still spawns directly.
+ */
+export async function resolveLaunch(command: string, args: string[]): Promise<LaunchTarget> {
+  if (process.platform !== 'win32') return { file: command, args, shell: false };
+  const file = (await resolveBinary(command)) ?? command;
+  if (!/\.(cmd|bat)$/i.test(file)) return { file, args, shell: false };
+  return { file: quoteForCmd(file), args: args.map(quoteForCmd), shell: true };
+}
+
+async function resolveWindowsBinary(name: string, pathVar: string): Promise<string | undefined> {
   const extensions =
     extname(name) !== ''
       ? ['']
@@ -32,14 +94,14 @@ async function hasWindowsBinary(name: string, pathVar: string): Promise<boolean>
       try {
         if ((await stat(candidate)).isFile()) {
           await access(candidate);
-          return true;
+          return candidate;
         }
       } catch {
         // Keep searching the rest of PATH. Detection must never take the CLI down.
       }
     }
   }
-  return false;
+  return undefined;
 }
 
 /**

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -11,3 +11,4 @@ export * from './mcp-config.js';
 export * from './opencode.js';
 export * from './registry.js';
 export * from './scaffold.js';
+export * from './session.js';

--- a/packages/adapters/src/opencode.ts
+++ b/packages/adapters/src/opencode.ts
@@ -1,6 +1,19 @@
 import type { Adapter, Launch, RecordContext } from '@orcareplay/plugin-api';
-import { detectAgent } from './detect.js';
+import { detectAgent, homeDirHas } from './detect.js';
 import { passKey, passThrough, proxyBase, readEnv } from './env.js';
+
+/**
+ * Where OpenCode keeps the credentials `opencode auth login` writes.
+ *
+ * Both locations, because the data directory moved and an installation that predates the move
+ * still has the old one. Finding either means the harness can authenticate on its own.
+ */
+const OPENCODE_AUTH_PATHS = ['.local/share/opencode/auth.json', '.config/opencode/auth.json'];
+
+/** Whether OpenCode has credentials of its own, independent of the environment. */
+export function opencodeHasOwnAuth(): boolean {
+  return OPENCODE_AUTH_PATHS.some(homeDirHas);
+}
 
 /**
  * OpenCode picks its provider per model, so both origins are redirected: whichever protocol the
@@ -23,10 +36,16 @@ export const openCodeAdapter: Adapter = {
     // calls — a recorded run that answers differently from the same command uninstrumented is the
     // worst kind of capture bug. With no credential at all there is no choice to flip, and a
     // client that refuses to start without a key helps nobody, so placeholders stand in.
+    //
+    // Unless OpenCode has signed in on its own. `opencode auth login` writes a credential file the
+    // environment knows nothing about, and inventing both variables in front of it is the failure
+    // Claude Code showed plainly: the harness prefers the environment, authenticates with a key
+    // that is not real, and the run dies before it starts. There is no provider choice to protect
+    // there either — the credential file already made it.
     const hasAny =
       readEnv(ctx.env, 'OPENAI_API_KEY') !== undefined ||
       readEnv(ctx.env, 'ANTHROPIC_API_KEY') !== undefined;
-    if (hasAny) {
+    if (hasAny || opencodeHasOwnAuth()) {
       passThrough(env, ctx.env, 'OPENAI_API_KEY');
       passThrough(env, ctx.env, 'ANTHROPIC_API_KEY');
     } else {

--- a/packages/adapters/src/session.ts
+++ b/packages/adapters/src/session.ts
@@ -1,0 +1,138 @@
+import { readdir, readFile, stat } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { SessionSupport } from '@orcareplay/plugin-api';
+
+export type { SessionSupport };
+
+/**
+ * Capturing what the harness itself wrote about the session.
+ *
+ * Orca's own capture layers record the *effects* of a run — model calls, tool calls, file writes,
+ * shell commands. None of them record the *stimulus*: what the person typed. A run started as
+ * `orca record claude` and driven by hand therefore replays into an agent with nothing to make it
+ * ask anything, which is why an interactive recording came back blank while an `-p` one replayed
+ * perfectly.
+ *
+ * Both harnesses already write that missing half to disk themselves, in their own transcript, and
+ * both can be pointed back at a session by id. So orca does not need to intercept a terminal: it
+ * needs to notice which file the harness just wrote, keep a copy, and read the prompts back out.
+ */
+
+/** What a harness recorded about one session, in the two forms orca needs. */
+export interface SessionCapture {
+  /** Harness session id, where the harness has one. This is what `--resume` takes. */
+  id?: string;
+  /** Path of the transcript relative to the harness session directory. */
+  relPath: string;
+  /** The harness's own file, verbatim. Restoring it is what makes a native fork possible. */
+  bytes: Uint8Array;
+  /** The user's turns, in order — the stimulus orca could not otherwise reconstruct. */
+  prompts: string[];
+}
+
+/** A directory listing keyed by path, so a second listing can be diffed against it. */
+export type DirSnapshot = Map<string, number>;
+
+/**
+ * List every file under `dir` with its mtime.
+ *
+ * Never throws. A harness that has never run has no directory, a sandbox may deny it, and neither
+ * is a reason to fail a recording that is otherwise fine.
+ */
+export async function snapshotDir(dir: string | undefined): Promise<DirSnapshot> {
+  const seen: DirSnapshot = new Map();
+  if (dir === undefined) return seen;
+  async function walk(current: string, prefix: string): Promise<void> {
+    let entries;
+    try {
+      entries = await readdir(current, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const rel = prefix === '' ? entry.name : `${prefix}/${entry.name}`;
+      const full = join(current, entry.name);
+      if (entry.isDirectory()) {
+        await walk(full, rel);
+      } else if (entry.isFile()) {
+        try {
+          seen.set(rel, (await stat(full)).mtimeMs);
+        } catch {
+          // Vanished between listing and stat — a rotating transcript, and not ours to mind.
+        }
+      }
+    }
+  }
+  await walk(dir, '');
+  return seen;
+}
+
+/**
+ * The transcript this run produced: the newest file that is new, or whose mtime moved.
+ *
+ * Newest rather than only-new because a harness resumed into an existing session appends to the
+ * file it already had, and that session is still the one this run belongs to.
+ */
+export async function captureSession(
+  support: SessionSupport,
+  cwd: string,
+  env: Record<string, string | undefined>,
+  before: DirSnapshot,
+): Promise<SessionCapture | undefined> {
+  const dir = support.dir(cwd, env);
+  if (dir === undefined) return undefined;
+  const after = await snapshotDir(dir);
+
+  let best: { relPath: string; mtime: number } | undefined;
+  for (const [relPath, mtime] of after) {
+    if (before.get(relPath) === mtime) continue;
+    if (best === undefined || mtime > best.mtime) best = { relPath, mtime };
+  }
+  if (best === undefined) return undefined;
+
+  let bytes: Uint8Array;
+  try {
+    bytes = await readFile(join(dir, best.relPath));
+  } catch {
+    return undefined;
+  }
+
+  let parsed: { id?: string; prompts: string[] } = { prompts: [] };
+  try {
+    parsed = support.parse(bytes);
+  } catch {
+    // A format orca does not recognise still has value as bytes a human can read; losing the
+    // prompts is a degraded capture, not a failed one.
+  }
+  return { id: parsed.id, relPath: best.relPath, bytes, prompts: parsed.prompts };
+}
+
+/** Read a JSONL transcript into objects, skipping anything that does not parse. */
+export function parseJsonl(bytes: Uint8Array): Record<string, unknown>[] {
+  const out: Record<string, unknown>[] = [];
+  for (const line of new TextDecoder().decode(bytes).split(/\r?\n/)) {
+    if (line.trim() === '') continue;
+    try {
+      const value: unknown = JSON.parse(line);
+      if (value !== null && typeof value === 'object') out.push(value as Record<string, unknown>);
+    } catch {
+      // A half-written final line is normal for a transcript captured while the harness exits.
+    }
+  }
+  return out;
+}
+
+/** Flatten the several shapes a harness uses for message content into plain text. */
+export function contentText(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  const parts: string[] = [];
+  for (const block of content) {
+    if (typeof block === 'string') parts.push(block);
+    else if (block !== null && typeof block === 'object' && 'text' in block) {
+      const text = (block as { text?: unknown }).text;
+      if (typeof text === 'string') parts.push(text);
+    }
+  }
+  return parts.join('');
+}

--- a/packages/adapters/test/adapters.test.ts
+++ b/packages/adapters/test/adapters.test.ts
@@ -7,6 +7,7 @@ import {
   AdapterRegistry,
   claudeCodeAdapter,
   codexAdapter,
+  selectedProvider,
   defaultAdapters,
   genericOpenAiAdapter,
   hasBinary,
@@ -213,14 +214,17 @@ describe('claudeCodeAdapter', () => {
     expect(launch.env.ANTHROPIC_API_KEY).toBe('sk-real');
   });
 
-  it('substitutes a placeholder key when none is set', async () => {
+  // Not a placeholder, unlike every SDK-shaped adapter: a Claude Code signed in to claude.ai has
+  // no ANTHROPIC_API_KEY, and inventing one stops the launch on an interactive trust prompt and
+  // then authenticates as nobody. The absence is what lets its own credential win.
+  it('invents no key when none is set, so a subscription login still authenticates', async () => {
     const launch = await claudeCodeAdapter.prepare(ctx());
-    expect(launch.env.ANTHROPIC_API_KEY).toBe('orca-recorded');
+    expect('ANTHROPIC_API_KEY' in launch.env).toBe(false);
   });
 
   it('treats an empty key as unset', async () => {
     const launch = await claudeCodeAdapter.prepare(ctx({ env: { ANTHROPIC_API_KEY: '' } }));
-    expect(launch.env.ANTHROPIC_API_KEY).toBe('orca-recorded');
+    expect('ANTHROPIC_API_KEY' in launch.env).toBe(false);
   });
 
   it('passes ANTHROPIC_AUTH_TOKEN through only when it is set', async () => {
@@ -249,11 +253,42 @@ describe('codexAdapter', () => {
     expect(launch.env.OPENAI_BASE_URL).toBe('http://127.0.0.1:51733/v1');
   });
 
-  it('passes OPENAI_API_KEY through, or substitutes a placeholder', async () => {
+  // No placeholder: Codex authenticates from its own auth.json, and inventing the variable
+  // overrides that with a key that is not real.
+  it('passes OPENAI_API_KEY through, and invents none when it is unset', async () => {
     const real = await codexAdapter.prepare(ctx({ env: { OPENAI_API_KEY: 'sk-real' } }));
     expect(real.env.OPENAI_API_KEY).toBe('sk-real');
-    const none = await codexAdapter.prepare(ctx());
-    expect(none.env.OPENAI_API_KEY).toBe('orca-recorded');
+    const none = await codexAdapter.prepare(ctx({ env: { CODEX_HOME: 'no-such-dir' } }));
+    expect('OPENAI_API_KEY' in none.env).toBe(false);
+  });
+
+  // The variable alone never reached a Codex pointed at a gateway: the origin comes from
+  // `model_providers.<name>.base_url`, so the override has to name whichever provider is selected.
+  it('overrides the selected provider base_url on the command line', async () => {
+    const launch = await codexAdapter.prepare(ctx({ env: { CODEX_HOME: 'no-such-dir' } }));
+    expect(launch.args.slice(0, 2)).toEqual([
+      '-c',
+      'model_providers.openai.base_url=http://127.0.0.1:51733/v1',
+    ]);
+  });
+
+  it('reads the provider name out of config.toml, ignoring same-named keys in tables', () => {
+    expect(selectedProvider('model_provider = "crs"\n[model_providers.crs]\n')).toBe('crs');
+    expect(selectedProvider("model = 'x'\nmodel_provider = 'gw'\n")).toBe('gw');
+    expect(selectedProvider('[a]\nmodel_provider = "ignored"\n')).toBe('openai');
+    expect(selectedProvider('')).toBe('openai');
+  });
+
+  it('puts the override before the user argv, so an explicit -c still wins', async () => {
+    const launch = await codexAdapter.prepare(
+      ctx({ env: { CODEX_HOME: 'no-such-dir' }, userArgs: ['exec', '--skip-git-repo-check'] }),
+    );
+    expect(launch.args).toEqual([
+      '-c',
+      'model_providers.openai.base_url=http://127.0.0.1:51733/v1',
+      'exec',
+      '--skip-git-repo-check',
+    ]);
   });
 
   it('detects by ~/.codex, and not at all in a bare environment', async () => {

--- a/packages/adapters/test/session.test.ts
+++ b/packages/adapters/test/session.test.ts
@@ -1,0 +1,355 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync, utimesSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdirSync as mkdirSync2, writeFileSync as writeFileSync2 } from 'node:fs';
+import {
+  captureSession,
+  claudeCodeAdapter,
+  codexAdapter,
+  openCodeAdapter,
+  claudeSession,
+  claudeProjectSlug,
+  codexSession,
+  contentText,
+  parseJsonl,
+  snapshotDir,
+} from '../src/index.js';
+import { bunOptionsWithHook, nodeOptionsWithHook } from '@orcareplay/node-instrument';
+
+/**
+ * The half of a run orca cannot see from the wire.
+ *
+ * Every other capture layer records what the agent *did*. None record what it was *asked*, because
+ * that was typed into a terminal — which is why an interactive recording replayed into a blank
+ * agent while an `-p` one replayed perfectly. These cover reading it back out of the transcript
+ * the harness wrote for itself.
+ */
+
+let scratch: string;
+
+beforeEach(() => {
+  scratch = mkdtempSync(join(tmpdir(), 'orca-session-'));
+});
+
+afterEach(() => {
+  rmSync(scratch, { recursive: true, force: true });
+});
+
+function write(rel: string, text: string, mtime?: number): string {
+  const path = join(scratch, rel);
+  mkdirSync(join(path, '..'), { recursive: true });
+  writeFileSync(path, text);
+  if (mtime !== undefined) utimesSync(path, mtime / 1000, mtime / 1000);
+  return path;
+}
+
+describe('snapshotDir', () => {
+  it('lists files recursively, since Codex nests transcripts under a date', async () => {
+    write('sessions/2026/08/31/a.jsonl', 'x');
+    write('sessions/b.jsonl', 'y');
+    const seen = await snapshotDir(join(scratch, 'sessions'));
+    expect([...seen.keys()].sort()).toEqual(['2026/08/31/a.jsonl', 'b.jsonl']);
+  });
+
+  // A harness that has never run has no directory, and that must not fail a recording.
+  it('is empty rather than throwing for a directory that is not there', async () => {
+    await expect(snapshotDir(join(scratch, 'nope'))).resolves.toEqual(new Map());
+    await expect(snapshotDir(undefined)).resolves.toEqual(new Map());
+  });
+});
+
+describe('captureSession', () => {
+  const support = {
+    dir: () => join(scratch, 'sessions'),
+    parse: (bytes: Uint8Array) => ({ id: 'sid', prompts: [new TextDecoder().decode(bytes)] }),
+    resumeArgs: (id: string) => ['--resume', id],
+  };
+
+  it('picks the transcript this run wrote, not one that was already there', async () => {
+    write('sessions/old.jsonl', 'old', 1_000_000);
+    const before = await snapshotDir(join(scratch, 'sessions'));
+    write('sessions/new.jsonl', 'new', 2_000_000);
+    const captured = await captureSession(support, '/work', {}, before);
+    expect(captured?.relPath).toBe('new.jsonl');
+    expect(captured?.prompts).toEqual(['new']);
+    expect(captured?.id).toBe('sid');
+  });
+
+  // A resumed session appends to the file it already had; that session is still this run's.
+  it('picks a file whose mtime moved, not only one that is new', async () => {
+    write('sessions/a.jsonl', 'a', 1_000_000);
+    const before = await snapshotDir(join(scratch, 'sessions'));
+    write('sessions/a.jsonl', 'a then more', 2_000_000);
+    expect((await captureSession(support, '/work', {}, before))?.relPath).toBe('a.jsonl');
+  });
+
+  it('is undefined when the harness wrote nothing', async () => {
+    write('sessions/a.jsonl', 'a', 1_000_000);
+    const before = await snapshotDir(join(scratch, 'sessions'));
+    await expect(captureSession(support, '/work', {}, before)).resolves.toBeUndefined();
+  });
+
+  // Bytes a human can still read are worth keeping even when orca cannot parse them.
+  it('keeps the transcript when parsing throws, losing only the prompts', async () => {
+    const before = await snapshotDir(join(scratch, 'sessions'));
+    write('sessions/x.jsonl', 'body', 2_000_000);
+    const captured = await captureSession(
+      {
+        ...support,
+        parse: () => {
+          throw new Error('unknown format');
+        },
+      },
+      '/work',
+      {},
+      before,
+    );
+    expect(new TextDecoder().decode(captured?.bytes)).toBe('body');
+    expect(captured?.prompts).toEqual([]);
+  });
+});
+
+describe('parseJsonl', () => {
+  it('skips a half-written final line, which is normal for a harness that just exited', () => {
+    const bytes = new TextEncoder().encode('{"a":1}\n{"b":2}\n{"c":');
+    expect(parseJsonl(bytes)).toEqual([{ a: 1 }, { b: 2 }]);
+  });
+});
+
+describe('contentText', () => {
+  it('flattens both shapes a harness uses for message content', () => {
+    expect(contentText('plain')).toBe('plain');
+    expect(contentText([{ type: 'text', text: 'a' }, { type: 'thinking' }, { text: 'b' }])).toBe(
+      'ab',
+    );
+    expect(contentText(undefined)).toBe('');
+  });
+});
+
+describe('claudeSession', () => {
+  it('names the project directory the way Claude Code does', () => {
+    expect(claudeProjectSlug('C:\\Users\\d\\proj')).toBe('C--Users-d-proj');
+    expect(claudeProjectSlug('/home/d/proj')).toBe('-home-d-proj');
+  });
+
+  /**
+   * Checked against a real install rather than inferred. An earlier version folded only the path
+   * separators and the drive colon, which was right for every path it happened to be tested
+   * against and wrong for the first one carrying an underscore: the computed name missed the real
+   * directory by a single character, and the capture then found nothing and said nothing.
+   */
+  it('folds every character a path may carry that the directory name does not', () => {
+    // One real directory covering all three at once: `slug_test.dir v2` -> `slug-test-dir-v2`.
+    expect(claudeProjectSlug('slug_test.dir v2')).toBe('slug-test-dir-v2');
+    expect(claudeProjectSlug('C:\\src\\my_project\\app')).toBe('C--src-my-project-app');
+    // Hyphens already present are kept, so a folded name and an original one stay distinguishable.
+    expect(claudeProjectSlug('already-hyphenated')).toBe('already-hyphenated');
+  });
+
+  it('honours CLAUDE_CONFIG_DIR, so a relocated install is still found', () => {
+    const home = join(scratch, 'cfg');
+    mkdirSync(join(home, 'projects', '-work'), { recursive: true });
+    expect(claudeSession.dir('/work', { CLAUDE_CONFIG_DIR: home })).toBe(
+      join(home, 'projects', '-work'),
+    );
+  });
+
+  /**
+   * The slug is a guess about someone else's naming, and a wrong guess loses the capture in
+   * silence — which is exactly what happened the first time this met a path with an underscore.
+   * Falling back to the whole projects tree keeps the run findable whatever it ended up called.
+   */
+  it('watches the whole projects tree when the named directory is not there', () => {
+    const home = join(scratch, 'cfg-empty');
+    mkdirSync(join(home, 'projects'), { recursive: true });
+    expect(claudeSession.dir('/work', { CLAUDE_CONFIG_DIR: home })).toBe(join(home, 'projects'));
+  });
+
+  it('reads the session id and the turns a person actually typed', () => {
+    const bytes = new TextEncoder().encode(
+      [
+        JSON.stringify({ type: 'user', sessionId: 'abc', message: { content: 'first question' } }),
+        JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'hi' }] } }),
+        JSON.stringify({
+          type: 'user',
+          message: { content: [{ type: 'text', text: 'second question' }] },
+        }),
+      ].join('\n'),
+    );
+    expect(claudeSession.parse(bytes)).toEqual({
+      id: 'abc',
+      prompts: ['first question', 'second question'],
+    });
+  });
+
+  /**
+   * Tool results and spliced reminders arrive with the same `user` role as a typed turn. Driving a
+   * replay with one would ask the model something the recording never asked.
+   */
+  it('drops the turns the harness synthesised for itself', () => {
+    const bytes = new TextEncoder().encode(
+      [
+        JSON.stringify({
+          type: 'user',
+          message: { content: '<system-reminder>x</system-reminder>' },
+        }),
+        JSON.stringify({ type: 'user', message: { content: '   ' } }),
+        JSON.stringify({ type: 'user', message: { content: 'real' } }),
+      ].join('\n'),
+    );
+    expect(claudeSession.parse(bytes).prompts).toEqual(['real']);
+  });
+
+  it('resumes by id', () => {
+    expect(claudeSession.resumeArgs('abc')).toEqual(['--resume', 'abc']);
+  });
+});
+
+describe('codexSession', () => {
+  it('honours CODEX_HOME', () => {
+    expect(codexSession.dir('/work', { CODEX_HOME: '/cx' })).toBe(join('/cx', 'sessions'));
+  });
+
+  it('reads the session id and the input_text turns out of a rollout', () => {
+    const bytes = new TextEncoder().encode(
+      [
+        JSON.stringify({ type: 'session_meta', payload: { id: 'sid-1', cwd: '/w' } }),
+        JSON.stringify({
+          type: 'response_item',
+          payload: {
+            type: 'message',
+            content: [{ type: 'input_text', text: '<skills>x</skills>' }],
+          },
+        }),
+        JSON.stringify({
+          type: 'response_item',
+          payload: { type: 'message', content: [{ type: 'input_text', text: 'the real ask' }] },
+        }),
+        JSON.stringify({
+          type: 'response_item',
+          payload: { type: 'message', content: [{ type: 'output_text', text: 'PONG' }] },
+        }),
+      ].join('\n'),
+    );
+    expect(codexSession.parse(bytes)).toEqual({ id: 'sid-1', prompts: ['the real ask'] });
+  });
+
+  it('resumes by id', () => {
+    expect(codexSession.resumeArgs('sid-1')).toEqual(['exec', 'resume', 'sid-1']);
+  });
+});
+
+describe('driveArgs', () => {
+  /**
+   * The recording's own flags still have to shape the replay: a run made with `--model x` that
+   * replays without it is a different run, and would diverge on every request.
+   */
+  it('extends the recorded argv rather than replacing it', () => {
+    expect(claudeCodeAdapter.driveArgs?.(['ask'], ['--model', 'x'])).toEqual([
+      '--model',
+      'x',
+      '-p',
+      'ask',
+    ]);
+  });
+
+  it('gives Codex the exec form when the recording had none', () => {
+    expect(codexAdapter.driveArgs?.(['ask'], [])).toEqual(['exec', '--skip-git-repo-check', 'ask']);
+  });
+
+  // `codex exec` with the prompt on stdin already carries the subcommand and its flags.
+  it('appends the prompt to an exec recording, keeping its flags', () => {
+    expect(codexAdapter.driveArgs?.(['ask'], ['exec', '--skip-git-repo-check'])).toEqual([
+      'exec',
+      '--skip-git-repo-check',
+      'ask',
+    ]);
+  });
+
+  it('drives nothing when the transcript yielded no prompt', () => {
+    expect(claudeCodeAdapter.driveArgs?.([], [])).toBeUndefined();
+    expect(codexAdapter.driveArgs?.([], [])).toBeUndefined();
+  });
+});
+
+describe('openCodeAdapter credentials', () => {
+  /**
+   * The placeholder exists so an unconfigured OpenCode still starts, and so that inventing one
+   * provider's key cannot flip which provider it chooses — hence all-or-nothing. What it did not
+   * account for is `opencode auth login`, which writes a credential file the environment knows
+   * nothing about. Inventing both variables in front of that is the failure Claude Code showed:
+   * the harness prefers the environment and authenticates as nobody.
+   */
+  function isolateHome(withAuth: boolean): void {
+    const home = join(scratch, `home-${withAuth ? 'auth' : 'bare'}`);
+    if (withAuth) {
+      const dir = join(home, '.local', 'share', 'opencode');
+      mkdirSync2(dir, { recursive: true });
+      writeFileSync2(join(dir, 'auth.json'), '{}');
+    } else {
+      mkdirSync2(home, { recursive: true });
+    }
+    process.env.HOME = home;
+    process.env.USERPROFILE = home;
+  }
+
+  const saved = { HOME: process.env.HOME, USERPROFILE: process.env.USERPROFILE };
+  afterEach(() => {
+    process.env.HOME = saved.HOME;
+    process.env.USERPROFILE = saved.USERPROFILE;
+  });
+
+  const ctx = () => ({
+    runId: 'run_abc123',
+    cwd: '/work',
+    proxyUrl: 'http://127.0.0.1:51733',
+    runDir: '/work/.orca/runs/run_abc123',
+    userArgs: [],
+    env: {},
+  });
+
+  it('invents no key when OpenCode has signed in on its own', async () => {
+    isolateHome(true);
+    const launch = await openCodeAdapter.prepare(ctx());
+    expect('OPENAI_API_KEY' in launch.env).toBe(false);
+    expect('ANTHROPIC_API_KEY' in launch.env).toBe(false);
+  });
+
+  // Unchanged where it was right: an OpenCode with no credentials anywhere still needs to start.
+  it('still substitutes placeholders when there is no credential anywhere', async () => {
+    isolateHome(false);
+    const launch = await openCodeAdapter.prepare(ctx());
+    expect(launch.env.OPENAI_API_KEY).toBe('orca-recorded');
+    expect(launch.env.ANTHROPIC_API_KEY).toBe('orca-recorded');
+  });
+});
+
+describe('bunOptionsWithHook', () => {
+  /**
+   * Bun parses `BUN_OPTIONS` with a parser that treats a backslash as an escape, so a Windows path
+   * reached the loader with its separators eaten. Quoting made it worse: Bun accepted the argument
+   * and loaded nothing, which is the silent miss the hook exists to prevent.
+   */
+  it('hands Bun a path its own parser will survive', () => {
+    const out = bunOptionsWithHook(String.raw`C:\Users\d\run\hook.cjs`, undefined, 'win32');
+    expect(out).not.toContain(String.fromCharCode(92));
+    expect(out).toBe('--preload C:/Users/d/run/hook.cjs');
+  });
+
+  /**
+   * A backslash is a legal character in a POSIX filename, so the rewrite is Windows-only: applying
+   * it everywhere would turn one real path into another real path that does not exist. Asserted
+   * rather than assumed, because the guard is what makes the rewrite above safe to do at all.
+   */
+  it('leaves a POSIX path alone, where a backslash is part of the name', () => {
+    const path = '/home/d/run' + String.fromCharCode(92) + 'odd/hook.cjs';
+    expect(bunOptionsWithHook(path, undefined, 'linux')).toBe(`--preload ${path}`);
+  });
+
+  // Node resolves `--require` from `NODE_OPTIONS` without that escaping, so it is left alone.
+  it('leaves the Node form as it was', () => {
+    const path = String.raw`C:\Users\d\run\hook.cjs`;
+    expect(nodeOptionsWithHook(path, undefined)).toBe(`--require ${path}`);
+  });
+});

--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -64,8 +64,14 @@ export interface Timeline {
   forkModel?: string;
   usage: { input: number; output: number };
   events: TimelineRow[];
-  /** Turns whose filesystem tree repeated — an agent going in circles. */
-  loops: { turns: number[]; tree: string }[];
+  /** Runs where the agent repeated itself rather than making progress. */
+  loops: {
+    turns: number[];
+    kind: 'repeated-action' | 'error-spin';
+    signature?: string;
+    repeats?: number;
+    tree?: string;
+  }[];
 }
 
 export interface RecordOptions {
@@ -162,7 +168,13 @@ export class Orca {
         detail: row.detail,
         meta: row.meta,
       })),
-      loops: detectLoops(events).map((loop) => ({ turns: loop.turns, tree: loop.tree })),
+      loops: detectLoops(events).map((loop) => ({
+        turns: loop.turns,
+        kind: loop.kind,
+        signature: loop.signature,
+        repeats: loop.repeats,
+        tree: loop.tree,
+      })),
     };
   }
 

--- a/packages/cli/src/commands/inspect.ts
+++ b/packages/cli/src/commands/inspect.ts
@@ -95,10 +95,13 @@ export async function showCommand(
   // empty cell for everything else — which quietly dropped a shell command's exit code, a tool
   // result's success or failure, and the stop reason, leaving a call and its result looking like
   // the same row printed twice.
-  const rows = buildTimeline(events).map((r) => [
+  // Indented by delegation depth, so a sub-agent's model and tool calls read as its work rather
+  // than as more of the parent's. `└─` on the first nested row marks where the delegation begins.
+  const timeline = buildTimeline(events);
+  const rows = timeline.map((r, i) => [
     String(r.seq),
     r.kind,
-    r.label,
+    `${nestPrefix(r.depth, timeline[i - 1]?.depth ?? 0)}${r.label}`,
     [r.detail, r.meta].filter((part) => part !== undefined && part !== '').join(' · '),
   ]);
   out.table(['SEQ', 'KIND', 'WHAT', 'DETAIL'], rows);
@@ -106,7 +109,15 @@ export async function showCommand(
   const loops = detectLoops(events);
   for (const loop of loops) {
     out.plain('');
-    out.warn('loop.detected', { turns: loop.turns.join(','), tree: loop.tree.slice(0, 8) });
+    // The signature is the point of the warning: "the same grep, four times" is something an
+    // operator can act on, where a list of turn numbers is something they have to go and look up.
+    out.warn('loop.detected', {
+      kind: loop.kind,
+      turns: loop.turns.join(','),
+      repeats: loop.repeats,
+      action: loop.signature,
+      tree: loop.tree?.slice(0, 8),
+    });
   }
 
   const cost = totalCost(events);
@@ -339,4 +350,10 @@ function totalCost(events: { type: string; attrs?: Record<string, unknown> }[]):
     }
   }
   return priced ? total : null;
+}
+
+/** `  `-per-level indent, with `└─` on the row where a delegation's work starts. */
+function nestPrefix(depth: number, previousDepth: number): string {
+  if (depth === 0) return '';
+  return '  '.repeat(depth - 1) + (depth > previousDepth ? '└─ ' : '   ');
 }

--- a/packages/cli/src/commands/record.ts
+++ b/packages/cli/src/commands/record.ts
@@ -4,7 +4,7 @@ import { delimiter, resolve } from 'node:path';
 import { TraceWriter, ensureRunsDir } from '@orcareplay/core';
 import { FsCapture } from '@orcareplay/fs-capture';
 import { createProxy, RunCa, type NetExchange, type RecordedExchange } from '@orcareplay/proxy';
-import { defaultAdapters } from '@orcareplay/adapters';
+import { captureSession, defaultAdapters, resolveLaunch, snapshotDir } from '@orcareplay/adapters';
 import type { Adapter, RecordContext } from '@orcareplay/plugin-api';
 import { ExchangeEventDeriver, appendDerivedEvents } from '../exchange-events.js';
 import { installShellShim, readShellFrames } from '@orcareplay/shell-shim';
@@ -42,6 +42,19 @@ export interface RecordResult {
  * happens before any teardown runs. Owning the key's lifetime out here means no failure path
  * inside can skip it.
  */
+/**
+ * Whether a tool call ran a command.
+ *
+ * By the shape of the arguments rather than by the tool's name: every harness names it something
+ * different — `Bash`, `shell`, `run_command`, `exec` — and a list of names would be wrong for the
+ * next one. A `command` string is what they all have in common.
+ */
+function isCommandTool(input: unknown): boolean {
+  if (input === null || typeof input !== 'object') return false;
+  const command = (input as { command?: unknown }).command;
+  return typeof command === 'string' && command.trim() !== '';
+}
+
 export async function recordCommand(
   args: ParsedArgs,
   out: Output,
@@ -168,6 +181,18 @@ async function runRecording(
 
   /** Model exchanges the proxy actually captured — the number the warning below turns on. */
   let modelExchanges = 0;
+  /**
+   * Tool calls that ran a command, counted from the model exchanges rather than from the shim.
+   *
+   * This is the evidence half of the shell-shim check. The shim reports success when it installs,
+   * which says nothing about whether the harness ever went through it: Claude Code on Windows
+   * resolves its shell without consulting PATH, so `shell=on` printed happily while the frames
+   * file stayed empty for a run full of Bash calls. Comparing what the model asked for against
+   * what the shim saw is what turns that silence into something orca can say out loud.
+   */
+  let commandToolCalls = 0;
+  /** Commands the shim actually saw. Zero against a non-zero `commandToolCalls` is the warning. */
+  let shellFrames = 0;
 
   const proxy = await createProxy({
     mode: 'record',
@@ -189,7 +214,11 @@ async function runRecording(
   async function persist(exchange: RecordedExchange): Promise<void> {
     turn += 1;
     turnStartedAt.push({ turn, at: Date.now() });
-    await appendDerivedEvents(writer, deriver, exchange, turn);
+    await appendDerivedEvents(writer, deriver, exchange, turn, (derived) => {
+      if (derived.type === 'tool.call' && isCommandTool(derived.attrs['input'])) {
+        commandToolCalls += 1;
+      }
+    });
 
     if (fs) await appendSnapshot(fs, writer, out, turn);
   }
@@ -212,10 +241,30 @@ async function runRecording(
     env: process.env,
   };
   const launch = await adapter.prepare(ctx);
+
+  // Listed before the agent starts, so the file it writes can be told from the ones already there.
+  // The harness's transcript is the only record of what the person typed; without it an
+  // interactive run is captured but not replayable.
+  const sessionBefore = await snapshotDir(adapter.session?.dir(cwd, process.env));
+
   if (shell) {
     launch.env.PATH = `${shell.dir}${delimiter}${process.env.PATH ?? ''}`;
   }
-  if (mcp) pointAtMcpConfig(launch.env, mcp.configPath);
+  if (mcp) {
+    pointAtMcpConfig(launch.env, mcp.configPath);
+    // The variables above are belt and braces for a harness orca has not met. What actually
+    // reaches Claude Code is this: it takes the path on the command line and reads no environment
+    // variable for it, so without this the instrumented config was written and never opened.
+    const mcpArgs = adapter.mcpConfigArgs?.(mcp.configPath);
+    if (mcpArgs !== undefined) launch.args = [...mcpArgs, ...launch.args];
+    else
+      out.warn('mcp.not_wired', {
+        adapter: adapter.id,
+        cause: `${adapter.id} has no command-line form for an MCP config, and reads none of the variables orca sets`,
+        effect:
+          'the instrumented config exists but the agent will not load it, so no MCP frames will be captured',
+      });
+  }
 
   if (proxy.tls) {
     await trustRunCa(writer, proxy.tls, proxy.url, launch.env, out);
@@ -277,7 +326,9 @@ async function runRecording(
     // exited, so stamping them at write time put every shell command at the end of the run with
     // the final turn number — which makes `mono_us` describe the drain rather than the command,
     // and leaves the commands unable to interleave with the model turns they happened between.
-    for (const frame of await readShellFrames(shell.framesPath)) {
+    const frames = await readShellFrames(shell.framesPath);
+    shellFrames = frames.length;
+    for (const frame of frames) {
       const startedAt = Date.parse(frame.startedAt);
       const at = Number.isNaN(startedAt) ? undefined : new Date(startedAt);
       const frameTurn = at === undefined ? turn : turnAt(startedAt);
@@ -333,6 +384,41 @@ async function runRecording(
     }
   }
 
+  /**
+   * The harness's own transcript, and with it the prompts nothing on the wire carries.
+   *
+   * Written before `run.end` so it is part of the run rather than an appendix, and stored as the
+   * harness's own bytes so a fork can put the file back and resume into it natively.
+   */
+  let session: Awaited<ReturnType<typeof captureSession>>;
+  if (adapter.session) {
+    try {
+      session = await captureSession(adapter.session, cwd, process.env, sessionBefore);
+    } catch (err) {
+      out.warn('session.unavailable', { reason: String(err) });
+    }
+  }
+  if (session) {
+    await writer.append({
+      type: 'session.snapshot',
+      actor: 'harness',
+      turn,
+      attrs: {
+        harness: adapter.id,
+        session_id: session.id,
+        rel_path: session.relPath,
+        prompts: session.prompts.length,
+        bytes: session.bytes.byteLength,
+      },
+      // The writer spills anything over the inline limit to a content-addressed blob, so the
+      // transcript rides the same path every other large payload does — redaction included.
+      payload: {
+        prompts: session.prompts,
+        transcript: new TextDecoder().decode(session.bytes),
+      },
+    });
+  }
+
   await writer.append({ type: 'run.end', actor: 'orca', turn, attrs: { exit_code: exitCode } });
   const manifest = await writer.close(exitCode);
 
@@ -368,6 +454,50 @@ async function runRecording(
     });
   }
 
+  /**
+   * Shell capture that was on and recorded nothing.
+   *
+   * `installShellShim` succeeding means a `bash` and an `sh` were written into the run directory
+   * and put at the front of PATH. It does not mean the harness went through them, and on Windows
+   * Claude Code does not: it finds its shell without consulting PATH, so the shim sits there
+   * unused while `shell=on` is printed and the frames file stays empty. What is lost is precisely
+   * what only the shim can see — the real exit code, the real duration, and which stream each byte
+   * came from — while the commands still appear as tool calls, so nothing looks wrong.
+   *
+   * The condition is evidence, not a platform check: commands demonstrably ran and the layer that
+   * was supposed to see them saw none of them, whatever the reason.
+   */
+  if (shell && shellFrames === 0 && commandToolCalls > 0) {
+    out.warn('shell.ineffective', {
+      commands: commandToolCalls,
+      captured: 0,
+      cause: 'the harness ran its shell without going through the PATH shim',
+      effect: 'exit codes, durations and the stdout/stderr split are not in this trace',
+      next: 'record with --no-shell, which claims nothing rather than claiming this',
+    });
+  }
+
+  /**
+   * A recording that captured turns but cannot be replayed.
+   *
+   * `capture.empty` covers the run that recorded nothing. This is the other half: an interactive
+   * run records its model calls perfectly, but the prompts that caused them were typed into a
+   * terminal and exist nowhere orca can see. Replaying it launches an agent with nothing to make
+   * it ask anything, and it comes back blank — which the user discovers only after paying for the
+   * recording. Saying so here, while they are still looking at it, is the whole point.
+   */
+  const drivable = args.passthrough.length > 0 || (session?.prompts.length ?? 0) > 0;
+  if (modelExchanges > 0 && !drivable) {
+    out.warn('replay.undrivable', {
+      exchanges: modelExchanges,
+      cause: adapter.session
+        ? 'no prompt in argv, and none found in the harness transcript'
+        : `no prompt in argv, and ${adapter.id} exposes no transcript orca can read`,
+      effect: 'this run can be inspected, but replay and fork have nothing to drive the agent with',
+      next: `orca show ${writer.runId}`,
+    });
+  }
+
   out.plain('');
   out.plain(`  orca replay ${writer.runId}            # reproduce it exactly`);
   out.plain(`  orca replay ${writer.runId} --ui       # open the timeline`);
@@ -391,17 +521,21 @@ async function runRecording(
  * agent's own chatter is still shown — it moves to stderr, where a human reads it and a parser
  * does not. stdin and stderr stay inherited so the agent can still prompt and still colour.
  */
-function runChild(
+async function runChild(
   command: string,
   argv: string[],
   env: NodeJS.ProcessEnv,
   cwd: string,
   quietStdout = false,
 ): Promise<number> {
+  // Resolved the way detection resolves, so a launcher never reports ENOENT for an agent that
+  // `orca doctor` just called present.
+  const target = await resolveLaunch(command, argv);
   return new Promise((resolve, reject) => {
-    const child = spawn(command, argv, {
+    const child = spawn(target.file, target.args, {
       env,
       cwd,
+      shell: target.shell,
       stdio: quietStdout ? ['inherit', 'pipe', 'inherit'] : 'inherit',
     });
     child.stdout?.pipe(process.stderr);

--- a/packages/cli/src/commands/replay.ts
+++ b/packages/cli/src/commands/replay.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import {
+  enclosingDelegation,
   TraceReader,
   deriveCheckpoints,
   resolveRunSelector,
@@ -12,7 +13,7 @@ import {
 } from '@orcareplay/core';
 import { FsCapture } from '@orcareplay/fs-capture';
 import { createProxy, defaultDialects, type RecordedExchange } from '@orcareplay/proxy';
-import { defaultAdapters } from '@orcareplay/adapters';
+import { defaultAdapters, resolveLaunch } from '@orcareplay/adapters';
 import { serveViewer } from '@orcareplay/viewer';
 import { isBlobRef, type TraceEvent } from '@orcareplay/schema';
 import { ExchangeEventDeriver, appendDerivedEvents } from '../exchange-events.js';
@@ -132,6 +133,78 @@ async function rawBodyOf(reader: TraceReader, event: TraceEvent): Promise<string
   return JSON.stringify(payload ?? {});
 }
 
+/**
+ * The arguments that will make the agent ask again.
+ *
+ * A run recorded as `orca record claude -- -p "..."` carries its prompt in argv, and replaying it
+ * is simply a matter of passing it back. A run driven by hand carries nothing: the prompt went
+ * into a terminal, and argv is just `["claude"]`. Replaying that launched an agent with no reason
+ * to call anything, so the recorded exchanges were never requested and the replay came back empty.
+ *
+ * The prompts recorded from the harness's own transcript are what closes that gap. Only the first
+ * turn is driven — the harnesses take one prompt per non-interactive invocation — so a multi-turn
+ * conversation says how much of itself it is reproducing instead of quietly reproducing one turn
+ * and calling it a replay.
+ */
+function driveArgs(
+  adapter: { driveArgs?(prompts: string[], recorded: string[]): string[] | undefined },
+  ctx: { manifest: { argv: string[] }; prompts: string[] },
+  out: Output,
+): string[] {
+  const recorded = ctx.manifest.argv.slice(1);
+  const prompts = ctx.prompts;
+  if (prompts.length === 0) return recorded;
+
+  // Whether argv already drives the run, decided by comparing it against the prompts the harness
+  // recorded rather than by looking for a flag. `codex exec` with the prompt on stdin has a
+  // non-empty argv that carries no prompt at all, so "argv is non-empty" answers the wrong
+  // question; "argv contains what the person actually asked" answers the right one.
+  if (prompts.some((prompt) => recorded.includes(prompt))) return recorded;
+
+  const driven = adapter.driveArgs?.(prompts, recorded);
+  if (driven === undefined) return recorded;
+
+  // Said before the run, not after, because it reframes every divergence that follows. A harness
+  // driven without a terminal does not send byte-identical requests to the ones it sent with one —
+  // Claude Code splices an extra reminder turn into an interactive conversation, and the calls it
+  // makes for itself, like naming the session, have no counterpart at all. Those show up as
+  // unmatched, and without this line they read as a corrupt trace rather than as the cost of
+  // reproducing a conversation nobody recorded the keystrokes of.
+  out.info('replay.driven', {
+    source: 'harness transcript',
+    turns_recorded: prompts.length,
+    turns_driven: 1,
+    note:
+      prompts.length > 1
+        ? 'the harness takes one prompt per non-interactive run; later turns are not re-asked'
+        : 'requests the harness made for itself may not recur',
+  });
+  return driven;
+}
+
+/**
+ * Prompts off a `session.snapshot`.
+ *
+ * The transcript rides in the same payload, so this spills to a blob for any real session — which
+ * is why it takes the reader rather than reading the event alone.
+ */
+async function readPrompts(reader: TraceReader, events: TraceEvent[]): Promise<string[]> {
+  const event = events.find((e) => e.type === 'session.snapshot');
+  if (event === undefined) return [];
+  let payload: unknown = event.payload;
+  try {
+    if (isBlobRef(payload)) {
+      payload = JSON.parse(new TextDecoder().decode(await reader.blob(payload)));
+    }
+    if (typeof payload === 'string') payload = JSON.parse(payload);
+  } catch {
+    return [];
+  }
+  if (payload === null || typeof payload !== 'object') return [];
+  const prompts = (payload as { prompts?: unknown }).prompts;
+  return Array.isArray(prompts) ? prompts.filter((p): p is string => typeof p === 'string') : [];
+}
+
 export async function replayCommand(
   args: ParsedArgs,
   out: Output,
@@ -161,13 +234,23 @@ export async function replayCommand(
   }
 
   const exchanges = await loadExchanges(reader);
+  const prompts = await readPrompts(reader, events);
   const from = args.num('from');
   const model = args.str('model');
   const isFork = from !== undefined || model !== undefined;
 
   const result = isFork
-    ? await replayFork(args, out, { manifest, events, exchanges, runDir, cwd, from, model })
-    : await replayExact(args, out, { manifest, events, exchanges, runDir, cwd });
+    ? await replayFork(args, out, {
+        manifest,
+        events,
+        exchanges,
+        runDir,
+        cwd,
+        prompts,
+        from,
+        model,
+      })
+    : await replayExact(args, out, { manifest, events, exchanges, runDir, cwd, prompts });
 
   if (args.bool('ui')) {
     // Show the run you just produced: after a fork that is the child, not the parent, because
@@ -196,6 +279,8 @@ interface Ctx {
   exchanges: RecordedExchange[];
   runDir: string;
   cwd: string;
+  /** The user's turns, recovered from the harness transcript. Empty when there was none. */
+  prompts: string[];
 }
 
 /**
@@ -265,10 +350,21 @@ async function replayExact(args: ParsedArgs, out: Output, ctx: Ctx): Promise<Rep
     // file contents — by far the most common cause of a halt, and invisible from the number alone.
     onUnmatched: (u) => {
       unmatched.push(u);
+      // A halt inside a delegation is not a corrupt trace and not a bug, and looks like both. The
+      // harness writes the delegate's prompt itself, fresh on every run, so the request really is
+      // a different question — which is exactly what the matcher refuses to serve from a
+      // recording. Without this the operator sees `distance 54` and goes looking for the fault.
+      const delegation = enclosingDelegation(ctx.events, u.seq);
       out.warn('replay.unmatched', {
         seq: u.seq,
         index: u.index,
         reason: u.reason,
+        ...(delegation === undefined
+          ? {}
+          : {
+              inside: `${delegation.subagent} delegated at seq ${delegation.seq}`,
+              why: 'the harness writes a delegate prompt of its own each run, so this request is a different question rather than a drifted one',
+            }),
         recorded_in: ctx.manifest.cwd,
         replayed_in: workspace.dir,
         next:
@@ -329,7 +425,10 @@ async function replayExact(args: ParsedArgs, out: Output, ctx: Ctx): Promise<Rep
   // talks to servers orca cannot see — or, for a harness that requires the variable, does not start
   // at all, which is how a replay of a working recording exits non-zero for a reason that has
   // nothing to do with the recording.
-  const mcp = trace === undefined ? undefined : await mcpForReplay(args, ctx.events, trace, out);
+  const mcp =
+    trace === undefined
+      ? undefined
+      : await mcpForReplay(args, ctx.events, trace, out, join(ctx.runDir, 'mcp-frames.jsonl'));
 
   const adapter = defaultAdapters().get(ctx.manifest.adapter.id);
   const launch = await adapter.prepare({
@@ -337,11 +436,17 @@ async function replayExact(args: ParsedArgs, out: Output, ctx: Ctx): Promise<Rep
     cwd: workspace.dir,
     proxyUrl: proxy.url,
     runDir: ctx.runDir,
-    userArgs: ctx.manifest.argv.slice(1),
+    userArgs: driveArgs(adapter, ctx, out),
     env: process.env,
   });
   if (proxy.tls) await trustRunCa(trace, proxy.tls, proxy.url, launch.env, out);
-  if (mcp) pointAtMcpConfig(launch.env, mcp.configPath);
+  if (mcp) {
+    pointAtMcpConfig(launch.env, mcp.configPath);
+    // Same as record: the path has to reach the harness the way the harness actually reads it, or
+    // a replay re-instruments a config nothing opens and every recorded MCP call goes unmatched.
+    const mcpArgs = adapter.mcpConfigArgs?.(mcp.configPath);
+    if (mcpArgs !== undefined) launch.args = [...mcpArgs, ...launch.args];
+  }
 
   let exitCode: number;
   try {
@@ -634,14 +739,20 @@ async function replayFork(
     cwd: worktree,
     proxyUrl: proxy.url,
     runDir: writer.runDir,
-    userArgs: ctx.manifest.argv.slice(1),
+    userArgs: driveArgs(adapter, ctx, out),
     env: process.env,
   });
 
   if (proxy.tls) {
     await trustRunCa(writer, proxy.tls, proxy.url, launch.env, out);
   }
-  if (mcp) pointAtMcpConfig(launch.env, mcp.configPath);
+  if (mcp) {
+    pointAtMcpConfig(launch.env, mcp.configPath);
+    // Same as record: the path has to reach the harness the way the harness actually reads it, or
+    // a replay re-instruments a config nothing opens and every recorded MCP call goes unmatched.
+    const mcpArgs = adapter.mcpConfigArgs?.(mcp.configPath);
+    if (mcpArgs !== undefined) launch.args = [...mcpArgs, ...launch.args];
+  }
 
   let exitCode: number;
   try {
@@ -798,17 +909,20 @@ async function replayWorkspace(args: ParsedArgs, out: Output, ctx: Ctx): Promise
  * agent's own output moves to stderr rather than landing in the middle of it. stdin and stderr
  * stay inherited, so a harness that prompts still can.
  */
-function runChild(
+async function runChild(
   command: string,
   argv: string[],
   env: NodeJS.ProcessEnv,
   cwd = process.cwd(),
   quietStdout = false,
 ): Promise<number> {
+  // Same resolution as record and as detection; see resolveLaunch.
+  const target = await resolveLaunch(command, argv);
   return new Promise((resolve, reject) => {
-    const child = spawn(command, argv, {
+    const child = spawn(target.file, target.args, {
       env,
       cwd,
+      shell: target.shell,
       stdio: quietStdout ? ['inherit', 'pipe', 'inherit'] : 'inherit',
     });
     child.stdout?.pipe(process.stderr);

--- a/packages/cli/src/exchange-events.ts
+++ b/packages/cli/src/exchange-events.ts
@@ -192,6 +192,14 @@ export async function appendDerivedEvents(
   deriver: ExchangeEventDeriver,
   exchange: RecordedExchange,
   turn: number,
+  /**
+   * Each derived event as it is written.
+   *
+   * The recorder needs to know whether the agent ran any commands, so it can say when the shell
+   * layer was on and saw none of them. That is only knowable from what the model asked for, and
+   * this is the one place the derived events exist.
+   */
+  onDerived?: (derived: DerivedEvent) => void,
 ): Promise<void> {
   /** `written[i]` is the seq of the i-th derived event, which is what `causesIndex` refers to. */
   const written: number[] = [];
@@ -214,6 +222,7 @@ export async function appendDerivedEvents(
       ...(causes.length > 0 ? { causes } : {}),
     });
     written.push(event.seq);
+    onDerived?.(derived);
     if (derived.type === 'tool.call') {
       deriver.markPending(String(derived.attrs['tool_use_id']), event.seq);
     }

--- a/packages/cli/src/flags.ts
+++ b/packages/cli/src/flags.ts
@@ -1,0 +1,89 @@
+import type { ParsedArgs } from './args.js';
+
+/**
+ * Which flags each command accepts.
+ *
+ * The parser takes any flag it is given, which is right for parsing and wrong for a CLI: a
+ * mistyped or invented flag was accepted in silence and simply had no effect, so a run that did
+ * something other than what was asked reported success.
+ *
+ * Every entry below is a flag the code actually reads — collected from the `args.bool/str/num/list`
+ * calls in each command and in the helpers it shares — not from what the documentation describes.
+ * Building it the other way round is how a flag that never existed came to be recommended in the
+ * first place, and a list that allows more than the code understands would rebuild exactly that.
+ */
+const GLOBAL = ['ci', 'json', 'verbose', 'color', 'help', 'version', 'h'] as const;
+
+/** Read by `config.ts` for any command that can reach a provider. */
+const UPSTREAM = ['upstream-anthropic', 'upstream-openai'] as const;
+
+/** Read by `tls-capture.ts`, which record, replay and compare all set up. */
+const TLS = ['tls-intercept', 'tls-hosts'] as const;
+
+const BY_COMMAND: Record<string, readonly string[]> = {
+  record: ['fs', 'shell', 'mcp-config', ...TLS, ...UPSTREAM],
+  replay: [
+    'from',
+    'model',
+    'fs',
+    'in-place',
+    'worktree',
+    'loose',
+    'trace',
+    'port',
+    'ui',
+    'mcp-config',
+    ...TLS,
+    ...UPSTREAM,
+  ],
+  compare: ['from', 'models', 'verify', 'share', 'loose', ...TLS, ...UPSTREAM],
+  show: [],
+  checkpoints: [],
+  export: ['o', 'out'],
+  ui: ['port'],
+  scrub: ['match', 'matches', 'dry-run', 'drop-fs'],
+  list: [],
+  gc: ['older-than', 'keep', 'dry-run'],
+  doctor: [],
+  setup: ['gateway', 'key', 'key-env', 'models'],
+  models: [],
+  mcp: [],
+  help: [],
+};
+
+/** The closest known flag, for a name that is probably a typo rather than an invention. */
+function nearest(name: string, known: readonly string[]): string | undefined {
+  let best: { name: string; score: number } | undefined;
+  for (const candidate of known) {
+    // Prefix and containment both catch the realistic slips: `--worktre`, `--model-s`.
+    const prefix = candidate.startsWith(name) || name.startsWith(candidate) ? 2 : 0;
+    const contains = candidate.includes(name) || name.includes(candidate) ? 1 : 0;
+    const score = Math.max(prefix, contains);
+    if (score > 0 && (best === undefined || score > best.score)) best = { name: candidate, score };
+  }
+  return best?.name;
+}
+
+/**
+ * Reject a flag this command does not have.
+ *
+ * Throws rather than warns. A flag is an instruction, and carrying on having ignored one produces
+ * a run that did something other than what was asked while reporting success — which is the
+ * failure this whole tool exists to make visible.
+ */
+export function assertKnownFlags(args: ParsedArgs): void {
+  const allowed = BY_COMMAND[args.command];
+  // An unknown command is reported by the dispatcher, which can say more about it than this can.
+  if (allowed === undefined) return;
+  const known = [...allowed, ...GLOBAL];
+  const unknown = Object.keys(args.flags).filter((name) => !known.includes(name));
+  if (unknown.length === 0) return;
+
+  const [first] = unknown;
+  const suggestion = nearest(first!, known);
+  throw new Error(
+    `unknown flag --${first} for "orca ${args.command}"` +
+      (suggestion === undefined ? '' : `\n  did you mean --${suggestion}?`) +
+      `\n  flags for this command: ${allowed.length === 0 ? '(none)' : allowed.map((f) => `--${f}`).join(' ')}`,
+  );
+}

--- a/packages/cli/src/fs-events.ts
+++ b/packages/cli/src/fs-events.ts
@@ -55,6 +55,8 @@ export async function appendSnapshot(
         status: change.status,
         insertions: change.insertions,
         deletions: change.deletions,
+        // Only when true, so a trace is not littered with a false on every unremarkable change.
+        ...(change.eolOnly === true ? { eol_only: true } : {}),
       },
     });
   }

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -1,3 +1,4 @@
+import { assertKnownFlags } from './flags.js';
 import { parseArgs, type ParsedArgs } from './args.js';
 import { Orca } from './api.js';
 import { serveMcp } from './mcp-server.js';
@@ -129,6 +130,11 @@ export async function main(argv: string[], cwd = process.cwd()): Promise<number>
   }
 
   try {
+    // Before anything runs: a flag the command does not have is an instruction that would be
+    // silently ignored, and a run that quietly did something else is the failure orca exists to
+    // surface. Inside the try so it is reported the same way every other failure is.
+    assertKnownFlags(args);
+
     switch (args.command) {
       case 'record':
         return (await recordCommand(args, out, cwd)).exitCode;

--- a/packages/cli/src/mcp.ts
+++ b/packages/cli/src/mcp.ts
@@ -68,10 +68,12 @@ export function usedMcp(events: { type: string }[]): boolean {
  * no MCP calls" instead of "orca was not looking".
  */
 export async function mcpForReplay(
-  args: { str(name: string): string | undefined },
+  args: { str(name: string): string | undefined; bool?(name: string, dflt?: boolean): boolean },
   events: { type: string; attrs?: Record<string, unknown> }[],
   writer: TraceWriter,
   out: Output,
+  /** The recording's own frames, so the servers are answered from rather than started. */
+  recordedFrames?: string,
 ): Promise<McpCapture | undefined> {
   const source = mcpSourceFrom(args.str('mcp-config'), events);
   if (source === undefined) {
@@ -90,7 +92,15 @@ export async function mcpForReplay(
     });
     return undefined;
   }
-  return setupMcpCapture({ sourceConfigPath: source, runDir: writer.runDir, out });
+  return setupMcpCapture({
+    sourceConfigPath: source,
+    runDir: writer.runDir,
+    out,
+    // A replay that starts the real servers is not a replay of them: it is a second live run whose
+    // answers happen to be read back through the same shim. Answering from the recording is what
+    // makes an MCP run reproducible after the server it talked to is gone.
+    ...(recordedFrames === undefined ? {} : { replayFrames: recordedFrames }),
+  });
 }
 
 /**
@@ -147,6 +157,16 @@ export async function setupMcpCapture(opts: {
   sourceConfigPath: string;
   runDir: string;
   out: Output;
+  /**
+   * Frames to answer from instead of starting the servers.
+   *
+   * Capture was only half of what this layer is for. The reason to record a server's traffic is
+   * that the run stays reproducible once the server is not — the token revoked, the repository
+   * moved, the service retired. Replay re-instrumented the same config and started the real server
+   * again, so an MCP recording could be read but not reproduced, and came apart on the first call
+   * when the server had gone. Pointed at a capture, the shim serves from it and launches nothing.
+   */
+  replayFrames?: string;
 }): Promise<McpCapture | undefined> {
   const raw = await readFile(opts.sourceConfigPath, 'utf8').catch(() => undefined);
   if (raw === undefined) {
@@ -164,11 +184,14 @@ export async function setupMcpCapture(opts: {
 
   const framesPath = join(opts.runDir, 'mcp-frames.jsonl');
   const shim = resolveShimEntry();
-  const { config, rewritten, skipped } = rewriteMcpConfig(parsed, process.execPath, [
-    shim,
-    '--out',
-    framesPath,
-  ]);
+  // Recording and replay are the same rewrite with a different flag: `--out` writes what the
+  // servers say, `--replay` says it back. Both keep `--out` so a replay records its own frames and
+  // is itself a run that can be read.
+  const shimArgs =
+    opts.replayFrames === undefined
+      ? [shim, '--out', framesPath]
+      : [shim, '--out', framesPath, '--replay', opts.replayFrames];
+  const { config, rewritten, skipped } = rewriteMcpConfig(parsed, process.execPath, shimArgs);
 
   const configPath = join(opts.runDir, 'mcp-config.json');
   await writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`, { mode: 0o600 });
@@ -176,6 +199,7 @@ export async function setupMcpCapture(opts: {
   opts.out.info('mcp.instrumented', {
     servers: rewritten.length,
     skipped: skipped.length,
+    mode: opts.replayFrames === undefined ? 'record' : 'replay',
     config: configPath,
   });
 

--- a/packages/cli/test/flags.test.ts
+++ b/packages/cli/test/flags.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { parseArgs } from '../src/args.js';
+import { assertKnownFlags } from '../src/flags.js';
+
+/**
+ * A flag is an instruction. The parser takes any it is given, which is right for parsing and wrong
+ * for a CLI: an invented one was accepted in silence and simply had no effect, so a run that did
+ * something other than what was asked reported success. Someone told to use a flag that does not
+ * exist got a normal run and no hint of it.
+ */
+describe('assertKnownFlags', () => {
+  const check = (argv: string[]) => () => assertKnownFlags(parseArgs(argv));
+
+  it('accepts the flags a command actually has', () => {
+    expect(check(['replay', 'last', '--from', '4', '--model', 'x', '--in-place'])).not.toThrow();
+    expect(check(['record', 'claude', '--no-shell', '--mcp-config', 'm.json'])).not.toThrow();
+    expect(check(['gc', '--older-than', '7d', '--dry-run'])).not.toThrow();
+  });
+
+  it('rejects one the command does not have, and says so', () => {
+    expect(check(['replay', 'last', '--explain-miss'])).toThrow(/unknown flag --explain-miss/);
+  });
+
+  // A flag that exists somewhere else is exactly the kind that reads as working.
+  it('rejects a flag that belongs to another command', () => {
+    expect(check(['list', '--from', '4'])).toThrow(/unknown flag --from/);
+  });
+
+  it('names the nearest flag when it looks like a typo', () => {
+    expect(check(['replay', 'last', '--worktre'])).toThrow(/did you mean --worktree/);
+  });
+
+  it('lists what the command does take, so the error is enough to act on', () => {
+    expect(check(['scrub', 'last', '--nope'])).toThrow(/--match --matches --dry-run --drop-fs/);
+  });
+
+  it('allows the global flags everywhere', () => {
+    expect(check(['show', 'last', '--json', '--verbose', '--ci'])).not.toThrow();
+  });
+
+  // `--no-shell` is `shell: false`; the negation must not read as a flag named `no-shell`.
+  it('understands a negated flag as the flag it negates', () => {
+    expect(check(['record', 'claude', '--no-fs', '--no-shell'])).not.toThrow();
+    expect(check(['replay', 'last', '--no-trace'])).not.toThrow();
+  });
+
+  /**
+   * The list is built from what the code reads, not from what the docs describe. `--no-trace` is
+   * a replay flag and record never looks at it, so record has to reject it — the alternative is
+   * the shape of failure this check exists for, with the flag ignored and the run reporting fine.
+   */
+  it('rejects a real flag on a command that does not read it', () => {
+    expect(check(['record', 'claude', '--no-trace'])).toThrow(/unknown flag --trace/);
+  });
+
+  it('says nothing about an unknown command, which the dispatcher reports better', () => {
+    expect(check(['bogus', '--whatever'])).not.toThrow();
+  });
+});

--- a/packages/core/src/graph.ts
+++ b/packages/core/src/graph.ts
@@ -401,3 +401,49 @@ export function pickChainTarget(events: TraceEvent[]): number | undefined {
     last((e) => e.type === 'fs.change')
   );
 }
+
+/** Attributes as a plain record, since the envelope leaves them optional. */
+function toAttrs(event: TraceEvent): Record<string, unknown> {
+  return event.attrs ?? {};
+}
+
+/** Tool calls that hand work to another agent, by the argument every harness gives them. */
+export function isDelegation(event: TraceEvent): boolean {
+  if (event.type !== 'tool.call') return false;
+  const input = toAttrs(event)['input'];
+  if (input === null || typeof input !== 'object') return false;
+  const shape = input as Record<string, unknown>;
+  return typeof shape['subagent_type'] === 'string' || typeof shape['agent'] === 'string';
+}
+
+/**
+ * The delegation whose span encloses `seq`, if any.
+ *
+ * A replay that halts inside one is the hardest kind of miss to read: the distance is small, the
+ * trace is intact, and nothing on the line says why the same run asked a different question. The
+ * answer is that the harness wrote the delegate's prompt itself and writes a fresh one every time,
+ * so that request genuinely was not the recorded one. Naming the delegation turns a number into
+ * that sentence.
+ */
+export function enclosingDelegation(
+  events: TraceEvent[],
+  seq: number,
+): { seq: number; subagent: string } | undefined {
+  const closesAt = new Map<number, number>();
+  for (const event of events) {
+    if (event.type !== 'tool.result') continue;
+    for (const cause of event.causes ?? []) closesAt.set(cause, event.seq);
+  }
+  let found: { seq: number; subagent: string } | undefined;
+  for (const event of events) {
+    if (event.seq > seq) break;
+    if (!isDelegation(event)) continue;
+    const closes = closesAt.get(event.seq);
+    // Still open at `seq`: an unclosed delegation ran to the end of the trace.
+    if (closes !== undefined && closes < seq) continue;
+    const input = toAttrs(event)['input'] as Record<string, unknown> | undefined;
+    const subagent = String(input?.['subagent_type'] ?? input?.['agent'] ?? 'sub-agent');
+    found = { seq: event.seq, subagent };
+  }
+  return found;
+}

--- a/packages/fs-capture/src/shadow.ts
+++ b/packages/fs-capture/src/shadow.ts
@@ -15,6 +15,16 @@ export interface FileChange {
   oldPath?: string;
   insertions: number;
   deletions: number;
+  /**
+   * True when the file's only change is its line endings.
+   *
+   * The shadow store keeps the bytes that were on disk, with no end-of-line normalisation — which
+   * is the right choice for a record of what happened, and produces a startling report on Windows.
+   * A tool that rewrites a CRLF file with LF changes every line as far as git is concerned, so a
+   * one-character fix comes back as `+42 −42`. The counts stay honest; this says why they are
+   * what they are.
+   */
+  eolOnly?: boolean;
 }
 
 export interface ShadowIndexOptions {
@@ -210,6 +220,11 @@ export class ShadowIndex {
       counts.set(path, { insertions, deletions });
     }
 
+    // Second pass, ignoring carriage returns at end of line. A file that reports changes in the
+    // first pass and none in this one changed only its line endings. Run once for the whole diff
+    // rather than per file, so the cost is one extra git invocation however many files moved.
+    const contentful = await this.changedIgnoringEol(fromTree, toTree);
+
     return records.map((record) => {
       const count = counts.get(record.path) ?? { insertions: 0, deletions: 0 };
       const change: FileChange = {
@@ -219,8 +234,50 @@ export class ShadowIndex {
         deletions: count.deletions,
       };
       if (record.oldPath !== undefined) change.oldPath = record.oldPath;
+      if (
+        contentful !== undefined &&
+        change.status === 'modified' &&
+        count.insertions + count.deletions > 0 &&
+        !contentful.has(record.path)
+      ) {
+        change.eolOnly = true;
+      }
       return change;
     });
+  }
+
+  /**
+   * Paths that still differ once a trailing carriage return is not counted as a difference, or
+   * undefined when this git cannot answer — in which case nothing is annotated, which is better
+   * than claiming a real edit was only line endings.
+   */
+  private async changedIgnoringEol(
+    fromTree: string,
+    toTree: string,
+  ): Promise<Set<string> | undefined> {
+    try {
+      const out = await this.run([
+        'diff-tree',
+        '-r',
+        '-M',
+        '-z',
+        '--numstat',
+        '--ignore-cr-at-eol',
+        fromTree,
+        toTree,
+      ]);
+      const paths = new Set<string>();
+      for (const token of out.split(' ')) {
+        if (token === '') continue;
+        const fields = token.split('	');
+        const path = fields[2];
+        if (path !== undefined && path !== '') paths.add(path);
+      }
+      return paths;
+    } catch {
+      // An older git without --ignore-cr-at-eol.
+      return undefined;
+    }
   }
 
   async patch(fromTree: string, toTree: string, path?: string): Promise<string> {

--- a/packages/fs-capture/test/shadow.test.ts
+++ b/packages/fs-capture/test/shadow.test.ts
@@ -208,6 +208,58 @@ describe('diff', () => {
   });
 });
 
+describe('line-ending-only changes', () => {
+  /**
+   * The shadow store keeps the bytes that were on disk, deliberately: normalising line endings
+   * would make the record disagree with the disk. The consequence on Windows is a one-character
+   * fix reported as every line changed, because the tool that made it wrote LF over a CRLF file.
+   * The counts are right, and unhelpful without this.
+   */
+  const CRLF = 'one\r\ntwo\r\nthree\r\n';
+  const LF = 'one\ntwo\nthree\n';
+
+  it('marks a file whose only change is CRLF to LF', async () => {
+    const { workTree, shadow } = await fixture();
+    await write(workTree, 'f.txt', CRLF);
+    const before = await shadow.snapshot();
+    await write(workTree, 'f.txt', LF);
+    const after = await shadow.snapshot();
+
+    const change = byPath(await shadow.diff(before, after), 'f.txt');
+    expect(change.status).toBe('modified');
+    // Honest, not silently normalised away: those lines really do differ byte for byte.
+    expect(change.insertions).toBe(3);
+    expect(change.deletions).toBe(3);
+    expect(change.eolOnly).toBe(true);
+  });
+
+  it('does not mark a real edit that also changed line endings', async () => {
+    const { workTree, shadow } = await fixture();
+    await write(workTree, 'f.txt', CRLF);
+    const before = await shadow.snapshot();
+    await write(workTree, 'f.txt', 'one\nTWO\nthree\n');
+    const after = await shadow.snapshot();
+    expect(byPath(await shadow.diff(before, after), 'f.txt').eolOnly).toBeUndefined();
+  });
+
+  it('does not mark a plain edit that left line endings alone', async () => {
+    const { workTree, shadow } = await fixture();
+    await write(workTree, 'f.txt', LF);
+    const before = await shadow.snapshot();
+    await write(workTree, 'f.txt', 'one\nTWO\nthree\n');
+    const after = await shadow.snapshot();
+    expect(byPath(await shadow.diff(before, after), 'f.txt').eolOnly).toBeUndefined();
+  });
+
+  it('does not mark a newly added file', async () => {
+    const { workTree, shadow } = await fixture();
+    const before = await shadow.snapshot();
+    await write(workTree, 'new.txt', CRLF);
+    const after = await shadow.snapshot();
+    expect(byPath(await shadow.diff(before, after), 'new.txt').eolOnly).toBeUndefined();
+  });
+});
+
 describe('exclusions', () => {
   itGit("honours the workspace's own .gitignore", async () => {
     const { workTree, shadow } = await fixture();

--- a/packages/mcp-shim/src/cli.ts
+++ b/packages/mcp-shim/src/cli.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 import { createWriteStream, realpathSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { runMock, type JsonRpcMessage, type RecordedFrame } from './mock.js';
 import { fileURLToPath } from 'node:url';
 import type { JsonRpcFrame } from './framing.js';
 import { runShim } from './shim.js';
@@ -8,6 +10,8 @@ import type { FrameDirection } from './shim.js';
 export interface ShimCliArgs {
   name: string;
   out?: string;
+  /** Recording to answer from, instead of starting the server. */
+  replay?: string;
   command: string;
   args: string[];
 }
@@ -32,16 +36,18 @@ function fail(problem: string): never {
 export function parseArgs(argv: string[]): ShimCliArgs {
   let name: string | undefined;
   let out: string | undefined;
+  let replay: string | undefined;
   let i = 0;
 
   for (; i < argv.length; i += 1) {
     const arg = argv[i] as string;
     if (arg === '--') break;
-    if (arg === '--name' || arg === '--out') {
+    if (arg === '--name' || arg === '--out' || arg === '--replay') {
       const value = argv[i + 1];
       if (value === undefined || value === '--') fail(`${arg} needs a value`);
       if (arg === '--name') name = value;
-      else out = value;
+      else if (arg === '--out') out = value;
+      else replay = value;
       i += 1;
       continue;
     }
@@ -53,7 +59,7 @@ export function parseArgs(argv: string[]): ShimCliArgs {
   const command = argv[i + 1];
   if (command === undefined) fail("no command after '--': give the MCP server to launch");
 
-  return { name, out, command, args: argv.slice(i + 2) };
+  return { name, out, replay, command, args: argv.slice(i + 2) };
 }
 
 /**
@@ -90,8 +96,62 @@ function toRecord(name: string, dir: FrameDirection, frame: JsonRpcFrame): strin
   return `${JSON.stringify(record)}\n`;
 }
 
+/** A mock's answer in the same capture format the pass-through shim writes. */
+function toMockRecord(name: string, dir: FrameDirection, message: JsonRpcMessage): string {
+  const raw = JSON.stringify(message);
+  const record: McpFrameRecord = {
+    ts: new Date().toISOString(),
+    name,
+    dir,
+    kind:
+      message.method === undefined
+        ? 'response'
+        : message.id === undefined
+          ? 'notification'
+          : 'request',
+    raw,
+  };
+  if (message.id !== undefined) record.id = message.id;
+  if (message.method !== undefined) record.method = message.method;
+  return `${JSON.stringify(record)}
+`;
+}
+
+/** The frames this server produced, read back out of a capture several servers may share. */
+async function readFrames(path: string, name: string): Promise<RecordedFrame[]> {
+  const text = await readFile(path, 'utf8').catch(() => '');
+  const frames: RecordedFrame[] = [];
+  for (const line of text.split(/\r?\n/)) {
+    if (line.trim() === '') continue;
+    let record: McpFrameRecord;
+    try {
+      record = JSON.parse(line) as McpFrameRecord;
+    } catch {
+      continue;
+    }
+    if (record.name !== name) continue;
+    let message: unknown;
+    try {
+      message = JSON.parse(record.raw);
+    } catch {
+      // A line the shim saw but could not parse is still in the capture; it just cannot answer.
+      continue;
+    }
+    frames.push({
+      server: record.name,
+      direction: record.dir === 'in' ? 'in' : 'out',
+      at: record.ts,
+      ...(record.id === undefined ? {} : { id: record.id }),
+      ...(record.method === undefined ? {} : { method: record.method }),
+      message: message as JsonRpcMessage,
+    });
+  }
+  return frames;
+}
+
 export async function main(argv: string[], io: ShimCliIo = {}): Promise<number> {
   const parsed = parseArgs(argv);
+
   // Append: several servers in one run may share a capture file, and a rerun must not erase it.
   const sink = parsed.out ? createWriteStream(parsed.out, { flags: 'a' }) : undefined;
   if (sink) {
@@ -106,6 +166,31 @@ export async function main(argv: string[], io: ShimCliIo = {}): Promise<number> 
   }
 
   try {
+    // Replay: answer from the recording and never start the server. The command is still parsed,
+    // because the config the agent reads is the same file either way — what changes is whether
+    // orca runs what it names. Frames are still written, so the replay is a readable run of its
+    // own rather than one whose MCP layer left no trace at all.
+    if (parsed.replay !== undefined) {
+      const frames = await readFrames(parsed.replay, parsed.name);
+      return await runMock({
+        name: parsed.name,
+        frames,
+        onMiss: (method: string) =>
+          (io.stderr ?? process.stderr).write(
+            `orca-mcp-shim: no recorded response for ${method} on ${parsed.name}
+`,
+          ),
+        ...(sink
+          ? {
+              onFrame: (dir: 'in' | 'out', message: JsonRpcMessage) =>
+                void sink.write(toMockRecord(parsed.name, dir, message)),
+            }
+          : {}),
+        ...(io.stdin ? { stdin: io.stdin } : {}),
+        ...(io.stdout ? { stdout: io.stdout } : {}),
+      });
+    }
+
     return await runShim({
       name: parsed.name,
       command: parsed.command,

--- a/packages/mcp-shim/src/index.ts
+++ b/packages/mcp-shim/src/index.ts
@@ -1,3 +1,4 @@
 export * from './cli.js';
 export * from './framing.js';
 export * from './shim.js';
+export * from './mock.js';

--- a/packages/mcp-shim/src/mock.ts
+++ b/packages/mcp-shim/src/mock.ts
@@ -1,0 +1,188 @@
+import { createInterface } from 'node:readline';
+
+/**
+ * Answering an MCP client from a recording, without the server.
+ *
+ * Recording MCP was only ever half of what the layer is for. The point of capturing a server's
+ * traffic is that the run stays reproducible after the server is not: the token is revoked, the
+ * repository moved, the service was turned off. Replay re-instrumented the same config and started
+ * the real server again, so a recording of an MCP run could be read but not reproduced — and once
+ * the server was gone it came apart on the first call.
+ *
+ * This is the other half. The shim answers from the frames the recording captured and never
+ * launches the child at all.
+ */
+
+/** A JSON-RPC message as it travels on the wire, which is what the capture stores. */
+export interface JsonRpcMessage {
+  jsonrpc?: string;
+  id?: string | number;
+  method?: string;
+  params?: unknown;
+  result?: unknown;
+  error?: unknown;
+}
+
+/** One recorded frame, as `mcp-frames.jsonl` stores it. */
+export interface RecordedFrame {
+  server: string;
+  direction: 'in' | 'out';
+  at: string;
+  id?: string | number;
+  method?: string;
+  message: JsonRpcMessage;
+}
+
+export interface MockOptions {
+  name: string;
+  frames: RecordedFrame[];
+  stdin?: NodeJS.ReadableStream;
+  stdout?: NodeJS.WritableStream;
+  /** Told what could not be answered, so a caller can report it rather than let the client hang. */
+  onMiss?: (method: string) => void;
+  /**
+   * Every message that crossed the shim, so a replay records what it served.
+   *
+   * A replay is a run of its own and has to be readable as one. Without this its trace has no
+   * `mcp.*` events at all, which reads as "the agent made no MCP calls" rather than as "these were
+   * answered from the parent recording" — the same ambiguity the capture layer exists to remove.
+   */
+  onFrame?: (direction: 'in' | 'out', message: JsonRpcMessage) => void;
+}
+
+/**
+ * Strip the per-run identifiers MCP carries alongside the arguments.
+ *
+ * `_meta` is the protocol's own side channel and every client fills it with things that are new
+ * each run — Claude Code puts the tool-use id and a progress token there. Comparing it makes an
+ * exact match impossible for `tools/call`, which is the one call anybody replays.
+ */
+function withoutMeta(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(withoutMeta);
+  if (value === null || typeof value !== 'object') return value;
+  const out: Record<string, unknown> = {};
+  for (const [key, inner] of Object.entries(value as Record<string, unknown>)) {
+    if (key === '_meta') continue;
+    out[key] = withoutMeta(inner);
+  }
+  return out;
+}
+
+/**
+ * Identity of a request: its method and its arguments, with per-run identifiers removed.
+ *
+ * Ids are deliberately not part of it either. A client numbers its requests per session, so the
+ * same call carries a different id on every run and matching on it would miss every time.
+ */
+export function keyOf(message: JsonRpcMessage): string {
+  const method = typeof message.method === 'string' ? message.method : '';
+  let params = '';
+  try {
+    params = JSON.stringify(withoutMeta(message.params ?? null));
+  } catch {
+    // A params object that will not serialise still identifies its method.
+  }
+  return `${method} ${params}`;
+}
+
+/**
+ * Responses from the recording, keyed by the request that drew them, in the order they came.
+ *
+ * A list per key rather than one entry: a client that called the same tool with the same arguments
+ * twice was answered twice, and may have been answered differently — a second `tools/call` against
+ * a queue returns the next item, not the first one again.
+ */
+export interface FrameIndex {
+  /** Answers to the exact question, arguments and all. */
+  byKey: Map<string, JsonRpcMessage[]>;
+  /** Answers to the method alone, for a question whose arguments cannot repeat. */
+  byMethod: Map<string, JsonRpcMessage[]>;
+}
+
+export function indexFrames(frames: RecordedFrame[]): FrameIndex {
+  const keyById = new Map<string | number, string>();
+  const methodById = new Map<string | number, string>();
+  const byKey = new Map<string, JsonRpcMessage[]>();
+  const byMethod = new Map<string, JsonRpcMessage[]>();
+  const push = (map: Map<string, JsonRpcMessage[]>, key: string, value: JsonRpcMessage): void => {
+    const bucket = map.get(key);
+    if (bucket === undefined) map.set(key, [value]);
+    else bucket.push(value);
+  };
+  for (const record of frames) {
+    const message = record.message;
+    if (record.direction === 'in') {
+      if (message.id === undefined) continue;
+      keyById.set(message.id, keyOf(message));
+      methodById.set(message.id, typeof message.method === 'string' ? message.method : '');
+      continue;
+    }
+    // A response carries no method of its own; the id is what ties it to the question asked.
+    if (message.id === undefined) continue;
+    const key = keyById.get(message.id);
+    if (key !== undefined) push(byKey, key, message);
+    const method = methodById.get(message.id);
+    if (method !== undefined) push(byMethod, method, message);
+  }
+  return { byKey, byMethod };
+}
+
+/** Serve an MCP client entirely from a recording. Resolves when the client closes stdin. */
+export async function runMock(options: MockOptions): Promise<number> {
+  const stdin = options.stdin ?? process.stdin;
+  const stdout = options.stdout ?? process.stdout;
+  const { byKey, byMethod } = indexFrames(options.frames);
+  const used = new Map<string, number>();
+
+  return new Promise((resolve) => {
+    const lines = createInterface({ input: stdin });
+    lines.on('line', (line) => {
+      if (line.trim() === '') return;
+      let message: JsonRpcMessage;
+      try {
+        message = JSON.parse(line) as JsonRpcMessage;
+      } catch {
+        return;
+      }
+      options.onFrame?.('in', message);
+      // A notification expects no answer, and inventing one desynchronises the client.
+      if (message.id === undefined) return;
+
+      // Two rungs, for the same reason the model matcher has four. Some questions repeat exactly
+      // and are answered on the first: a `tools/call` with the same arguments. Others cannot —
+      // `initialize` carries the client's own version and capabilities, and a client that is not
+      // byte-for-byte the recorded one still has to be answered or nothing else in the session
+      // happens. Falling back to the method alone answers those in the order they were asked.
+      const method = typeof message.method === 'string' ? message.method : '';
+      const key = keyOf(message);
+      const exact = byKey.get(key);
+      const bucket = exact ?? byMethod.get(method) ?? [];
+      const slot = exact === undefined ? `method:${method}` : key;
+      const nth = used.get(slot) ?? 0;
+      // Past the end, the last recorded answer stands: a client that calls once more than the
+      // recording did gets a stale answer rather than an error it has no way to interpret.
+      const recorded = bucket.length === 0 ? undefined : bucket[Math.min(nth, bucket.length - 1)];
+      used.set(slot, nth + 1);
+
+      if (recorded === undefined) {
+        const method = typeof message.method === 'string' ? message.method : '(no method)';
+        options.onMiss?.(method);
+        // JSON-RPC "method not found". The client is told this server cannot do that, which is
+        // true of a recording that never saw it — and is recoverable, where silence is a hang.
+        const answer: JsonRpcMessage = {
+          jsonrpc: '2.0',
+          id: message.id,
+          error: { code: -32601, message: `orca: no recorded response for ${method}` },
+        };
+        options.onFrame?.('out', answer);
+        stdout.write(`${JSON.stringify(answer)}\n`);
+        return;
+      }
+      // The recorded id belonged to the recorded session; the client is waiting on its own.
+      const answer: JsonRpcMessage = { ...recorded, id: message.id };
+      options.onFrame?.('out', answer);
+      stdout.write(`${JSON.stringify(answer)}\n`);
+    });
+    lines.on('close', () => resolve(0));
+  });
+}

--- a/packages/mcp-shim/test/mock.test.ts
+++ b/packages/mcp-shim/test/mock.test.ts
@@ -1,0 +1,200 @@
+import { PassThrough } from 'node:stream';
+import { describe, expect, it } from 'vitest';
+import {
+  indexFrames,
+  keyOf,
+  runMock,
+  type JsonRpcMessage,
+  type RecordedFrame,
+} from '../src/mock.js';
+
+/**
+ * Serving an MCP client from a recording.
+ *
+ * Capture was only half of what this layer is for. The reason to record a server's traffic is that
+ * the run stays reproducible once the server is not — the token revoked, the repository moved, the
+ * service retired. Replay used to re-instrument the same config and start the real server again,
+ * so an MCP recording could be read but not reproduced, and came apart on the first call when the
+ * server had gone.
+ */
+
+/** Ids are explicit: a counter shared across tests silently pairs a request with another's reply. */
+function req(id: number, method: string, params?: unknown): RecordedFrame {
+  return {
+    server: 's',
+    direction: 'in',
+    at: '2026-01-01T00:00:00.000Z',
+    id,
+    method,
+    message: { jsonrpc: '2.0', id, method, ...(params === undefined ? {} : { params }) },
+  };
+}
+function res(id: number, result: unknown): RecordedFrame {
+  return {
+    server: 's',
+    direction: 'out',
+    at: '2026-01-01T00:00:00.000Z',
+    id,
+    message: { jsonrpc: '2.0', id, result },
+  };
+}
+
+/** Drive the mock with a list of client messages and collect what it wrote back. */
+async function ask(frames: RecordedFrame[], sent: JsonRpcMessage[]): Promise<JsonRpcMessage[]> {
+  const stdin = new PassThrough();
+  const stdout = new PassThrough();
+  const out: JsonRpcMessage[] = [];
+  stdout.on('data', (chunk: Buffer) => {
+    for (const line of chunk.toString('utf8').split('\n')) {
+      if (line.trim() !== '') out.push(JSON.parse(line) as JsonRpcMessage);
+    }
+  });
+  const done = runMock({ name: 's', frames, stdin, stdout });
+  for (const message of sent) stdin.write(`${JSON.stringify(message)}\n`);
+  stdin.end();
+  await done;
+  return out;
+}
+
+describe('keyOf', () => {
+  /**
+   * `_meta` is the protocol's own side channel and every client fills it with values that are new
+   * each run — Claude Code puts the tool-use id and a progress token there. Comparing it made an
+   * exact match impossible for `tools/call`, which is the one call anybody replays.
+   */
+  it('ignores the per-run identifiers MCP carries beside the arguments', () => {
+    const bare = keyOf({ method: 'tools/call', params: { name: 'x', arguments: {} } });
+    const withMeta = keyOf({
+      method: 'tools/call',
+      params: { name: 'x', arguments: {}, _meta: { 'claudecode/toolUseId': 'toolu_abc' } },
+    });
+    expect(withMeta).toBe(bare);
+  });
+
+  it('separates calls that differ in their real arguments', () => {
+    expect(keyOf({ method: 'tools/call', params: { name: 'a' } })).not.toBe(
+      keyOf({ method: 'tools/call', params: { name: 'b' } }),
+    );
+  });
+});
+
+describe('indexFrames', () => {
+  it('ties each response to the question its id answered', () => {
+    const { byKey, byMethod } = indexFrames([
+      req(1, 'tools/list'),
+      res(1, { tools: [] }),
+      req(2, 'tools/call', { name: 'x' }),
+      res(2, { content: 'first' }),
+    ]);
+    expect(byKey.get(keyOf({ method: 'tools/call', params: { name: 'x' } }))).toEqual([
+      { jsonrpc: '2.0', id: 2, result: { content: 'first' } },
+    ]);
+    expect(byMethod.get('tools/list')).toHaveLength(1);
+  });
+});
+
+describe('runMock', () => {
+  it('answers a repeated call in the order the recording answered it', async () => {
+    const frames = [
+      req(1, 'tools/call', { name: 'next' }),
+      res(1, { content: 'first' }),
+      req(2, 'tools/call', { name: 'next' }),
+      res(2, { content: 'second' }),
+    ];
+    const out = await ask(frames, [
+      { jsonrpc: '2.0', id: 10, method: 'tools/call', params: { name: 'next' } },
+      { jsonrpc: '2.0', id: 11, method: 'tools/call', params: { name: 'next' } },
+    ]);
+    expect(out.map((m) => m.result)).toEqual([{ content: 'first' }, { content: 'second' }]);
+    // The recorded id belonged to the recorded session; the client is waiting on its own.
+    expect(out.map((m) => m.id)).toEqual([10, 11]);
+  });
+
+  /**
+   * The call anybody actually replays. Claude Code puts a fresh `claudecode/toolUseId` in `_meta`
+   * on every run, so comparing it made an exact match impossible for `tools/call` — the recording
+   * was there and the answer never came out of it.
+   */
+  it('answers a tools/call whose _meta is new this run', async () => {
+    const frames = [
+      req(1, 'tools/call', {
+        name: 'magic',
+        arguments: {},
+        _meta: { 'claudecode/toolUseId': 'toolu_recorded' },
+      }),
+      res(1, { content: [{ type: 'text', text: 'MAGIC-7788' }] }),
+    ];
+    const out = await ask(frames, [
+      {
+        jsonrpc: '2.0',
+        id: 42,
+        method: 'tools/call',
+        params: {
+          name: 'magic',
+          arguments: {},
+          _meta: { 'claudecode/toolUseId': 'toolu_totally_different', progressToken: 9 },
+        },
+      },
+    ]);
+    expect(out[0]?.result).toEqual({ content: [{ type: 'text', text: 'MAGIC-7788' }] });
+  });
+
+  /**
+   * `initialize` carries the client's own version and capabilities, so it can never match
+   * byte-for-byte across runs — and nothing else in a session happens until it is answered.
+   */
+  it('answers by method when the arguments could not repeat', async () => {
+    const frames = [
+      req(1, 'initialize', { protocolVersion: '2025-11-25', clientInfo: { name: 'recorded' } }),
+      res(1, { serverInfo: { name: 'srv' } }),
+    ];
+    const out = await ask(frames, [
+      {
+        jsonrpc: '2.0',
+        id: 7,
+        method: 'initialize',
+        params: { protocolVersion: '2024-11-05', clientInfo: { name: 'different' } },
+      },
+    ]);
+    expect(out).toEqual([{ jsonrpc: '2.0', id: 7, result: { serverInfo: { name: 'srv' } } }]);
+  });
+
+  // Answering one would desynchronise a client that is not waiting for a reply.
+  it('says nothing to a notification', async () => {
+    const out = await ask(
+      [req(1, 'tools/list'), res(1, { tools: [] })],
+      [{ jsonrpc: '2.0', method: 'notifications/initialized' }],
+    );
+    expect(out).toEqual([]);
+  });
+
+  // Silence is a hang, and a hang is the failure a client cannot recover from or report.
+  it('answers a method the recording never saw with an error rather than nothing', async () => {
+    const misses: string[] = [];
+    const stdin = new PassThrough();
+    const stdout = new PassThrough();
+    const seen: JsonRpcMessage[] = [];
+    stdout.on('data', (c: Buffer) => seen.push(JSON.parse(c.toString('utf8')) as JsonRpcMessage));
+    const done = runMock({
+      name: 's',
+      frames: [],
+      stdin,
+      stdout,
+      onMiss: (method) => misses.push(method),
+    });
+    stdin.write(`${JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'resources/read' })}\n`);
+    stdin.end();
+    await done;
+    expect(misses).toEqual(['resources/read']);
+    expect((seen[0]?.error as { code: number }).code).toBe(-32601);
+  });
+
+  it('repeats the last answer rather than failing when a client asks once more', async () => {
+    const frames = [req(1, 'tools/call', { name: 'x' }), res(1, { content: 'only' })];
+    const out = await ask(frames, [
+      { jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name: 'x' } },
+      { jsonrpc: '2.0', id: 2, method: 'tools/call', params: { name: 'x' } },
+    ]);
+    expect(out.map((m) => m.result)).toEqual([{ content: 'only' }, { content: 'only' }]);
+  });
+});

--- a/packages/node-instrument/src/install.ts
+++ b/packages/node-instrument/src/install.ts
@@ -128,6 +128,32 @@ export function nodeOptionsWithHook(hookPath: string, existing: string | undefin
  * package exists to prevent. `--preload` is Bun's own spelling and `BUN_OPTIONS` is how it reaches
  * a command orca did not write. Both were checked against a real `bun` before this was written.
  */
-export function bunOptionsWithHook(hookPath: string, existing: string | undefined): string {
-  return withHook('--preload', hookPath, existing);
+export function bunOptionsWithHook(
+  hookPath: string,
+  existing: string | undefined,
+  platform: string = process.platform,
+): string {
+  return withHook('--preload', bunReadablePath(hookPath, platform), existing);
+}
+
+/**
+ * A path Bun will still recognise after it has parsed `BUN_OPTIONS`.
+ *
+ * Bun splits that variable with a parser that treats a backslash as an escape, so a Windows path
+ * arrives at the loader with its separators eaten and the run dies on `preload not found` before
+ * the agent starts. Quoting does not help and is worse: Bun then accepts the argument, loads
+ * nothing, and the agent runs uninstrumented while orca reports success — the silent miss this
+ * package exists to prevent.
+ *
+ * Forward slashes survive that parser and Windows accepts them everywhere, so the separator is
+ * simply changed. Checked against bun 1.4 on Windows: backslashes fail, quoted backslashes load
+ * nothing, forward slashes load the hook.
+ *
+ * Only on Windows: a backslash is a legal character in a POSIX filename, so rewriting one there
+ * would corrupt a path rather than repair it. `platform` is a parameter so both branches are
+ * reachable from a test on either OS — the Windows behaviour is the whole point of this
+ * function, and a test that can only run on Windows leaves it unproven everywhere CI runs.
+ */
+export function bunReadablePath(path: string, platform: string = process.platform): string {
+  return platform === 'win32' ? path.replaceAll('\\', '/') : path;
 }

--- a/packages/plugin-api/src/plugins.ts
+++ b/packages/plugin-api/src/plugins.ts
@@ -40,8 +40,43 @@ export interface Adapter {
   harnessVersions?: string;
   detect(cwd: string): Promise<boolean>;
   prepare(ctx: RecordContext): Promise<Launch>;
-  /** Harness-internal state a fork must restore, where the harness exposes it. */
-  sessionState?(ctx: RecordContext): Promise<Uint8Array | undefined>;
+  /**
+   * The harness's own session records, where it keeps any.
+   *
+   * Orca's capture layers see what a run *did*; only the harness knows what it was *asked*. A run
+   * driven by hand has its prompts nowhere on the wire, so without this a replay launches an agent
+   * with nothing to make it ask anything. Supplying it is what makes an interactive recording
+   * replayable and forkable at all.
+   */
+  session?: SessionSupport;
+  /**
+   * Arguments that load an MCP config from a path, for a harness that takes one.
+   *
+   * The environment variables orca sets alongside this are read by none of the harnesses it
+   * targets: Claude Code loads MCP servers from `.mcp.json`, from the user config, or from
+   * `--mcp-config`, and ignores `CLAUDE_MCP_CONFIG` entirely — so `orca record --mcp-config`
+   * instrumented a copy of the file and then launched an agent that never opened it. The capture
+   * reported success and recorded no frames, which is the same silent shape the base-URL variables
+   * had before an adapter passed those on the command line too.
+   */
+  mcpConfigArgs?(path: string): string[] | undefined;
+  /**
+   * Arguments that drive this harness through a recorded prompt with no terminal attached.
+   *
+   * `recorded` is the argv the run was made with, so an adapter can extend it rather than replace
+   * it — the flags that shaped the recording still have to shape the replay.
+   */
+  driveArgs?(prompts: string[], recorded: string[]): string[] | undefined;
+}
+
+/** How to find, read and resume a harness's own session transcripts. */
+export interface SessionSupport {
+  /** Directory the harness writes session transcripts into, or undefined if it keeps none. */
+  dir(cwd: string, env: Record<string, string | undefined>): string | undefined;
+  /** Pull the session id and the user's turns out of one transcript. */
+  parse(bytes: Uint8Array): { id?: string; prompts: string[] };
+  /** Arguments that resume that session, for a fork continuing where the run stopped. */
+  resumeArgs(id: string): string[];
 }
 
 /** How to reach a model when the replay cursor goes live. */

--- a/packages/proxy/src/matching.ts
+++ b/packages/proxy/src/matching.ts
@@ -34,6 +34,16 @@ export interface MatchResult {
   index: number;
   divergence?: Divergence;
   reason?: string;
+  /**
+   * Recorded requests passed over to reach this one.
+   *
+   * A recording holds calls the harness made for itself — a quota probe before the first turn, a
+   * request to name the session — and a replay driven without a terminal does not repeat them. The
+   * cursor used to stop dead at the first of those, so a recording of an ordinary interactive
+   * session could not be replayed at all. Skipping is only ever done onto an exact or near-exact
+   * match, and is reported here because a silently skipped exchange is a replay that lies.
+   */
+  skipped?: number;
 }
 
 /** Fields that change every run and say nothing about what was asked. */
@@ -49,6 +59,15 @@ const VOLATILE_METADATA = new Set([
 
 /** Rung 2 accepts differences up to this share of the request's total size. */
 const MINOR_DISTANCE_RATIO = 0.15;
+
+/**
+ * How many unplayed recorded requests a live one may step over.
+ *
+ * Small on purpose. The calls a harness makes for itself cluster at the start of a session — a
+ * quota probe, a title — so a handful is enough for the case this exists for, and a wide window
+ * turns a coincidental near-match into a wrong answer served under a `minor` label.
+ */
+const LOOKAHEAD = 8;
 
 /**
  * Reduce a request to what actually determines the model's answer: same model, same conversation,
@@ -335,6 +354,20 @@ export interface MatcherOptions {
  * a conversation replays forwards, so a match behind the cursor would mean the agent went
  * backwards, which is a divergence rather than a match.
  */
+/**
+ * Tools the recording had and the replay does not.
+ *
+ * The reason a miss is worth naming rather than counting. A session recorded through a terminal is
+ * offered tools that only make sense with a person in front of it — asking a question, entering
+ * plan mode, ending the conversation — and a replay driven without one is not offered them. Their
+ * schemas are large, so the distance runs into the hundreds of thousands and reads as a corrupted
+ * trace, when what happened is that the same agent was started two different ways.
+ */
+function toolsOnlyInRecording(live: CanonicalRequest, recorded: CanonicalRequest): string[] {
+  const replayed = new Set((live.tools ?? []).map((t) => t.name));
+  return (recorded.tools ?? []).map((t) => t.name).filter((name) => !replayed.has(name));
+}
+
 export class RequestMatcher {
   readonly #recorded: CanonicalRequest[];
   /** Redacted but unfolded — rung 1 compares these, so "exact" still means exact. */
@@ -372,13 +405,54 @@ export class RequestMatcher {
       };
     }
 
-    const index = this.#cursor;
+    const at = this.#matchAt(incoming, this.#cursor);
+    if (at.matched) {
+      this.#cursor = at.index + 1;
+      return at;
+    }
+
+    // Nothing at the cursor. Before halting, look for this request further along: a recording made
+    // through a terminal carries calls the harness made for itself — a quota probe, a request to
+    // name the session — and a replay driven from a transcript never repeats them. Only an exact
+    // or near-exact match is worth stepping over an unplayed exchange for; anything looser and the
+    // agent would be handed some other turn's answer.
+    for (let ahead = this.#cursor + 1; ahead <= this.#lookaheadLimit(); ahead += 1) {
+      const later = this.#matchAt(incoming, ahead);
+      if (!later.matched || later.rung > 2) continue;
+      const skipped = ahead - this.#cursor;
+      this.#cursor = ahead + 1;
+      const skippedNote =
+        `, skipping ${skipped} recorded ${skipped === 1 ? 'request' : 'requests'} ` +
+        'the replay did not repeat';
+      return {
+        ...later,
+        skipped,
+        // Always said, even when the match had a divergence of its own: a skipped exchange that
+        // goes unmentioned is a replay claiming to have reproduced something it stepped over.
+        divergence: {
+          level: later.divergence?.level ?? 'minor',
+          rung: later.rung,
+          distance: later.divergence?.distance ?? 0,
+          detail: `${later.divergence?.detail ?? `matched request ${ahead}`}${skippedNote}`,
+        },
+      };
+    }
+
+    return at;
+  }
+
+  /** How far ahead a skip may reach. Bounded: past this, a match is more likely a coincidence. */
+  #lookaheadLimit(): number {
+    return Math.min(this.#cursor + LOOKAHEAD, this.#recorded.length - 1);
+  }
+
+  /** Match against one recorded request, without moving the cursor. */
+  #matchAt(incoming: CanonicalRequest, index: number): MatchResult {
     const recorded = this.#comparable[index]!;
 
     // Rung 1 — canonical hash. Redacted the same way the recording was, but not folded: a request
     // only counts as exact when nothing in it had to be approximated.
     if (hashOf(redactedForm(incoming, this.#redactor)) === this.#strict[index]) {
-      this.#cursor += 1;
       return { matched: true, rung: 1, index };
     }
 
@@ -391,7 +465,6 @@ export class RequestMatcher {
     // is reported rather than waved through: this is the ordinary shape of replaying a real
     // harness, whose own prompt carries a session id.
     if (distance === 0) {
-      this.#cursor += 1;
       const secrets = this.#secrets[index]!;
       return {
         matched: true,
@@ -423,7 +496,6 @@ export class RequestMatcher {
       messageCount(live) === messageCount(recorded) &&
       distance <= Math.max(64, size * MINOR_DISTANCE_RATIO)
     ) {
-      this.#cursor += 1;
       return {
         matched: true,
         rung: 2,
@@ -442,7 +514,6 @@ export class RequestMatcher {
 
     // Rung 3 — the ask is the same, the history is not. Typical after context compaction.
     if (sameAsk) {
-      this.#cursor += 1;
       return {
         matched: true,
         rung: 3,
@@ -468,7 +539,6 @@ export class RequestMatcher {
     // A message count that differs is already covered: `leafDistance` charges the full weight of
     // any message only one side has, so it cannot come back zero.
     if (leafDistance(withoutToolOutput(live), withoutToolOutput(recorded)) === 0) {
-      this.#cursor += 1;
       return {
         matched: true,
         rung: 3,
@@ -485,6 +555,7 @@ export class RequestMatcher {
     }
 
     // Rung 4 — no match. Halt and report; the caller decides whether --loose continues live.
+    const missingTools = toolsOnlyInRecording(incoming, this.#recorded[index]!);
     return {
       matched: false,
       rung: 4,
@@ -492,7 +563,13 @@ export class RequestMatcher {
       reason:
         `request ${index} does not match the recording ` +
         `(distance ${distance}, ${messageCount(recorded)} recorded vs ` +
-        `${messageCount(live)} replayed messages)`,
+        `${messageCount(live)} replayed messages)` +
+        (missingTools.length === 0
+          ? ''
+          : `; the recording offered ${missingTools.length} tools this replay is not: ` +
+            `${missingTools.slice(0, 6).join(', ')}` +
+            `${missingTools.length > 6 ? ', …' : ''}` +
+            ' — a session recorded through a terminal carries tools that need one'),
     };
   }
 }

--- a/packages/proxy/src/server.ts
+++ b/packages/proxy/src/server.ts
@@ -60,6 +60,48 @@ export type {
 
 export type ProxyMode = 'record' | 'replay' | 'hybrid';
 
+/**
+ * Beta flags that belong to the model that was recorded, not to the request.
+ *
+ * `anthropic-beta` is a header, so substituting a model in the body leaves it untouched — and a
+ * fork of a run made on a 1M-context model onto one without that entitlement comes back
+ * `400 The long context beta is not yet available for this subscription`. The failure names the
+ * subscription rather than the flag, so it reads as an account problem and not as orca carrying
+ * over something it should have dropped.
+ *
+ * Only entitlement-gated flags are removed. The rest of the header is what the harness needs to
+ * speak its own protocol — tool shapes, output formats — and dropping those would break the fork
+ * in a way that is much harder to see than a 400.
+ */
+const MODEL_GATED_BETAS = [/^context-\d+m\b/i];
+
+/** `anthropic-beta` with the recorded model's entitlements taken out, or undefined if empty. */
+export function betasForModelChange(value: string): string | undefined {
+  const kept = value
+    .split(',')
+    .map((flag) => flag.trim())
+    .filter((flag) => flag !== '' && !MODEL_GATED_BETAS.some((re) => re.test(flag)));
+  return kept.length > 0 ? kept.join(',') : undefined;
+}
+
+/** The outbound headers for a live call, reconciled with a model the recording did not use. */
+function headersForModel(
+  headers: Record<string, string>,
+  forkModel: string | undefined,
+): Record<string, string> {
+  if (forkModel === undefined) return headers;
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() !== 'anthropic-beta') {
+      out[key] = value;
+      continue;
+    }
+    const kept = betasForModelChange(value);
+    if (kept !== undefined) out[key] = kept;
+  }
+  return out;
+}
+
 export interface RecordedExchange {
   seq: number;
   dialect: string;
@@ -539,7 +581,7 @@ export async function createProxy(options: ProxyOptions): Promise<ProxyHandle> {
       method: 'POST',
       headers: {
         'content-type': 'application/json',
-        ...headers,
+        ...headersForModel(headers, options.forkModel),
         ...(options.upstreamHeaders ?? {}),
       },
       body: outboundBody,

--- a/packages/proxy/test/beta-headers.test.ts
+++ b/packages/proxy/test/beta-headers.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { betasForModelChange } from '../src/server.js';
+
+/**
+ * `anthropic-beta` is a header, so substituting a model in the request body leaves it behind. A
+ * fork of a run made on a 1M-context model onto one without that entitlement came back
+ * `400 The long context beta is not yet available for this subscription` — a failure that names
+ * the subscription rather than the flag, and so reads as an account problem rather than as orca
+ * carrying over something it should have dropped.
+ */
+describe('betasForModelChange', () => {
+  it('drops a context-window entitlement, which belongs to the recorded model', () => {
+    expect(betasForModelChange('context-1m-2025-08-07')).toBeUndefined();
+    expect(betasForModelChange('context-200m-2026-01-01')).toBeUndefined();
+  });
+
+  // The rest of the header is how the harness speaks its own protocol. Dropping tool shapes or
+  // output formats would break the fork in a way far harder to see than a 400.
+  it('keeps protocol flags, which belong to the harness', () => {
+    const value = 'tools-2024-05-16,prompt-caching-2024-07-31';
+    expect(betasForModelChange(value)).toBe(value);
+  });
+
+  it('keeps the protocol flags alongside an entitlement it removes', () => {
+    expect(betasForModelChange('context-1m-2025-08-07,tools-2024-05-16')).toBe('tools-2024-05-16');
+    expect(betasForModelChange('tools-2024-05-16, context-1m-2025-08-07')).toBe('tools-2024-05-16');
+  });
+
+  it('is undefined rather than empty, so the header is removed and not sent blank', () => {
+    expect(betasForModelChange('')).toBeUndefined();
+    expect(betasForModelChange(' , ')).toBeUndefined();
+  });
+
+  // Substring, not prefix: a flag that merely mentions context is not an entitlement.
+  it('does not drop a flag that only looks like one', () => {
+    const value = 'extended-context-cache-2026-01-01';
+    expect(betasForModelChange(value)).toBe(value);
+  });
+});

--- a/packages/proxy/test/lookahead.test.ts
+++ b/packages/proxy/test/lookahead.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import type { CanonicalRequest } from '@orcareplay/plugin-api';
+import { RequestMatcher } from '../src/matching.js';
+
+/**
+ * Stepping over what the replay did not repeat.
+ *
+ * A recording made through a terminal holds calls the harness made for itself: a quota probe
+ * before the first turn, a request to name the session. A replay driven from a transcript never
+ * makes them, and the cursor used to stop dead on the first one — so a recording of an ordinary
+ * interactive session could not be replayed at all, however faithful the rest of it was.
+ */
+function req(text: string, over: Partial<CanonicalRequest> = {}): CanonicalRequest {
+  return {
+    model: 'claude-opus-5',
+    messages: [{ role: 'user', content: [{ type: 'text', text }] }],
+    ...over,
+  };
+}
+
+describe('RequestMatcher lookahead', () => {
+  it('steps over a recorded request the replay did not make', () => {
+    const m = new RequestMatcher([req('quota'), req('the real question')]);
+    const result = m.match(req('the real question'));
+    expect(result.matched).toBe(true);
+    expect(result.index).toBe(1);
+    expect(result.skipped).toBe(1);
+  });
+
+  // A skipped exchange that goes unmentioned is a replay claiming to reproduce what it stepped over.
+  it('says how many it stepped over, even when the match itself was exact', () => {
+    const m = new RequestMatcher([req('quota'), req('ask')]);
+    const result = m.match(req('ask'));
+    expect(result.skipped).toBe(1);
+    expect(result.divergence?.detail ?? '').toContain('skipping 1 recorded request');
+  });
+
+  it('does not step over anything when the cursor already matches', () => {
+    const m = new RequestMatcher([req('a'), req('b')]);
+    const result = m.match(req('a'));
+    expect(result.index).toBe(0);
+    expect(result.skipped).toBeUndefined();
+  });
+
+  /**
+   * Only an exact or near-exact match is worth stepping over an unplayed exchange for. A loose one
+   * would hand the agent some other turn's answer, which is worse than halting and saying so.
+   */
+  it('halts rather than stepping onto a weak match', () => {
+    const m = new RequestMatcher([req('first question'), req('a completely different question')]);
+    const result = m.match(req('something else again'));
+    expect(result.matched).toBe(false);
+    expect(result.rung).toBe(4);
+  });
+
+  it('leaves the cursor past the request it matched, not past the one it skipped', () => {
+    const m = new RequestMatcher([req('quota'), req('one'), req('two')]);
+    m.match(req('one'));
+    expect(m.match(req('two')).index).toBe(2);
+  });
+
+  /**
+   * A session recorded through a terminal is offered tools that need one — asking a question,
+   * entering plan mode. Their schemas are large, so the distance runs into six figures and reads
+   * as a corrupted trace rather than as the same agent started two different ways.
+   */
+  it('names the tools the recording had that the replay cannot', () => {
+    const withTools = req('ask', {
+      tools: [
+        { name: 'Read', description: '', input_schema: {} },
+        { name: 'AskUserQuestion', description: '', input_schema: {} },
+      ],
+    });
+    const withoutTools = req('a different ask entirely', {
+      tools: [{ name: 'Read', description: '', input_schema: {} }],
+    });
+    const result = new RequestMatcher([withTools]).match(withoutTools);
+    expect(result.matched).toBe(false);
+    expect(result.reason).toContain('AskUserQuestion');
+    expect(result.reason).toContain('a session recorded through a terminal');
+  });
+
+  it('says nothing about tools when both sides offer the same ones', () => {
+    const tools = [{ name: 'Read', description: '', input_schema: {} }];
+    const result = new RequestMatcher([req('one thing', { tools })]).match(
+      req('a totally unrelated other thing', { tools }),
+    );
+    expect(result.matched).toBe(false);
+    expect(result.reason).not.toContain('tools');
+  });
+});

--- a/packages/schema/schema/event.schema.json
+++ b/packages/schema/schema/event.schema.json
@@ -32,6 +32,7 @@
         "checkpoint",
         "fork",
         "route.decision",
+        "session.snapshot",
         "note"
       ]
     },

--- a/packages/schema/src/constants.ts
+++ b/packages/schema/src/constants.ts
@@ -28,6 +28,7 @@ export const EVENT_TYPES = [
   'checkpoint',
   'fork',
   'route.decision',
+  'session.snapshot',
   'note',
 ] as const;
 

--- a/packages/viewer/src/render.ts
+++ b/packages/viewer/src/render.ts
@@ -7,6 +7,7 @@
  */
 
 import type { Manifest, TraceEvent } from '@orcareplay/schema';
+import { isDelegation } from '@orcareplay/core';
 
 export type Tone = 'attention' | 'normal' | 'quiet';
 
@@ -20,6 +21,16 @@ export interface TimelineRow {
   kind: string;
   /** The one thing worth reading at a glance. Never empty. */
   label: string;
+  /**
+   * How many sub-agent calls this row is inside.
+   *
+   * A harness that delegates runs the delegate's model and tool calls through the same proxy, so
+   * they land in the same flat sequence as the parent's — and a run that spawned an Explore agent
+   * read as one stream in which no line said whose work it was. The nesting is already in the
+   * trace: the `tool.result` closing a sub-agent call names it in `causes`, so everything between
+   * the two belongs to the delegate.
+   */
+  depth: number;
   /** Secondary text, dimmed. */
   detail: string;
   /** Right-aligned trailing text (ids, token counts, durations). */
@@ -43,8 +54,20 @@ export interface RunSummary {
 export interface LoopFinding {
   fromTurn: number;
   toTurn: number;
-  tree: string;
   turns: number[];
+  /** Why this run was called a loop, which is also what makes it actionable. */
+  kind: 'repeated-action' | 'error-spin';
+  /** The action being repeated, for `repeated-action`. */
+  signature?: string;
+  /** Times the cycle went round, for `repeated-action`. */
+  repeats?: number;
+  /**
+   * Filesystem tree the run sat on, when every turn in it shared one.
+   *
+   * Optional now: it was the whole basis of the old detector and is only context here, and an
+   * error-spin can happen in a run that has no filesystem capture at all.
+   */
+  tree?: string;
 }
 
 const KIND_BY_TYPE: Record<string, string> = {
@@ -223,6 +246,9 @@ function parts(event: TraceEvent): RowParts {
         pick(a, 'status'),
         added === undefined ? '' : `+${added}`,
         removed === undefined ? '' : `−${removed}`,
+        // Without this, a tool that rewrote a CRLF file with LF reports every line as changed and
+        // there is nothing to say the content is the same.
+        a['eol_only'] === true ? '(line endings only)' : '',
       ]
         .filter(Boolean)
         .join(' ');
@@ -289,14 +315,45 @@ function parts(event: TraceEvent): RowParts {
   }
 }
 
+/**
+ * Nesting depth per seq, from the delegation calls open in the trace at that point.
+ *
+ * Read off `causes` rather than guessed from ordering: the result event of a delegation names the
+ * call it answers, so the span is exactly [call, result] and survives interleaving, background
+ * tasks and delegations inside delegations.
+ */
+function depthBySeq(events: TraceEvent[]): Map<number, number> {
+  const closesAt = new Map<number, number>();
+  for (const event of events) {
+    if (event.type !== 'tool.result') continue;
+    for (const cause of event.causes ?? []) closesAt.set(cause, event.seq);
+  }
+
+  const open: number[] = [];
+  const depth = new Map<number, number>();
+  for (const event of events) {
+    while (open.length > 0 && event.seq > open[open.length - 1]!) open.pop();
+    // The opening call sits at the parent's level; everything up to and including the result
+    // that closes it is nested, so the block reads as one piece.
+    depth.set(event.seq, open.length);
+    if (isDelegation(event)) {
+      const closes = closesAt.get(event.seq);
+      if (closes !== undefined) open.push(closes);
+    }
+  }
+  return depth;
+}
+
 /** One display row per event, in trace order. */
 export function buildTimeline(events: TraceEvent[]): TimelineRow[] {
+  const depth = depthBySeq(events);
   return events.map((event) => {
     const derived = parts(event);
     return {
       seq: event.seq,
       monoUs: event.mono_us,
       turn: event.turn,
+      depth: depth.get(event.seq) ?? 0,
       kind: kindForType(event.type),
       label: clamp(oneLine(derived.label || humanize(event.type)), LABEL_MAX),
       detail: clamp(oneLine(derived.detail ?? ''), DETAIL_MAX),
@@ -394,29 +451,161 @@ export function summarize(manifest: Manifest, events: TraceEvent[]): RunSummary 
  * emitted no snapshot says nothing about the tree either way. Where a turn carries several
  * snapshots, the last one is that turn's end state.
  */
+/**
+ * Loops, meaning the agent is going round rather than getting somewhere.
+ *
+ * The first version of this asked whether the filesystem tree had changed, and called three turns
+ * on one tree a loop. That is not what a loop is. It fires on any conversation that runs three
+ * turns without writing a file — a question answered in prose, a plan discussed before any edit —
+ * so a real agent session raised it almost every time and the finding meant nothing. What makes a
+ * loop a loop is the agent *repeating itself*, so that is what is looked for here.
+ *
+ * Two shapes, because agents get stuck in two ways:
+ *
+ *   - **repeated-action** — the same tool call, or the same short cycle of them, over and over.
+ *     Three repetitions, since two of anything is a retry and retries are how agents work.
+ *   - **error-spin** — turns that call the model and then do nothing at all, after something has
+ *     already failed. Two is enough here: the error is the evidence that the agent was trying,
+ *     which is exactly what an ordinary conversation lacks and why this does not fire on one.
+ */
 export function detectLoops(events: TraceEvent[]): LoopFinding[] {
-  const lastTreeByTurn = new Map<number, string>();
+  return [...repeatedActions(events), ...errorSpins(events)].sort(
+    (a, b) => a.fromTurn - b.fromTurn,
+  );
+}
+
+/** Identity of a tool call: the same tool with the same arguments is the same action. */
+function actionSignature(event: TraceEvent): string {
+  const a = attrs(event);
+  const name = typeof a['name'] === 'string' ? a['name'] : 'tool';
+  let input = '';
+  try {
+    input = JSON.stringify(event.payload ?? a['input'] ?? '');
+  } catch {
+    // A payload that will not serialise still identifies the tool it belongs to.
+  }
+  // Bounded so one enormous argument cannot dominate the comparison or the memory.
+  return `${name}:${input.slice(0, 512)}`;
+}
+
+const MAX_CYCLE = 4;
+const MIN_REPEATS = 3;
+
+function repeatedActions(events: TraceEvent[]): LoopFinding[] {
+  const calls = events
+    .filter((e) => e.type === 'tool.call')
+    .map((e) => ({ turn: e.turn, sig: actionSignature(e) }));
+
+  const findings: LoopFinding[] = [];
+  let i = 0;
+  while (i < calls.length) {
+    let best: { period: number; repeats: number } | undefined;
+    // Shortest cycle first: a run of one repeated call is that, not a 2-cycle of it with itself.
+    for (let period = 1; period <= MAX_CYCLE; period += 1) {
+      if (i + period * MIN_REPEATS > calls.length) break;
+      let repeats = 1;
+      while (
+        i + period * (repeats + 1) <= calls.length &&
+        matchesCycle(calls, i, period, repeats)
+      ) {
+        repeats += 1;
+      }
+      if (repeats >= MIN_REPEATS) {
+        best = { period, repeats };
+        break;
+      }
+    }
+    if (best === undefined) {
+      i += 1;
+      continue;
+    }
+    const span = calls.slice(i, i + best.period * best.repeats);
+    const turns = [...new Set(span.map((c) => c.turn))].sort((a, b) => a - b);
+    findings.push({
+      fromTurn: turns[0]!,
+      toTurn: turns[turns.length - 1]!,
+      turns,
+      kind: 'repeated-action',
+      signature: span[0]!.sig.slice(0, 120),
+      repeats: best.repeats,
+    });
+    i += best.period * best.repeats;
+  }
+  return findings;
+}
+
+/** Whether the `repeats`-th repetition of a `period`-length cycle starting at `i` matches. */
+function matchesCycle(
+  calls: { sig: string }[],
+  i: number,
+  period: number,
+  repeats: number,
+): boolean {
+  for (let k = 0; k < period; k += 1) {
+    if (calls[i + k]!.sig !== calls[i + repeats * period + k]!.sig) return false;
+  }
+  return true;
+}
+
+const MIN_SPIN_TURNS = 2;
+
+function errorSpins(events: TraceEvent[]): LoopFinding[] {
+  const turns = [...new Set(events.map((e) => e.turn))].sort((a, b) => a - b);
+  const called = new Set<number>();
+  const modelled = new Set<number>();
+  const changed = new Set<number>();
+  let firstErrorTurn: number | undefined;
+
   for (const event of events) {
-    if (event.type !== 'fs.snapshot') continue;
-    const tree = attrs(event)['tree'];
-    if (typeof tree !== 'string' || tree === '') continue;
-    lastTreeByTurn.set(event.turn, tree);
+    if (event.type === 'tool.call') called.add(event.turn);
+    if (event.type === 'model.request') modelled.add(event.turn);
+    if (event.type === 'fs.snapshot' && Number(attrs(event)['changes'] ?? 0) > 0) {
+      changed.add(event.turn);
+    }
+    const isError =
+      event.type === 'error' || (event.type === 'tool.result' && attrs(event)['is_error'] === true);
+    if (isError && firstErrorTurn === undefined) firstErrorTurn = event.turn;
   }
 
-  const turns = [...lastTreeByTurn.keys()].sort((a, b) => a - b);
+  /** A turn that asked the model something and then did nothing with the answer. */
+  const spinning = (turn: number): boolean =>
+    modelled.has(turn) && !called.has(turn) && !changed.has(turn);
+
   const findings: LoopFinding[] = [];
   let start = 0;
   while (start < turns.length) {
-    const tree = lastTreeByTurn.get(turns[start]!)!;
+    if (!spinning(turns[start]!)) {
+      start += 1;
+      continue;
+    }
     let end = start;
-    while (end + 1 < turns.length && lastTreeByTurn.get(turns[end + 1]!) === tree) end += 1;
+    while (end + 1 < turns.length && spinning(turns[end + 1]!)) end += 1;
     const run = turns.slice(start, end + 1);
-    if (run.length >= 3) {
-      findings.push({ fromTurn: run[0]!, toTurn: run[run.length - 1]!, tree, turns: run });
+    // Only after something has failed. Without that, turns like these are a conversation.
+    const afterError = firstErrorTurn !== undefined && run[0]! >= firstErrorTurn;
+    if (run.length >= MIN_SPIN_TURNS && afterError) {
+      findings.push({
+        fromTurn: run[0]!,
+        toTurn: run[run.length - 1]!,
+        turns: run,
+        kind: 'error-spin',
+        tree: treeAt(events, run[run.length - 1]!),
+      });
     }
     start = end + 1;
   }
   return findings;
+}
+
+/** The last filesystem tree seen in a turn, as context on a finding. */
+function treeAt(events: TraceEvent[], turn: number): string | undefined {
+  let tree: string | undefined;
+  for (const event of events) {
+    if (event.type !== 'fs.snapshot' || event.turn !== turn) continue;
+    const value = attrs(event)['tree'];
+    if (typeof value === 'string' && value !== '') tree = value;
+  }
+  return tree;
 }
 
 /** `842ms`, `9.4s`, `42s`, `4m 51s`, `2h 14m`. Fixed shapes so columns line up. */

--- a/packages/viewer/test/html.test.ts
+++ b/packages/viewer/test/html.test.ts
@@ -330,14 +330,25 @@ describe('document structure', () => {
     expect(html).toContain('Recorded with OrcaReplay');
   });
 
+  // Three turns on one tree used to be the definition of a loop, and is now the definition of a
+  // conversation. What the page has to surface is the agent repeating an action.
   it('surfaces loop findings from the derived analyzer', () => {
+    const call = (turn: number) =>
+      ev({ type: 'tool.call', turn, actor: 'model', attrs: { name: 'grep', input: { q: 'JWT' } } });
+    const html = renderTraceHtml({
+      manifest: manifest(),
+      events: [call(0), call(1), call(2)],
+    });
+    expect(html).toContain('LOOP');
+    expect(html).toMatch(/turns 0.{1,3}2/);
+  });
+
+  it('does not call a conversation a loop', () => {
     const html = renderTraceHtml({
       manifest: manifest(),
       events: [snap(0, 'tree_b'), snap(1, 'tree_b'), snap(2, 'tree_b')],
     });
-    expect(html).toContain('LOOP');
-    expect(html).toContain('tree_b');
-    expect(html).toMatch(/turns 0.{1,3}2/);
+    expect(html).not.toContain('LOOP');
   });
 });
 

--- a/packages/viewer/test/render.test.ts
+++ b/packages/viewer/test/render.test.ts
@@ -324,79 +324,178 @@ describe('summarize', () => {
 });
 
 describe('detectLoops', () => {
-  it('finds three or more consecutive turns with the same tree', () => {
-    const events = [
-      snap(0, 'tree_a'),
-      snap(1, 'tree_b'),
-      snap(2, 'tree_b'),
-      snap(3, 'tree_b'),
-      snap(4, 'tree_c'),
-    ];
-    const found = detectLoops(events);
-    expect(found).toHaveLength(1);
-    expect(found[0]).toEqual({ fromTurn: 1, toTurn: 3, tree: 'tree_b', turns: [1, 2, 3] });
-  });
+  /**
+   * The detector this replaced asked only whether the filesystem tree had changed, and called
+   * three turns on one tree a loop. Every one of these cases came back positive under it: a
+   * question answered in prose, a plan discussed before the first edit, a run that simply had no
+   * files to write. A finding that fires on almost every session is not a finding, so what is
+   * checked here is the agent repeating itself.
+   */
+  const call = (turn: number, name: string, input: unknown = {}) =>
+    ev({ type: 'tool.call', turn, actor: 'model', attrs: { name }, payload: input as never });
+  const model = (turn: number) => ev({ type: 'model.request', turn, actor: 'agent' });
+  const failure = (turn: number) =>
+    ev({ type: 'tool.result', turn, actor: 'tool', attrs: { is_error: true } });
 
-  it('does not flag two consecutive turns', () => {
-    expect(detectLoops([snap(0, 'tree_a'), snap(1, 'tree_a'), snap(2, 'tree_b')])).toEqual([]);
-  });
-
-  it('does not flag a repeated tree that is interrupted by real work', () => {
-    const events = [snap(0, 'tree_a'), snap(1, 'tree_a'), snap(2, 'tree_z'), snap(3, 'tree_a')];
-    expect(detectLoops(events)).toEqual([]);
-  });
-
-  it('uses the last snapshot in a turn as that turn end state', () => {
-    const events = [
-      snap(0, 'tree_a'),
-      snap(1, 'tree_x'),
-      snap(1, 'tree_a'),
-      snap(2, 'tree_a'),
-      snap(3, 'tree_a'),
-    ];
-    const found = detectLoops(events);
-    expect(found).toHaveLength(1);
-    expect(found[0]!.turns).toEqual([0, 1, 2, 3]);
-  });
-
-  it('reports several independent loops', () => {
-    const events = [
-      snap(0, 'a'),
-      snap(1, 'a'),
-      snap(2, 'a'),
-      snap(3, 'b'),
-      snap(4, 'c'),
-      snap(5, 'c'),
-      snap(6, 'c'),
-      snap(7, 'c'),
-    ];
-    const found = detectLoops(events);
-    expect(found.map((f) => [f.fromTurn, f.toTurn])).toEqual([
-      [0, 2],
-      [4, 7],
+  it('finds the same call repeated three times', () => {
+    resetSeq();
+    const found = detectLoops([
+      call(1, 'grep', { q: 'JWT' }),
+      call(2, 'grep', { q: 'JWT' }),
+      call(3, 'grep', { q: 'JWT' }),
     ]);
-    expect(found[1]!.turns).toEqual([4, 5, 6, 7]);
+    expect(found).toHaveLength(1);
+    expect(found[0]!.kind).toBe('repeated-action');
+    expect(found[0]!.repeats).toBe(3);
+    expect(found[0]!.turns).toEqual([1, 2, 3]);
   });
 
-  it('ignores snapshots with no tree and traces with none at all', () => {
-    expect(detectLoops([])).toEqual([]);
+  // Two of anything is a retry, and retries are how agents work.
+  it('does not flag a call made twice', () => {
+    resetSeq();
+    expect(detectLoops([call(1, 'grep'), call(2, 'grep')])).toEqual([]);
+  });
+
+  it('finds a two-call cycle going round three times', () => {
+    resetSeq();
+    const found = detectLoops([
+      call(1, 'edit'),
+      call(1, 'test'),
+      call(2, 'edit'),
+      call(2, 'test'),
+      call(3, 'edit'),
+      call(3, 'test'),
+    ]);
+    expect(found).toHaveLength(1);
+    expect(found[0]!.repeats).toBe(3);
+  });
+
+  // Same tool, different arguments, is work — reading three files is not a loop.
+  it('separates calls by their arguments, not only by tool name', () => {
+    resetSeq();
     expect(
       detectLoops([
-        ev({ type: 'fs.snapshot', turn: 0, attrs: {} }),
-        ev({ type: 'fs.snapshot', turn: 1, attrs: {} }),
-        ev({ type: 'fs.snapshot', turn: 2, attrs: {} }),
+        call(1, 'read', { path: 'a' }),
+        call(2, 'read', { path: 'b' }),
+        call(3, 'read', { path: 'c' }),
       ]),
     ).toEqual([]);
   });
 
-  it('is not confused by non-snapshot events between turns', () => {
+  it('finds turns that call the model and do nothing, once something has failed', () => {
+    resetSeq();
+    const found = detectLoops([call(1, 'test'), failure(1), model(2), model(3)]);
+    expect(found).toHaveLength(1);
+    expect(found[0]!.kind).toBe('error-spin');
+    expect(found[0]!.turns).toEqual([2, 3]);
+  });
+
+  /**
+   * The false positive that made the old detector useless, in the shape it actually took: orca
+   * snapshots the workspace before every model request, so a conversation that writes no files
+   * produces a run of turns all carrying the same tree. That is what the tree-based detector
+   * called a loop, and it is what answering a question looks like.
+   */
+  it('does not flag tool-less turns when nothing has failed', () => {
+    resetSeq();
     const events = [
-      snap(0, 'a'),
-      ev({ type: 'tool.call', turn: 0 }),
-      snap(1, 'a'),
-      ev({ type: 'shell.exec', turn: 1 }),
-      snap(2, 'a'),
+      snap(0, 'tree_a'),
+      model(0),
+      snap(1, 'tree_a'),
+      model(1),
+      snap(2, 'tree_a'),
+      model(2),
+      snap(3, 'tree_a'),
+      model(3),
     ];
-    expect(detectLoops(events)).toHaveLength(1);
+    expect(detectLoops(events)).toEqual([]);
+  });
+
+  it('does not flag a turn that did real work, even after a failure', () => {
+    resetSeq();
+    const found = detectLoops([failure(1), call(2, 'edit'), model(3), model(4)]);
+    expect(found.map((l) => l.turns)).toEqual([[3, 4]]);
+  });
+
+  it('reports several independent loops in order', () => {
+    resetSeq();
+    const found = detectLoops([
+      call(1, 'a'),
+      call(2, 'a'),
+      call(3, 'a'),
+      call(4, 'b'),
+      call(5, 'c'),
+      call(6, 'c'),
+      call(7, 'c'),
+    ]);
+    expect(found.map((l) => l.turns)).toEqual([
+      [1, 2, 3],
+      [5, 6, 7],
+    ]);
+  });
+});
+
+describe('buildTimeline depth', () => {
+  /**
+   * A harness that delegates runs the delegate's model and tool calls through the same proxy, so
+   * they land in the same flat sequence as the parent's. Before this, a run that spawned an
+   * Explore agent read as one stream with no line saying whose work it was — six Bash calls the
+   * parent never made, indistinguishable from six the parent did.
+   */
+  const agentCall = (seq: number) =>
+    ev({
+      seq,
+      type: 'tool.call',
+      actor: 'model',
+      attrs: { name: 'Agent', input: { subagent_type: 'Explore' } },
+    });
+  const agentResult = (seq: number, causes: number[]) =>
+    ev({ seq, type: 'tool.result', actor: 'tool', causes, attrs: { name: 'Agent' } });
+  const plain = (seq: number) => ev({ seq, type: 'model.request', actor: 'agent' });
+
+  it('nests the work between a delegation and the result that closes it', () => {
+    const rows = buildTimeline([
+      plain(0),
+      agentCall(1),
+      plain(2),
+      plain(3),
+      agentResult(4, [1]),
+      plain(5),
+    ]);
+    expect(rows.map((r) => r.depth)).toEqual([0, 0, 1, 1, 1, 0]);
+  });
+
+  it('nests a delegation inside a delegation', () => {
+    const rows = buildTimeline([
+      agentCall(0),
+      agentCall(1),
+      plain(2),
+      agentResult(3, [1]),
+      plain(4),
+      agentResult(5, [0]),
+      plain(6),
+    ]);
+    expect(rows.map((r) => r.depth)).toEqual([0, 1, 2, 2, 1, 1, 0]);
+  });
+
+  // An ordinary tool call is not a delegation, however many of them there are.
+  it('leaves a run with no delegation flat', () => {
+    const rows = buildTimeline([
+      plain(0),
+      ev({
+        seq: 1,
+        type: 'tool.call',
+        actor: 'model',
+        attrs: { name: 'Bash', input: { command: 'ls' } },
+      }),
+      ev({ seq: 2, type: 'tool.result', actor: 'tool', causes: [1], attrs: { name: 'Bash' } }),
+    ]);
+    expect(rows.map((r) => r.depth)).toEqual([0, 0, 0]);
+  });
+
+  // A delegation whose result never arrived — the run was killed — must not swallow the rest.
+  it('does not nest forever when the closing result is missing', () => {
+    const rows = buildTimeline([agentCall(0), plain(1), plain(2)]);
+    expect(rows.map((r) => r.depth)).toEqual([0, 0, 0]);
   });
 });

--- a/python/orca_trace/models.py
+++ b/python/orca_trace/models.py
@@ -51,6 +51,7 @@ EVENT_TYPES: Final[frozenset[str]] = frozenset(
         "fs.change",
         "net.request",
         "net.response",
+        "session.snapshot",
         "error",
         "divergence",
         "checkpoint",

--- a/scripts/conformance.mjs
+++ b/scripts/conformance.mjs
@@ -135,6 +135,23 @@ try {
     attrs: { server: 'files', kind: 'response', id: 1 },
     payload: JSON.stringify({ jsonrpc: '2.0', id: 1, result: { tools: [] } }),
   });
+  // The harness's own transcript, which `orca record` captures for real whenever the adapter
+  // knows where the harness keeps one. It is the only record of what a hand-driven run was
+  // *asked*, so a trace missing it cannot be replayed at all — worth a line here for the same
+  // reason the MCP pair above is.
+  await writer.append({
+    type: 'session.snapshot',
+    actor: 'harness',
+    turn: 1,
+    attrs: {
+      harness: 'claude-code',
+      session_id: '11111111-2222-3333-4444-555555555555',
+      rel_path: 'a1b2c3.jsonl',
+      prompts: 2,
+      bytes: 128,
+    },
+    payload: JSON.stringify({ type: 'user', message: { role: 'user', content: 'hello' } }),
+  });
   // A fork and the divergence a fork reports. Both come out of `orca replay --from N --model X`.
   await writer.append({
     type: 'fork',

--- a/spec/orca-trace-v0.md
+++ b/spec/orca-trace-v0.md
@@ -72,6 +72,7 @@ Because every model turn resends the whole conversation, content addressing is w
 | `shell.exec` / `shell.result` | A shell command, from the PATH shim. |
 | `fs.snapshot` / `fs.change` | A workspace tree id, and a diff against the previous tree. |
 | `net.request` / `net.response` | Non-model HTTP seen by the proxy. |
+| `session.snapshot` | The harness's own transcript, captured at the point the run ended. Carries what the run was *asked*, which a hand-driven run leaves nowhere on the wire. |
 | `error` | A failure derived from another event or reported by the harness. |
 | `divergence` | Replay matched inexactly. See §4. |
 | `checkpoint` | A forkable point. Derived, not recorded live. See §3. |


### PR DESCRIPTION
## What this changes

Six fixes that together let a run recorded by hand on Windows be captured, replayed and read:

1. **Launch each harness the way that harness is actually launched.** `spawn` does not apply `PATHEXT`, so `orca record claude` died with `spawn claude ENOENT` on every Windows box. Resolving the binary then exposed the next layer — Node refuses to run a `.cmd` without a shell (CVE-2024-27980), so `resolveLaunch` quotes for `cmd` and sets `shell` only for `.cmd`/`.bat`. Also: the adapters invented `ANTHROPIC_API_KEY=orca-recorded`, which stops Claude Code on an interactive "detected a custom API key" prompt and switches a subscription install off the credential it was going to use — the key is now passed through only when it is genuinely set. codex never read `OPENAI_BASE_URL` at all; it reads `model_providers.<name>.base_url`, so the proxy is now passed with `-c`.

2. **Record and replay the half of a run that never reaches the wire.** A run driven by hand has its prompts nowhere in the traffic, so `orca replay` launched an agent with nothing to make it ask anything and the viewer was blank. Adapters now declare where their harness keeps its own transcript; `record` snapshots it as a `session.snapshot` event and `replay` drives from it.

3. **Answer MCP from the recording.** The shim recorded frames but replay still needed the live server, so a trace outlived nothing.

4. **Step over what a replay never repeats, and name what it could not match.** The matcher had no lookahead, so one unrepeated request stalled the rest of the run; and an unmatched turn reported no reason.

5. **Make the timeline say what happened, not what nearly happened.** Loop detection keyed on filesystem trees, which flagged any two turns that touched nothing.

6. **Refuse a flag that would do nothing.** `orca replay --explain-miss` exited 0 having ignored the flag entirely. Unknown flags now fail with the nearest real one.

## Why

`orca record claude` could not start a single agent on Windows, and when the launch problems were worked around by hand the resulting trace was unreplayable: `orca replay last` rendered blank because the prompts were never on the wire. Each fix here was found by running the real harnesses — `claude`, `codex`, `opencode`, `bun` — not by reading the code.

Two of them are the "silent miss" shape this project already names in its own comments: a capture layer that reports success and records nothing. The codex base URL is one (proved with a fake proxy that received zero requests while codex answered normally); the Bun `--preload` path is the other (Bun's `BUN_OPTIONS` parser eats backslashes, so the hook never loaded and the agent's traffic went straight to the provider).

## Tests

Honest answer: the implementation came first. These were found by running real harnesses against real failures, and the tests were written to pin each behaviour down afterwards.

Rather than leave that as an untested claim, every test added here was then verified the way test-first would have proven it — the fix was removed from the source, the test was run, and it had to go red *for the stated reason* before the fix was restored. Nine rounds, and it caught three tests that proved nothing — the third only after CI ran it on Linux:

- **`buildTimeline` loop detection** — `does not flag tool-less turns when nothing has failed` stayed green with the old detector still in place, because the fixture used only `model` events with no `fs.snapshot`, so the tree-based detector returned `[]` too. Rewritten to snapshot a tree before each turn; it now fails without the fix.
- **MCP mock** — nothing at `runMock` level proved a `tools/call` carrying a fresh `_meta` still matches, which is the whole point of stripping it. Added; red without the fix.
- **Bun path rewriting** — `hands Bun a path its own parser will survive` passed on Windows and failed on Linux, because the rewrite is deliberately `win32`-only and the test asserted it unconditionally. The platform is a parameter now, and both branches are asserted everywhere. See the CI note at the end.

The `--explain-miss` bug produced a test of its own kind: the flag allowlist is built from the actual `args.*` call sites rather than from the docs, because the first version of it was written from the docs and handed `record` eight flags it does not read — caught by its own test.

`scripts/conformance.mjs` now exercises `session.snapshot`. It reported the type as declared-but-unexercised, which is exactly the gap that file exists to surface.

Verified on a clean checkout with its own `node_modules`:

- `npm run fmt:check`, `npx tsc --build --force` (0 errors), `node scripts/conformance.mjs` (38 events, 0 failures), `node scripts/check-neutrality.mjs` — all pass.
- Every one of the six commits type-checks standalone.
- `npx vitest run`: **23 failed / 1421 passed** on this branch vs **24 failed / 1351 passed** on `origin/main` in the same worktree. The remaining failures are pre-existing and Windows-only (`chmod 0600` is a no-op on Windows, `git` line-ending behaviour, and similar) — no failure on this branch is absent from `main`. The one that main fails and this branch does not is `install.test.ts > runs when BUN_OPTIONS carries --preload`, which is fix 1's Bun path.

## Checklist

- [x] `npm run check` passes locally
- [ ] Tests were written before the implementation — no. Implementation came first; every test has since been proven red without its fix, and that pass found three tests that were passing for the wrong reason (details above)
- [x] Spec and schema updated together, if the trace format changed — `session.snapshot` is now in `event.schema.json`, `constants.ts`, `spec/orca-trace-v0.md` §2.3, the Python SDK's `EVENT_TYPES`, and the conformance corpus. It was not, when this box was first ticked; see below
- [x] No new runtime dependencies
- [x] Commits signed off

### CI status

One job fails: `check (node 20)` → `tls-intercept.test.ts > replays a zstd-compressed Codex request inside intercepted TLS`. That is #8's new test and it fails the same way on `main`'s own CI run for the merge commit (`adc725d`) — Node 20's `zlib` has no zstd. It is not from this branch, and this branch does not touch that file. Every other job passes.

### What CI caught that I had not

The first push of this PR failed three jobs, and two of them were mine. Worth writing down, because both are the same shape as the bugs this branch fixes — a check that reported success while being wrong.

1. **`Spec and schema updated together` was ticked, and it was not true.** Adding `session.snapshot` to `event.schema.json` and `constants.ts` satisfies the TypeScript parity test, so locally everything was green. But the trace format is also written down in `spec/orca-trace-v0.md` §2.3 and implemented a second time in `python/orca_trace/models.py`, and `python sdk` failed on exactly that: `EVENT_TYPES` no longer matched the schema enum. Both are updated now, and the box above is accurate. The lesson is the one this branch keeps running into — the local check passing is not the same as the claim being true.

2. **My own Bun test only tested anything on Windows.** `hands Bun a path its own parser will survive` asserted the output contains no backslash, but `bunReadablePath` rewrites separators only on `win32` — correct, since a backslash is a legal character in a POSIX filename — so on Linux the assertion tested the opposite of the behaviour and failed. `bunReadablePath` now takes the platform as a parameter, and both branches are asserted on any OS: the Windows rewrite, and the POSIX path with a backslash in its name that must be left alone. Verified the way the rest were — removing the rewrite reddens the first, removing the platform guard reddens the second.

   This one is the more embarrassing of the two: the Windows behaviour is the entire point of the function, and as written the test proved it on precisely the one platform CI does not run.
