### PR TITLE
allow the picture flags the export command actually reads

### DIFF
--- a/packages/cli/src/flags.ts
+++ b/packages/cli/src/flags.ts
@@ -12,7 +12,7 @@ import type { ParsedArgs } from './args.js';
  * Building it the other way round is how a flag that never existed came to be recommended in the
  * first place, and a list that allows more than the code understands would rebuild exactly that.
  */
-const GLOBAL = ['ci', 'json', 'verbose', 'color', 'help', 'version', 'h'] as const;
+export const GLOBAL = ['ci', 'json', 'verbose', 'color', 'help', 'version', 'h'] as const;
 
 /** Read by `config.ts` for any command that can reach a provider. */
 const UPSTREAM = ['upstream-anthropic', 'upstream-openai'] as const;
@@ -20,7 +20,7 @@ const UPSTREAM = ['upstream-anthropic', 'upstream-openai'] as const;
 /** Read by `tls-capture.ts`, which record, replay and compare all set up. */
 const TLS = ['tls-intercept', 'tls-hosts'] as const;
 
-const BY_COMMAND: Record<string, readonly string[]> = {
+export const BY_COMMAND: Record<string, readonly string[]> = {
   record: ['fs', 'shell', 'mcp-config', ...TLS, ...UPSTREAM],
   replay: [
     'from',
@@ -39,7 +39,13 @@ const BY_COMMAND: Record<string, readonly string[]> = {
   compare: ['from', 'models', 'verify', 'share', 'loose', ...TLS, ...UPSTREAM],
   show: [],
   checkpoints: [],
-  export: ['o', 'out'],
+  events: [],
+  // `inspect.ts` serves graph, export and ui from one file, so the flags of all three are read
+  // there. Reading a file rather than a command is how the first version of this list came to
+  // give `export` two flags and lose the three it needs — `--card`, `--graph-card` and `--to`
+  // are the picture commands the README documents, and rejecting them broke a working feature.
+  graph: ['to'],
+  export: ['o', 'out', 'card', 'graph-card', 'to'],
   ui: ['port'],
   scrub: ['match', 'matches', 'dry-run', 'drop-fs'],
   list: [],

--- a/packages/cli/test/flags.test.ts
+++ b/packages/cli/test/flags.test.ts
@@ -1,6 +1,9 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { parseArgs } from '../src/args.js';
-import { assertKnownFlags } from '../src/flags.js';
+import { BY_COMMAND, GLOBAL, assertKnownFlags } from '../src/flags.js';
 
 /**
  * A flag is an instruction. The parser takes any it is given, which is right for parsing and wrong
@@ -55,5 +58,54 @@ describe('assertKnownFlags', () => {
 
   it('says nothing about an unknown command, which the dispatcher reports better', () => {
     expect(check(['bogus', '--whatever'])).not.toThrow();
+  });
+});
+
+/**
+ * The list is hand-written, and a hand-written mirror of the code drifts the moment the code moves.
+ * These two read the source and hold it to the same standard the file claims for itself.
+ *
+ * Both were written after the list shipped with real holes in it: `orca export --card` — a picture
+ * command the README documents and `inspect.ts` implements — was rejected outright, and `graph`
+ * had no entry at all, so every flag it took went unchecked. One file, `inspect.ts`, serves show,
+ * graph, export and ui, and the list was built a command at a time; the flags of the other three
+ * were simply never looked for.
+ */
+describe('the allowlist against the source it mirrors', () => {
+  const SRC = join(dirname(fileURLToPath(import.meta.url)), '..', 'src');
+
+  /** Every `args.bool|str|num|list('name')` in the CLI's own source. */
+  function flagsReadInSource(): Set<string> {
+    const found = new Set<string>();
+    const walk = (dir: string): void => {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const path = join(dir, entry.name);
+        if (entry.isDirectory()) walk(path);
+        else if (entry.name.endsWith('.ts')) {
+          const src = readFileSync(path, 'utf8');
+          for (const m of src.matchAll(/args\.(?:bool|str|num|list)\('([^']+)'\)/g)) {
+            found.add(m[1]!);
+          }
+        }
+      }
+    };
+    walk(SRC);
+    return found;
+  }
+
+  it('allows every flag the CLI actually reads somewhere', () => {
+    const allowed = new Set<string>([...GLOBAL, ...Object.values(BY_COMMAND).flat()]);
+    const unreachable = [...flagsReadInSource()].filter((name) => !allowed.has(name)).sort();
+    // A flag the code reads and no command allows can never be passed: the command throws first.
+    expect(unreachable).toEqual([]);
+  });
+
+  it('has an entry for every command the dispatcher handles', () => {
+    const main = readFileSync(join(SRC, 'main.ts'), 'utf8');
+    const dispatched = [...main.matchAll(/case '([a-z-]+)':/g)].map((m) => m[1]!);
+    // Without an entry, assertKnownFlags returns early and the command validates nothing at all —
+    // silently, which is the failure this whole file exists to prevent.
+    const unvalidated = dispatched.filter((c) => BY_COMMAND[c] === undefined).sort();
+    expect(unvalidated).toEqual([]);
   });
 });


### PR DESCRIPTION
## What this changes

`orca export --card` and `orca export --graph-card` work again, and `orca graph` gets its flags validated at all.

## Why

Both are documented in `orca --help` and implemented in `inspect.ts`, and #9's flag allowlist rejected them outright:

```
$ orca export last --card chain.svg
error export.failed
  unknown flag --card for "orca export"
  flags for this command: --o --out
```

`graph` was worse in the opposite direction: it had no entry in the allowlist at all, so `assertKnownFlags` returned early and every flag it was given went unchecked — the silent-accept that file exists to prevent, reintroduced by the file itself.

The cause is one file serving four commands. `inspect.ts` implements show, graph, export and ui; the list was built a command at a time from the `args.*` calls, and `--card`, `--graph-card` and `--to` were simply never looked for. This is the same mistake #9 already made once and wrote a comment about — the first version of that list was built from the documentation instead of the code — landing this time from the other direction: reading the code, but not all of it.

Found by running the full command surface against a real recording rather than by reading the list again.

## Tests

Two, and both read the source rather than mirror it by hand, because a hand-written mirror of the code is exactly what drifted:

- **`allows every flag the CLI actually reads somewhere`** — scans `packages/cli/src/**/*.ts` for `args.bool|str|num|list('name')` and asserts every name is allowed by some command or by the globals. A flag the code reads and no command allows can never be passed: the command throws first.
- **`has an entry for every command the dispatcher handles`** — parses the `case '...'` labels out of `main.ts`. Without an entry a command validates nothing, silently.

Both were checked against the bug in the way test-first would have proven them — the fix removed, the test run, red for the stated reason:

```
× allows every flag the CLI actually reads somewhere
  → expected [ 'card', 'graph-card', 'to' ] to deeply equal []
× has an entry for every command the dispatcher handles
  → expected [ 'graph' ] to deeply equal []
```

Verified after the fix:

```
$ orca export run_896988b839c3 --card card.svg
info carded path=…\card.svg bytes=3296 to=19 format=svg
$ orca export run_896988b839c3 --graph-card graph.svg
info carded path=…\graph.svg bytes=11438 kind=graph format=svg
$ orca graph run_896988b839c3 --to 19
16 model.response  17 tool.call  recorded  tool_use block in the response
17 tool.call       19 fs.change  inferred  changed path appears in tool input
```

`npm run fmt:check` and `npx tsc --build` clean; `vitest` is at the Windows baseline (23 failures, all pre-existing and all present on `main`).

### One thing noticed while checking that baseline

`packages/cli/test/config.test.ts` and `packages/cli/test/compare.test.ts` read the real user config when `XDG_CONFIG_HOME` is unset, so on a machine where someone has run `orca setup` the suite picks up their gateway and models: 27 failures with a config present, 23 with `XDG_CONFIG_HOME` pointed at an empty directory. CI has no config, so it never shows there. Not touched here — flagging it as a separate thing.

## Checklist

- [x] `npm run check` passes locally
- [ ] Tests were written before the implementation — no. The bug was found by running the command; both tests were then proven red without the fix, as shown above
- [x] Spec and schema updated together, if the trace format changed — n/a
- [x] No new runtime dependencies
- [x] Commits signed off
