### PR TITLE
0.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1846,28 +1846,28 @@
     },
     "packages/adapters": {
       "name": "@orcareplay/adapters",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@orcareplay/node-instrument": "0.1.0",
-        "@orcareplay/plugin-api": "0.1.0"
+        "@orcareplay/node-instrument": "0.1.1",
+        "@orcareplay/plugin-api": "0.1.1"
       }
     },
     "packages/cli": {
       "name": "orcareplay",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@orcareplay/adapters": "0.1.0",
-        "@orcareplay/core": "0.1.0",
-        "@orcareplay/fs-capture": "0.1.0",
-        "@orcareplay/mcp-shim": "0.1.0",
-        "@orcareplay/plugin-api": "0.1.0",
-        "@orcareplay/providers": "0.1.0",
-        "@orcareplay/proxy": "0.1.0",
-        "@orcareplay/schema": "0.1.0",
-        "@orcareplay/shell-shim": "0.1.0",
-        "@orcareplay/viewer": "0.1.0"
+        "@orcareplay/adapters": "0.1.1",
+        "@orcareplay/core": "0.1.1",
+        "@orcareplay/fs-capture": "0.1.1",
+        "@orcareplay/mcp-shim": "0.1.1",
+        "@orcareplay/plugin-api": "0.1.1",
+        "@orcareplay/providers": "0.1.1",
+        "@orcareplay/proxy": "0.1.1",
+        "@orcareplay/schema": "0.1.1",
+        "@orcareplay/shell-shim": "0.1.1",
+        "@orcareplay/viewer": "0.1.1"
       },
       "bin": {
         "orca": "dist/cli.js",
@@ -1879,24 +1879,24 @@
     },
     "packages/core": {
       "name": "@orcareplay/core",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@orcareplay/plugin-api": "0.1.0",
-        "@orcareplay/schema": "0.1.0"
+        "@orcareplay/plugin-api": "0.1.1",
+        "@orcareplay/schema": "0.1.1"
       }
     },
     "packages/fs-capture": {
       "name": "@orcareplay/fs-capture",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@orcareplay/schema": "0.1.0"
+        "@orcareplay/schema": "0.1.1"
       }
     },
     "packages/mcp-shim": {
       "name": "@orcareplay/mcp-shim",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "bin": {
         "orca-mcp-shim": "dist/cli.js"
@@ -1904,37 +1904,37 @@
     },
     "packages/node-instrument": {
       "name": "@orcareplay/node-instrument",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0"
     },
     "packages/plugin-api": {
       "name": "@orcareplay/plugin-api",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0"
     },
     "packages/providers": {
       "name": "@orcareplay/providers",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@orcareplay/plugin-api": "0.1.0",
-        "@orcareplay/schema": "0.1.0"
+        "@orcareplay/plugin-api": "0.1.1",
+        "@orcareplay/schema": "0.1.1"
       }
     },
     "packages/proxy": {
       "name": "@orcareplay/proxy",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@orcareplay/core": "0.1.0",
-        "@orcareplay/plugin-api": "0.1.0",
-        "@orcareplay/providers": "0.1.0",
-        "@orcareplay/schema": "0.1.0"
+        "@orcareplay/core": "0.1.1",
+        "@orcareplay/plugin-api": "0.1.1",
+        "@orcareplay/providers": "0.1.1",
+        "@orcareplay/schema": "0.1.1"
       }
     },
     "packages/schema": {
       "name": "@orcareplay/schema",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.17.1",
@@ -1943,18 +1943,18 @@
     },
     "packages/shell-shim": {
       "name": "@orcareplay/shell-shim",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@orcareplay/schema": "0.1.0"
+        "@orcareplay/schema": "0.1.1"
       }
     },
     "packages/viewer": {
       "name": "@orcareplay/viewer",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@orcareplay/schema": "0.1.0"
+        "@orcareplay/schema": "0.1.1"
       }
     }
   }

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orcareplay/adapters",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "license": "Apache-2.0",
   "main": "./dist/index.js",
@@ -12,7 +12,7 @@
     "dist"
   ],
   "dependencies": {
-    "@orcareplay/node-instrument": "0.1.0",
-    "@orcareplay/plugin-api": "0.1.0"
+    "@orcareplay/node-instrument": "0.1.1",
+    "@orcareplay/plugin-api": "0.1.1"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "orcareplay",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "license": "Apache-2.0",
   "description": "Record, replay and fork debugger for AI agents",
@@ -35,15 +35,15 @@
     "url": "https://github.com/Continuum-AI-Corp/OrcaReplay.git"
   },
   "dependencies": {
-    "@orcareplay/schema": "0.1.0",
-    "@orcareplay/plugin-api": "0.1.0",
-    "@orcareplay/core": "0.1.0",
-    "@orcareplay/proxy": "0.1.0",
-    "@orcareplay/providers": "0.1.0",
-    "@orcareplay/adapters": "0.1.0",
-    "@orcareplay/fs-capture": "0.1.0",
-    "@orcareplay/viewer": "0.1.0",
-    "@orcareplay/mcp-shim": "0.1.0",
-    "@orcareplay/shell-shim": "0.1.0"
+    "@orcareplay/schema": "0.1.1",
+    "@orcareplay/plugin-api": "0.1.1",
+    "@orcareplay/core": "0.1.1",
+    "@orcareplay/proxy": "0.1.1",
+    "@orcareplay/providers": "0.1.1",
+    "@orcareplay/adapters": "0.1.1",
+    "@orcareplay/fs-capture": "0.1.1",
+    "@orcareplay/viewer": "0.1.1",
+    "@orcareplay/mcp-shim": "0.1.1",
+    "@orcareplay/shell-shim": "0.1.1"
   }
 }

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -1,1 +1,1 @@
-export const ORCA_VERSION = '0.1.0';
+export const ORCA_VERSION = '0.1.1';

--- a/packages/cli/test/api.test.ts
+++ b/packages/cli/test/api.test.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { Orca } from '../src/api.js';
+import { ORCA_VERSION } from '../src/version.js';
 import { startResponsesModel } from './fixtures/responses-model.mjs';
 
 const run = promisify(execFile);
@@ -88,7 +89,11 @@ describe('Orca — the programmatic API', () => {
     expect(timeline.runId).toBe(recorded.runId);
     // Versioned, as the manifest records it: which adapter *version* produced a trace is the
     // fact that matters when an adapter has rotted and a recording no longer replays.
-    expect(timeline.adapter).toBe('generic-openai@0.1.0');
+    //
+    // Against the constant rather than a literal. A hardcoded version here asserts nothing about
+    // the shape being tested and turns every release into a failing build — which is exactly what
+    // it did on the 0.1.1 bump, where the only change in the diff was the version itself.
+    expect(timeline.adapter).toBe(`generic-openai@${ORCA_VERSION}`);
     expect(timeline.exitCode).toBe(0);
     expect(timeline.events.length).toBeGreaterThan(4);
     // The rows a caller actually wants to filter on.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orcareplay/core",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "license": "Apache-2.0",
   "main": "./dist/index.js",
@@ -12,7 +12,7 @@
     "dist"
   ],
   "dependencies": {
-    "@orcareplay/plugin-api": "0.1.0",
-    "@orcareplay/schema": "0.1.0"
+    "@orcareplay/plugin-api": "0.1.1",
+    "@orcareplay/schema": "0.1.1"
   }
 }

--- a/packages/fs-capture/package.json
+++ b/packages/fs-capture/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orcareplay/fs-capture",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "license": "Apache-2.0",
   "main": "./dist/index.js",
@@ -12,6 +12,6 @@
     "dist"
   ],
   "dependencies": {
-    "@orcareplay/schema": "0.1.0"
+    "@orcareplay/schema": "0.1.1"
   }
 }

--- a/packages/mcp-shim/package.json
+++ b/packages/mcp-shim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orcareplay/mcp-shim",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "license": "Apache-2.0",
   "main": "./dist/index.js",

--- a/packages/node-instrument/package.json
+++ b/packages/node-instrument/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orcareplay/node-instrument",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "license": "Apache-2.0",
   "description": "Capture model traffic from a JS agent that reads no base-URL variable",

--- a/packages/plugin-api/package.json
+++ b/packages/plugin-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orcareplay/plugin-api",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "license": "Apache-2.0",
   "main": "./dist/index.js",

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orcareplay/providers",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "license": "Apache-2.0",
   "main": "./dist/index.js",
@@ -12,7 +12,7 @@
     "dist"
   ],
   "dependencies": {
-    "@orcareplay/plugin-api": "0.1.0",
-    "@orcareplay/schema": "0.1.0"
+    "@orcareplay/plugin-api": "0.1.1",
+    "@orcareplay/schema": "0.1.1"
   }
 }

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orcareplay/proxy",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "license": "Apache-2.0",
   "main": "./dist/index.js",
@@ -12,9 +12,9 @@
     "dist"
   ],
   "dependencies": {
-    "@orcareplay/plugin-api": "0.1.0",
-    "@orcareplay/schema": "0.1.0",
-    "@orcareplay/core": "0.1.0",
-    "@orcareplay/providers": "0.1.0"
+    "@orcareplay/plugin-api": "0.1.1",
+    "@orcareplay/schema": "0.1.1",
+    "@orcareplay/core": "0.1.1",
+    "@orcareplay/providers": "0.1.1"
   }
 }

--- a/packages/proxy/test/tls-intercept.test.ts
+++ b/packages/proxy/test/tls-intercept.test.ts
@@ -7,9 +7,22 @@ import type { AddressInfo, Socket } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { connect as tlsConnect } from 'node:tls';
-import { zstdCompressSync } from 'node:zlib';
+import zlib from 'node:zlib';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { RunCa } from '../src/ca.js';
+
+/**
+ * zstd landed in Node's `zlib` after the oldest runtime this CLI supports, so on Node 20 the named
+ * import was simply `undefined` and the test below died on `zstdCompressSync is not a function` —
+ * a red build on every pull request, saying nothing about the change that triggered it.
+ *
+ * Looked up dynamically, the same way `decodeRequestBody` looks up the other half of the pair, so
+ * the module still loads. Skipped rather than deleted: the behaviour is real on the runtimes that
+ * have zstd, and a skipped test names the runtime that is missing something where a deleted one
+ * would just be gone.
+ */
+const zstdCompressSync = (zlib as typeof zlib & { zstdCompressSync?: (input: Buffer) => Buffer })
+  .zstdCompressSync;
 import {
   createProxy,
   type NetExchange,
@@ -362,83 +375,86 @@ describe('TLS interception', () => {
     expect(netExchanges).toHaveLength(0);
   });
 
-  it('replays a zstd-compressed Codex request inside intercepted TLS', async () => {
-    const dialect = defaultDialects().find((candidate) => candidate.id === 'codex')!;
-    const request = {
-      model: 'gpt-5.6-luna',
-      instructions: 'Answer briefly.',
-      input: [
-        {
-          type: 'message',
-          role: 'user',
-          content: [{ type: 'input_text', text: 'say hello' }],
+  it.skipIf(zstdCompressSync === undefined)(
+    'replays a zstd-compressed Codex request inside intercepted TLS',
+    async () => {
+      const dialect = defaultDialects().find((candidate) => candidate.id === 'codex')!;
+      const request = {
+        model: 'gpt-5.6-luna',
+        instructions: 'Answer briefly.',
+        input: [
+          {
+            type: 'message',
+            role: 'user',
+            content: [{ type: 'input_text', text: 'say hello' }],
+          },
+        ],
+        stream: true,
+      };
+      const response =
+        'event: response.created\n' +
+        'data: ' +
+        JSON.stringify({
+          type: 'response.created',
+          response: { id: 'resp_test', model: 'gpt-5.6-luna', status: 'in_progress' },
+        }) +
+        '\n\n' +
+        'event: response.output_text.delta\n' +
+        'data: ' +
+        JSON.stringify({ type: 'response.output_text.delta', delta: 'CODEX_REPLAY_OK' }) +
+        '\n\n' +
+        'event: response.completed\n' +
+        'data: ' +
+        JSON.stringify({
+          type: 'response.completed',
+          response: {
+            id: 'resp_test',
+            model: 'gpt-5.6-luna',
+            status: 'completed',
+            usage: { input_tokens: 3, output_tokens: 1 },
+          },
+        }) +
+        '\n\n';
+      proxy = await createProxy({
+        mode: 'replay',
+        exchanges: [
+          {
+            seq: 0,
+            dialect: 'codex',
+            path: '/backend-api/codex/responses',
+            rawRequest: JSON.stringify(request),
+            rawResponse: response,
+            status: 200,
+            streamed: true,
+            canonicalRequest: dialect.toCanonicalRequest(request),
+            canonicalResponse: dialect.parseStream(response),
+          },
+        ],
+        tls: {
+          ca: runCa,
+          hosts: [`127.0.0.1:${model.port}`],
+          trustedOriginCerts: [originCa.certPem],
         },
-      ],
-      stream: true,
-    };
-    const response =
-      'event: response.created\n' +
-      'data: ' +
-      JSON.stringify({
-        type: 'response.created',
-        response: { id: 'resp_test', model: 'gpt-5.6-luna', status: 'in_progress' },
-      }) +
-      '\n\n' +
-      'event: response.output_text.delta\n' +
-      'data: ' +
-      JSON.stringify({ type: 'response.output_text.delta', delta: 'CODEX_REPLAY_OK' }) +
-      '\n\n' +
-      'event: response.completed\n' +
-      'data: ' +
-      JSON.stringify({
-        type: 'response.completed',
-        response: {
-          id: 'resp_test',
-          model: 'gpt-5.6-luna',
-          status: 'completed',
-          usage: { input_tokens: 3, output_tokens: 1 },
-        },
-      }) +
-      '\n\n';
-    proxy = await createProxy({
-      mode: 'replay',
-      exchanges: [
-        {
-          seq: 0,
-          dialect: 'codex',
-          path: '/backend-api/codex/responses',
-          rawRequest: JSON.stringify(request),
-          rawResponse: response,
-          status: 200,
-          streamed: true,
-          canonicalRequest: dialect.toCanonicalRequest(request),
-          canonicalResponse: dialect.parseStream(response),
-        },
-      ],
-      tls: {
-        ca: runCa,
-        hosts: [`127.0.0.1:${model.port}`],
-        trustedOriginCerts: [originCa.certPem],
-      },
-    });
+      });
 
-    const replayed = await through({
-      proxyPort: proxy.port,
-      host: '127.0.0.1',
-      port: model.port,
-      trust: [runCa.certPem],
-      method: 'POST',
-      path: '/backend-api/codex/responses',
-      body: zstdCompressSync(Buffer.from(JSON.stringify(request))),
-      headers: { 'content-type': 'application/json', 'content-encoding': 'zstd' },
-    });
+      const replayed = await through({
+        proxyPort: proxy.port,
+        host: '127.0.0.1',
+        port: model.port,
+        trust: [runCa.certPem],
+        method: 'POST',
+        path: '/backend-api/codex/responses',
+        body: zstdCompressSync(Buffer.from(JSON.stringify(request))),
+        headers: { 'content-type': 'application/json', 'content-encoding': 'zstd' },
+      });
 
-    expect(replayed.status).toBe(200);
-    expect(replayed.body).toBe(response);
-    expect(proxy.stats().matchedExact).toBe(1);
-    expect(proxy.stats().unmatched).toBe(0);
-    expect(netExchanges).toHaveLength(0);
-  });
+      expect(replayed.status).toBe(200);
+      expect(replayed.body).toBe(response);
+      expect(proxy.stats().matchedExact).toBe(1);
+      expect(proxy.stats().unmatched).toBe(0);
+      expect(netExchanges).toHaveLength(0);
+    },
+  );
 
   it('never records the credentials it forwards', async () => {
     const handle = await startProxy([`127.0.0.1:${model.port}`]);

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orcareplay/schema",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "license": "Apache-2.0",
   "main": "./dist/index.js",

--- a/packages/shell-shim/package.json
+++ b/packages/shell-shim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orcareplay/shell-shim",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "license": "Apache-2.0",
   "main": "./dist/index.js",
@@ -12,6 +12,6 @@
     "dist"
   ],
   "dependencies": {
-    "@orcareplay/schema": "0.1.0"
+    "@orcareplay/schema": "0.1.1"
   }
 }

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orcareplay/viewer",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "license": "Apache-2.0",
   "main": "./dist/index.js",
@@ -12,6 +12,6 @@
     "dist"
   ],
   "dependencies": {
-    "@orcareplay/schema": "0.1.0"
+    "@orcareplay/schema": "0.1.1"
   }
 }


### PR DESCRIPTION
## What this changes

Version only: 0.1.0 → 0.1.1 across all twelve workspaces, the exact-pinned internal dependencies between them, and `ORCA_VERSION`. No behaviour changes, no dependency-tree changes — filtering the version strings out of the `package-lock.json` diff leaves it empty.

`SCHEMA_VERSION` in `packages/schema/src/constants.ts` deliberately stays at `0.1.0`. It is the version of the trace format, not of the package, and `python/tests/test_models.py` asserts it — bumping the two together would break conformance and the Python SDK at once.

## Why

0.1.0 is on npm and is missing #10. `orca export --card` and `orca export --graph-card` are documented in the CLI's own `--help` and implemented in `inspect.ts`, and the published version rejects both:

```
$ orca export last --card chain.svg
error export.failed
  unknown flag --card for "orca export"
  flags for this command: --o --out
```

`graph` had no allowlist entry at all in 0.1.0, so every flag it was given went unchecked.

That is my mistake, and worth writing down because the cause is dull and repeatable: 0.1.0 was published from a local `git checkout --detach origin/main` against a **stale** ref. `origin/main` had moved to `539b7ab` when #10 merged at `2026-08-31T10:24:56Z`; the publish happened at `2026-09-01T02:35:48Z` — sixteen hours later — and still carried `gitHead ae038c5`, the #9 merge. No `git fetch` ran in between. The published `gitHead` looked right, which is exactly why nobody caught it: it named a real commit that really was on main, just not the tip.

## Tests

None added — there is no behaviour here to test. Verified instead that the tree this tags is the one that ships:

- `npx tsc --build` — 0 errors
- `npm run fmt:check` — clean
- `npx vitest run` — 23 failed / 1424 passed, identical to `main`'s own baseline on this machine (Windows-only pre-existing failures: `chmod 0600` is a no-op on Windows, git line-ending behaviour). Run with `XDG_CONFIG_HOME` pointed at an empty directory; see the note below.
- No `0.1.0` string left in any `package.json` or `version.ts`.
- `#10`'s fix confirmed present in this tree: `graph: ['to']` and `export: ['o', 'out', 'card', 'graph-card', 'to']`.

The release workflow itself was rehearsed on `main` before this branch existed — `workflow_dispatch` with `dry-run: true`, run `33463571121`, **success**: `fmt:check`, `tsc --build`, the full `vitest` suite, `conformance.mjs`, `check-neutrality.mjs`, and all twelve packages packed. So the tag path is known to work end to end.

### Two things noticed, neither touched here

**The suite is not hermetic.** `packages/cli/test/config.test.ts` and `packages/cli/test/compare.test.ts` read the real user config when `XDG_CONFIG_HOME` is unset, so on a machine where someone has run `orca setup` they pick up that gateway and model list: 27 failures with a config present, 23 with the variable pointed at an empty directory. CI has no config, so it never shows there.

**0.1.0 has no provenance attestation.** A local publish cannot produce one — it needs the OIDC token only a CI runner has. Tagging this release runs `release.yml`, which publishes with `--provenance`, so 0.1.1 will be the first version anyone can actually verify came from this repository at this commit.

## Checklist

- [x] `npm run check` passes locally
- [ ] Tests were written before the implementation — n/a, no implementation
- [x] Spec and schema updated together, if the trace format changed — n/a; `SCHEMA_VERSION` unchanged, and that is the point
- [x] No new runtime dependencies
- [x] Commits signed off

---

After merge, tagging `v0.1.1` fires `release.yml`, which checks the tag against `packages/cli/version` before it publishes anything.
