### PR TITLE
Capture below the agent: any local agent, and agents in a sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,9 @@ whether orca understands the wire format it speaks once it arrives.
 | **opencode** | `orca record opencode` | adapter shipped, both origins redirected |
 | **LangGraph / LangChain** | `OPENAI_BASE_URL`, `ANTHROPIC_BASE_URL` | should work — it goes through the official clients, but nothing here tests it yet |
 | **Hermes** (Nous Research) | `ORCA_BASE_URL_VARS=… orca record generic-openai -- hermes …` | should work — it overrides per provider; [name the variable](#a-base-url-variable-orca-has-never-heard-of) |
+| **Codex-in-the-IDE** | `orca record exec --tls-intercept -- code .` | works — the extension spawns the agent, and it inherits the capture |
+| **a bot with a hardcoded origin** | `orca record exec --tls-intercept -- <cmd>` | works — a Grok bot posting to a URL in its own source, [in detail](#an-agent-that-reads-nothing-at-all) |
+| **an agent in a sandbox or on another machine** | `orca attach` | works — orca is reachable and prints what to export, [in detail](#an-agent-that-is-not-on-this-machine) |
 | **anything else** | `orca record generic-openai -- <cmd>` | works if it reads a base-URL variable; `orca record node -- <cmd>` if it does not |
 
 Only Claude Code has been driven end to end against the real harness, and
@@ -372,6 +375,78 @@ That inheritance is a property of the operating system rather than of orca, whic
 thing that stays obviously true right up until some layer in between sanitises the environment. So
 it has a test: a gateway fixture that makes no model call of its own, spawns an agent that does, and
 is recorded and replayed offline through the grandchild's traffic.
+
+### An agent that reads nothing at all
+
+A bot with `https://api.x.ai/v1` typed into its source reads no variable, so nothing can be
+redirected. It is also, by some distance, the most common shape of agent people write. Capture it
+below the agent instead, at the socket:
+
+```console
+orca record exec --tls-intercept -- python bot.py
+orca record exec --tls-intercept -- ./my-agent --task "fix the test"
+```
+
+`exec` (or `any`) launches your command and sets nothing — no origin and no credential — so the bot
+still talks to whoever it was already talking to, and orca reads the conversation on the way past.
+`api.x.ai` is on the default decrypt list, so a Grok bot needs no host named.
+
+The same command reaches an agent orca did not launch, as long as something orca *did* launch is
+its ancestor. That is the shape of Codex-in-the-IDE: the extension spawns the agent as a child, so
+recording the editor captures the agent underneath it.
+
+```console
+orca record exec --tls-intercept -- code .
+orca record exec --tls-intercept -- cursor .
+```
+
+Replay needs no flags repeated. A run recorded through interception writes down which hosts it
+decrypted, and `orca replay` reads that back and re-establishes the same policy — `--no-tls-intercept`
+if you would rather it did not.
+
+To decrypt an endpoint the default list does not cover, add it rather than replacing the list:
+
+```console
+orca record exec --tls-intercept --tls-hosts '+my-gateway.internal' -- ./my-agent
+```
+
+A plain `--tls-hosts a,b` still means "decrypt exactly these", as it always has. Mixing the two
+forms is refused rather than guessed at.
+
+### An agent that is not on this machine
+
+An agent in a dev container, on a VPS, or in someone's CI cannot be launched by orca, so there is
+no environment for it to build. `orca attach` turns it around: orca holds the proxy open, prints
+the block to paste on the far side, and records whatever arrives until you stop it.
+
+```console
+orca attach --for claude
+orca attach --for claude --bind 0.0.0.0 --advertise host.docker.internal
+orca attach --tls-intercept          # for an agent over there that reads no variable either
+```
+
+```
+info attached run=run_e3d64e15ee8f proxy=http://127.0.0.1:33437 for=claude-code
+
+  # in the sandbox, before starting your agent:
+  export ANTHROPIC_BASE_URL='http://127.0.0.1:33437'
+
+  Recording. Press ctrl-C when the agent is done.
+```
+
+The variables come from the same adapters `orca record` uses, so a sandbox recording cannot drift
+from a local one. `--advertise` is required when you bind a wildcard: `0.0.0.0` is a statement about
+listening, not an address anything can dial, and orca refuses to print a URL that cannot work.
+
+Replaying such a run has the same problem in reverse — the agent may not exist on this machine — so
+replay attaches too:
+
+```console
+orca attach --replay <run>
+```
+
+It serves the recording with egress blocked and takes the harness from the recording itself. Point
+the same remote agent at it and the run happens again, offline, with no model called.
 
 ### A base-URL variable orca has never heard of
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -35,12 +35,25 @@ your harness exposes internal state a fork would otherwise lose (context compact
 lists, memory files).
 
 **Before you write one**, check whether the agent respects a base-URL environment variable. That
-single fact decides whether an adapter is an afternoon or a week — or whether one can be written at
-all. Base-URL injection is the only capture mechanism there is; there is no CA mode to fall back on
-(see [SECURITY.md](../SECURITY.md)), so a harness that reads no base-URL variable cannot be
-recorded today. If it reads an unusual one, the generic OpenAI adapter probably already covers you:
-it sets `OPENAI_BASE_URL`, `OPENAI_API_BASE` and `ANTHROPIC_BASE_URL` at once and takes the command
-from argv.
+single fact decides how much work an adapter is — not, any longer, whether one is possible. There
+are three capture mechanisms, and an adapter picks whichever the harness allows:
+
+| The harness… | Capture by | Adapter looks like |
+|---|---|---|
+| reads a base-URL variable | pointing it at `ctx.proxyUrl` | one or two lines, as below |
+| is JavaScript and reads none | the fetch hook — see `node.ts` | a preload plus `NODE_OPTIONS` |
+| is neither | `--tls-intercept`, at the socket | nothing at all — see `exec.ts` |
+
+If it reads an unusual variable, the generic OpenAI adapter probably already covers you: it sets
+`OPENAI_BASE_URL`, `OPENAI_API_BASE` and `ANTHROPIC_BASE_URL` at once and takes the command from
+argv. If it reads none and is not JavaScript — a bot with its origin typed into its source, a Go
+binary, an editor that spawns the agent as a child — `orca record exec --tls-intercept -- <cmd>`
+records it with no adapter at all, and an adapter is only worth writing if you want a name for it.
+
+An adapter that relies on interception must say so with `capture: 'transport'`. It redirects
+nothing, which is otherwise indistinguishable from the broken adapter the contract's
+`redirects-model-traffic` check exists to catch; declaring it takes that one check's exemption and
+no other. See [SECURITY.md](../SECURITY.md) for what interception does and does not decrypt.
 
 ## The adapter contract
 

--- a/packages/adapters/fixtures/harness/exec.json
+++ b/packages/adapters/fixtures/harness/exec.json
@@ -1,0 +1,10 @@
+{
+  "adapter": "exec",
+  "harness_versions": null,
+  "verified_at": "2026-09-01",
+  "command": "my-agent",
+  "env_vars": [],
+  "base_urls": {},
+  "optional_env_vars": [],
+  "note": "Captures at the transport, so it sets nothing at all: no origin and no credential. The empty env_vars list is the assertion — an agent recorded through --tls-intercept must not be silently repointed at a provider it never asked for, and this fixture fails the moment something starts injecting one. The command is the first user arg, so my-agent here is the test's argv rather than a fixed binary."
+}

--- a/packages/adapters/src/contract.ts
+++ b/packages/adapters/src/contract.ts
@@ -94,7 +94,10 @@ export async function checkAdapterContract(
       ['id-format', async () => idFormat(adapter)],
       ['detect-resolves', () => detectResolves(adapter, base, join(root, 'missing-workspace'))],
       ['prepare-shape', async () => prepareShape(primary)],
-      ['redirects-model-traffic', async () => redirectsModelTraffic(primary, base)],
+      [
+        'redirects-model-traffic',
+        async () => redirectsModelTraffic(primary, base, adapter.capture ?? 'env'),
+      ],
       ['no-invented-keys', () => noInventedKeys(adapter, base)],
       ['no-ctx-mutation', () => noCtxMutation(adapter, base)],
       ['deterministic', () => deterministic(adapter, base)],
@@ -225,10 +228,30 @@ function prepareShape(primary: Attempt): CheckOutcome {
  * the adapter, capture returns nothing while every other signal — exit code, output, the agent's
  * own answers — still says the run worked.
  */
-function redirectsModelTraffic(primary: Attempt, base: RecordContext): CheckOutcome {
+function redirectsModelTraffic(
+  primary: Attempt,
+  base: RecordContext,
+  capture: 'env' | 'transport',
+): CheckOutcome {
   if ('error' in primary) return notVerified('prepare-shape');
   const env = primary.launch.env;
   if (!isStringRecord(env)) return notVerified('prepare-shape');
+
+  // An adapter that captures at the transport redirects nothing on purpose: `--tls-intercept`
+  // terminates the agent's own TLS, and the run — not the adapter — puts `HTTPS_PROXY` and the run
+  // CA into the child's environment. Failing it for "points the harness nowhere" would be scoring
+  // it against a mechanism it does not use. It is still held to every other check, including the
+  // one below that any origin it *does* set must point at the proxy.
+  if (capture === 'transport') {
+    const stray = Object.entries(env)
+      .filter(([name]) => BASE_URL_LIKE.test(name))
+      .filter(([, value]) => !pointsAtHost(value, hostOf(base.proxyUrl) ?? base.proxyUrl));
+    if (stray.length > 0) {
+      const names = stray.map(([name, value]) => `${name}=${value}`).join(', ');
+      return `${names} does not point at the proxy (${base.proxyUrl}); traffic on that origin goes straight to the provider and never reaches the trace`;
+    }
+    return SKIP;
+  }
 
   // Any base-URL-shaped variable counts, not only the three orca happens to know: a harness with
   // its own spelling — grok-cli reads `GROK_BASE_URL` — is redirected just as effectively. So is

--- a/packages/adapters/src/exec.ts
+++ b/packages/adapters/src/exec.ts
@@ -1,0 +1,59 @@
+import type { Adapter, Launch, RecordContext } from '@orcareplay/plugin-api';
+import { applyNamedBaseUrls } from './env.js';
+
+/**
+ * Any agent at all, captured at the transport.
+ *
+ * The other adapters here each name a harness and the variable it reads. This one names neither,
+ * because the cases it exists for have nothing to name:
+ *
+ *   - a bot with its origin hardcoded in source — a Grok bot posting to `https://api.x.ai/v1`
+ *     because someone typed that string, which no environment variable will ever move;
+ *   - an agent in a language the fetch hook cannot reach, which is every language except JS;
+ *   - an editor that spawns the real agent as a child, where orca launches the editor and the
+ *     agent inherits the capture two processes down.
+ *
+ * For all three the redirect happens below the agent, at the socket: `--tls-intercept` terminates
+ * the TLS the agent established itself. That is applied by the run rather than by this adapter,
+ * which is why `prepare` looks nearly empty — the emptiness is the design.
+ *
+ * It is deliberately not `generic-openai` with a better name. That adapter sets `OPENAI_BASE_URL`,
+ * `OPENAI_API_BASE` and `ANTHROPIC_BASE_URL` at once, which is right when you know your agent
+ * reads one of them and actively wrong when you do not: an injected origin silently repoints a
+ * harness that would otherwise have called somewhere else, and the trace then describes a run the
+ * user never asked for. Pointing an unknown agent nowhere is the honest default.
+ */
+export const execAdapter: Adapter = {
+  id: 'exec',
+  // `any` is what someone types when their agent is not on the list, which is the whole audience.
+  aliases: ['any'],
+
+  // Redirecting nothing is the intent, not a defect. See the `capture` field on `Adapter`.
+  capture: 'transport',
+
+  async detect(_cwd: string): Promise<boolean> {
+    // Never automatic. An adapter that does not know what it would be launching must not claim a
+    // workspace — the same rule `generic-openai` and `node` follow, for the same reason.
+    return false;
+  },
+
+  async prepare(ctx: RecordContext): Promise<Launch> {
+    const [command, ...args] = ctx.userArgs;
+    if (command === undefined || command === '') {
+      throw new Error(
+        'exec needs the command to run: orca record exec --tls-intercept -- <command> [args...], ' +
+          'e.g. orca record exec --tls-intercept -- python bot.py',
+      );
+    }
+
+    // Nothing is invented: no origin, and no credential. An agent recorded this way authenticates
+    // with whatever it already had, because orca never learned which provider it talks to.
+    const env: Record<string, string> = {};
+    // The one exception, and only because the operator asked for it by name. This is what makes
+    // `exec` useful for a harness that reads an unusual variable but has no adapter yet, without
+    // needing interception at all.
+    applyNamedBaseUrls(env, ctx.env, ctx.proxyUrl);
+
+    return { command, args, env };
+  },
+};

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -3,6 +3,7 @@ export * from './codex.js';
 export * from './contract.js';
 export * from './detect.js';
 export * from './env.js';
+export * from './exec.js';
 export * from './generic-openai.js';
 export * from './grok.js';
 export * from './node.js';

--- a/packages/adapters/src/registry.ts
+++ b/packages/adapters/src/registry.ts
@@ -1,6 +1,7 @@
 import type { Adapter } from '@orcareplay/plugin-api';
 import { claudeCodeAdapter } from './claude-code.js';
 import { codexAdapter } from './codex.js';
+import { execAdapter } from './exec.js';
 import { genericOpenAiAdapter } from './generic-openai.js';
 import { grokAdapter } from './grok.js';
 import { openClawAdapter } from './openclaw.js';
@@ -89,5 +90,7 @@ export function defaultAdapters(): AdapterRegistry {
   registry.register(openClawAdapter);
   registry.register(nodeAdapter);
   registry.register(genericOpenAiAdapter);
+  // Last: it detects nothing, and it is the fallback someone reaches for by name.
+  registry.register(execAdapter);
   return registry;
 }

--- a/packages/adapters/test/adapters.test.ts
+++ b/packages/adapters/test/adapters.test.ts
@@ -376,8 +376,9 @@ describe('genericOpenAiAdapter', () => {
 
 describe('AdapterRegistry', () => {
   it('registers every adapter by default, with the escape hatches last', () => {
-    // Order is the detection order, and `node` and `generic-openai` both decline to detect — so
-    // they sit at the end where they cannot shadow an adapter that can recognise its own harness.
+    // Order is the detection order, and `node`, `generic-openai` and `exec` all decline to detect
+    // — so they sit at the end where they cannot shadow an adapter that can recognise its own
+    // harness. `exec` is last of all: it is the one that knows the least about what it launches.
     expect(defaultAdapters().ids()).toEqual([
       'claude-code',
       'codex',
@@ -386,6 +387,7 @@ describe('AdapterRegistry', () => {
       'openclaw',
       'node',
       'generic-openai',
+      'exec',
     ]);
   });
 

--- a/packages/adapters/test/contract.test.ts
+++ b/packages/adapters/test/contract.test.ts
@@ -59,10 +59,18 @@ describe('every registered adapter', () => {
   });
 
   it.each(registry.ids())('%s is checked by every contract check, not a subset', async (id) => {
-    const result = await checkAdapterContract(registry.get(id));
+    const adapter = registry.get(id);
+    const result = await checkAdapterContract(adapter);
     // harness-versions only applies to adapters that declare a range; everything else is universal.
     const universal = CONTRACT_CHECKS.filter((c) => c !== 'harness-versions');
-    expect(result.passed).toEqual(expect.arrayContaining([...universal]));
+    // An adapter that captures at the transport redirects nothing on purpose, so the one check
+    // that asks "where does this point the harness" cannot apply to it. The exemption is narrow
+    // by construction: it is subtracted here by name, so a transport adapter that stopped passing
+    // any *other* check would still fail this test rather than quietly opt out of the contract.
+    const exempt = adapter.capture === 'transport' ? ['redirects-model-traffic'] : [];
+    const required = universal.filter((c) => !exempt.includes(c));
+    expect(result.passed).toEqual(expect.arrayContaining([...required]));
+    for (const check of exempt) expect(result.passed).not.toContain(check);
   });
 
   it('covers the registry as a whole, so a new adapter cannot skip the guard', async () => {

--- a/packages/adapters/test/exec-adapter.test.ts
+++ b/packages/adapters/test/exec-adapter.test.ts
@@ -1,0 +1,114 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { RecordContext } from '@orcareplay/plugin-api';
+import { checkAdapterContract, formatContractResult } from '../src/contract.js';
+import { defaultAdapters } from '../src/registry.js';
+import { execAdapter } from '../src/exec.js';
+
+/**
+ * The adapter for an agent orca knows nothing about.
+ *
+ * Every other adapter here names a harness and the variable that harness reads. This one names
+ * neither, because the case it exists for is an agent whose model loop orca cannot see into at
+ * all: a Python bot with a hardcoded xAI origin, a Go binary, an editor that spawns its own agent
+ * as a child. Capture for those happens at the transport — `--tls-intercept` — and the adapter's
+ * whole job is to launch the command and get out of the way.
+ *
+ * The interesting assertions here are therefore about what it does *not* set. `generic-openai`
+ * already covers "run my command and redirect the usual variables"; if this adapter also injected
+ * an origin it would be that adapter with a different name, and it would be pointing agents at a
+ * provider they never asked for.
+ */
+describe('the exec adapter', () => {
+  let root: string;
+  let ctx: RecordContext;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'orca-exec-'));
+    ctx = {
+      runId: 'run_test',
+      cwd: join(root, 'work'),
+      runDir: join(root, 'run'),
+      proxyUrl: 'http://127.0.0.1:44100',
+      userArgs: ['python', 'bot.py'],
+      env: {},
+    };
+  });
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('passes the adapter contract', async () => {
+    const result = await checkAdapterContract(execAdapter, {
+      ctx: { userArgs: ['python', 'bot.py'] },
+    });
+    expect(result.ok, formatContractResult(result)).toBe(true);
+  });
+
+  it('answers to the names people type', () => {
+    const registry = defaultAdapters();
+    expect(registry.get('exec').id).toBe('exec');
+    expect(registry.get('any').id).toBe('exec');
+  });
+
+  it('never claims a workspace, because it cannot know what it would launch', async () => {
+    expect(await execAdapter.detect(ctx.cwd)).toBe(false);
+  });
+
+  it('launches the command from argv and forwards the rest', async () => {
+    const launch = await execAdapter.prepare({
+      ...ctx,
+      userArgs: ['python', 'bot.py', '--task', 'fix it'],
+    });
+    expect(launch.command).toBe('python');
+    expect(launch.args).toEqual(['bot.py', '--task', 'fix it']);
+  });
+
+  /**
+   * The whole point of the adapter. An injected origin is not free: a harness that reads
+   * `OPENAI_BASE_URL` and would otherwise have called xAI gets silently repointed, and the run
+   * records traffic for a provider the user never chose.
+   */
+  it('injects no base-url variable of its own', async () => {
+    const launch = await execAdapter.prepare(ctx);
+    for (const name of ['OPENAI_BASE_URL', 'OPENAI_API_BASE', 'ANTHROPIC_BASE_URL']) {
+      expect(launch.env[name], `${name} must not be invented`).toBeUndefined();
+    }
+    expect(Object.keys(launch.env).filter((n) => /_BASE_URL$|_API_BASE$/.test(n))).toEqual([]);
+  });
+
+  it('invents no credential', async () => {
+    const launch = await execAdapter.prepare(ctx);
+    expect(Object.keys(launch.env).filter((n) => /KEY$|TOKEN$|SECRET$/.test(n))).toEqual([]);
+  });
+
+  /**
+   * The one redirect it will do, because the operator asked for it by name. This is what makes
+   * `exec` useful without `--tls-intercept` for a harness that reads an unusual variable.
+   */
+  it('redirects a variable the operator names', async () => {
+    const launch = await execAdapter.prepare({
+      ...ctx,
+      env: { ORCA_BASE_URL_VARS: 'GROK_BASE_URL' },
+    });
+    expect(launch.env.GROK_BASE_URL).toBe('http://127.0.0.1:44100/v1');
+  });
+
+  it('says what to type when the command is missing', async () => {
+    await expect(execAdapter.prepare({ ...ctx, userArgs: [] })).rejects.toThrow(
+      /orca record exec .*-- <command>/,
+    );
+  });
+
+  /**
+   * Declared rather than inferred. The contract's `redirects-model-traffic` check exists to catch
+   * an adapter that points the harness nowhere — which is precisely, and deliberately, what this
+   * adapter does. Marking it as transport-captured is how it opts out honestly, instead of setting
+   * an inert `ORCA_PROXY_URL` to look like it installed a hook it never installed.
+   */
+  it('declares that it captures at the transport, not through the environment', () => {
+    expect(execAdapter.capture).toBe('transport');
+  });
+});

--- a/packages/cli/src/attach.ts
+++ b/packages/cli/src/attach.ts
@@ -18,6 +18,21 @@ import { isIP } from 'node:net';
  * address nothing can dial — and those are only testable if the strings are values.
  */
 
+/**
+ * Variable names whose values must never be printed.
+ *
+ * The block goes to a terminal, and a terminal is scrollback, a screen share, a pasted ticket and
+ * a CI log. Over-matching here costs a line the operator did not need; under-matching prints
+ * somebody's API key, so the pattern is deliberately broad.
+ *
+ * Omitting them is also simply correct. The agent in the sandbox already holds whatever credential
+ * it authenticates with, and orca forwards it upstream untouched. Exporting the local machine's
+ * key would leak it; exporting the `orca-recorded` placeholder an adapter substitutes when the
+ * local environment has none would be worse — it would overwrite a working key over there and turn
+ * a functioning setup into a 401.
+ */
+const CREDENTIAL_LIKE = /(?:KEY|TOKEN|SECRET|PASSWORD|CREDENTIALS?)$/;
+
 /** Bind addresses that mean "every interface", and so mean nothing as a destination. */
 const WILDCARD_BINDS = new Set(['0.0.0.0', '::', '[::]', '*']);
 
@@ -103,7 +118,11 @@ export interface AttachRequest {
  * trusts nothing — because the file those variables name is not there.
  */
 export function attachExports(req: AttachRequest): Record<string, string> {
-  const env: Record<string, string> = { ...req.adapterEnv };
+  const env: Record<string, string> = {};
+  for (const [name, value] of Object.entries(req.adapterEnv)) {
+    if (CREDENTIAL_LIKE.test(name)) continue;
+    env[name] = value;
+  }
   if (!req.ca || !req.remoteCaPath) return env;
 
   env.HTTPS_PROXY = req.proxyUrl;
@@ -153,5 +172,7 @@ export function attachInstructions(req: AttachRequest): string[] {
   for (const [name, value] of Object.entries(attachExports(req))) {
     lines.push(`export ${name}=${shellQuote(value)}`);
   }
+  // Said out loud, because a block with no key in it reads as an incomplete one.
+  lines.push(`# your agent's own credential is unchanged — orca forwards it upstream`);
   return lines;
 }

--- a/packages/cli/src/attach.ts
+++ b/packages/cli/src/attach.ts
@@ -65,11 +65,23 @@ function bracketed(host: string): string {
   return isIP(host) === 6 ? `[${host}]` : host;
 }
 
-/** Does this host already carry its own port? Written to survive an IPv6 literal. */
+/**
+ * Does this host already carry its own port?
+ *
+ * An IPv6 literal is mostly colons, so the last one says nothing on its own: `fd00::1` ends in
+ * `:1`, which reads as a port and is not one. Answering wrongly drops the real port and hands the
+ * sandbox `http://fd00::1`, which means port 80 and connects to nothing.
+ *
+ * A bracketed host is unambiguous — anything after the `]` is a port. An unbracketed one carries a
+ * port only if it has exactly one colon, because more than one makes it an address rather than a
+ * host-and-port.
+ */
 function hasPort(host: string): boolean {
-  const colon = host.lastIndexOf(':');
-  if (colon === -1 || colon < host.lastIndexOf(']')) return false;
-  return /^\d+$/.test(host.slice(colon + 1));
+  const close = host.lastIndexOf(']');
+  if (close !== -1) return /^:\d+$/.test(host.slice(close + 1));
+  const first = host.indexOf(':');
+  if (first === -1 || first !== host.lastIndexOf(':')) return false;
+  return /^\d+$/.test(host.slice(first + 1));
 }
 
 export interface AttachRequest {

--- a/packages/cli/src/attach.ts
+++ b/packages/cli/src/attach.ts
@@ -1,0 +1,145 @@
+import { isIP } from 'node:net';
+
+/**
+ * Recording an agent orca does not launch.
+ *
+ * Every other capture path here ends in a child process: an adapter builds an environment and orca
+ * spawns the agent inside it. That is the design, and it has exactly one boundary it cannot cross
+ * — an agent that is not on this machine. A bot on a VPS, an agent inside a dev container or a
+ * cloud sandbox, a harness someone else's CI runs: there is no process to spawn, so there is no
+ * environment to build.
+ *
+ * Orca can still be reachable, and can still say precisely what to set. The proxy already accepts
+ * a bind address. What was missing is this half: the block of variables the operator pastes on the
+ * far side, which has to be right or the run comes back empty with nothing to explain why.
+ *
+ * Everything here is pure and returns data rather than printing, because the failure mode being
+ * guarded against is a *wrong instruction* — a path that exists here and not there, a wildcard
+ * address nothing can dial — and those are only testable if the strings are values.
+ */
+
+/** Bind addresses that mean "every interface", and so mean nothing as a destination. */
+const WILDCARD_BINDS = new Set(['0.0.0.0', '::', '[::]', '*']);
+
+export interface AdvertiseRequest {
+  /** The address the proxy is listening on. */
+  bind: string;
+  /** The port it actually bound, which is not the advertised one behind a port mapping. */
+  port: number;
+  /** An explicit host, optionally with its own `:port`, overriding both of the above. */
+  advertise?: string;
+}
+
+/**
+ * The origin a remote agent should be pointed at.
+ *
+ * `0.0.0.0` is a statement about listening, not an address: an agent handed `http://0.0.0.0:8080`
+ * fails in a way that looks like orca is broken rather than like the invocation was incomplete. So
+ * a wildcard bind must be paired with the name the sandbox actually reaches this machine by, and
+ * refusing is the only honest option — orca cannot discover that name, and guessing one produces a
+ * run that records nothing.
+ */
+export function advertisedUrl(req: AdvertiseRequest): string {
+  if (req.advertise !== undefined && req.advertise.trim() !== '') {
+    const host = req.advertise
+      .trim()
+      .replace(/^https?:\/\//, '')
+      .replace(/\/+$/, '');
+    // A host the operator wrote a port into is used as-is: behind a port-mapped container the
+    // reachable port is not the one orca bound, and orca has no way to learn the mapping.
+    return `http://${hasPort(host) ? host : `${bracketed(host)}:${req.port}`}`;
+  }
+  if (WILDCARD_BINDS.has(req.bind)) {
+    throw new Error(
+      `--bind ${req.bind} listens on every interface, which is not an address an agent can ` +
+        'connect to. Add --advertise <host> naming how the sandbox reaches this machine, ' +
+        'e.g. --advertise 10.0.0.5 or --advertise host.docker.internal.',
+    );
+  }
+  return `http://${bracketed(req.bind)}:${req.port}`;
+}
+
+/** A bare IPv6 literal is not a URL host until it is bracketed. */
+function bracketed(host: string): string {
+  if (host.startsWith('[')) return host;
+  return isIP(host) === 6 ? `[${host}]` : host;
+}
+
+/** Does this host already carry its own port? Written to survive an IPv6 literal. */
+function hasPort(host: string): boolean {
+  const colon = host.lastIndexOf(':');
+  if (colon === -1 || colon < host.lastIndexOf(']')) return false;
+  return /^\d+$/.test(host.slice(colon + 1));
+}
+
+export interface AttachRequest {
+  /** Where the remote agent should send its model traffic. */
+  proxyUrl: string;
+  /** Variables the named adapter would have set, already pointed at `proxyUrl`. */
+  adapterEnv: Record<string, string>;
+  /** Present only when the run is intercepting. Paths are local, and are only for the copy step. */
+  ca?: { certPath: string; bundlePath: string };
+  /** Where the CA will live *in the sandbox* once copied. Every printed path uses this. */
+  remoteCaPath?: string;
+}
+
+/**
+ * The variables to set on the far side.
+ *
+ * The CA paths are the remote ones throughout. Printing this machine's path is the subtle failure
+ * this function exists to prevent: the block runs cleanly, every variable is set, and the agent
+ * trusts nothing — because the file those variables name is not there.
+ */
+export function attachExports(req: AttachRequest): Record<string, string> {
+  const env: Record<string, string> = { ...req.adapterEnv };
+  if (!req.ca || !req.remoteCaPath) return env;
+
+  env.HTTPS_PROXY = req.proxyUrl;
+  env.https_proxy = req.proxyUrl;
+  // One path for all of them, unlike a local run. The bundle exists so an intercepted child keeps
+  // reaching the hosts orca deliberately does not decrypt; a sandbox that already trusts the
+  // public roots needs only the run CA added, and shipping one file is what makes the copy step a
+  // single line the operator will actually run.
+  for (const name of [
+    'NODE_EXTRA_CA_CERTS',
+    'SSL_CERT_FILE',
+    'REQUESTS_CA_BUNDLE',
+    'CURL_CA_BUNDLE',
+    'AWS_CA_BUNDLE',
+    'DENO_CERT',
+  ]) {
+    env[name] = req.remoteCaPath;
+  }
+  // Deliberately not carried across. `NO_PROXY` is set for a local run so the agent's plaintext
+  // calls to the proxy do not loop back through it; inherited into a sandbox it is just a list of
+  // hosts that machine will refuse to proxy, which is a silent way to record nothing.
+  return env;
+}
+
+/** Single-quote a value so no shell can reinterpret it, however it was spelled. */
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+/**
+ * The block the operator pastes into the sandbox.
+ *
+ * The copy step comes first because the export block references a file that has to exist by the
+ * time the agent starts, and an operator who pastes the second half alone gets an agent that
+ * cannot verify the proxy it was just told to trust.
+ */
+export function attachInstructions(req: AttachRequest): string[] {
+  const lines: string[] = [];
+  if (req.ca && req.remoteCaPath) {
+    lines.push(`# 1. copy the run's certificate authority into the sandbox:`);
+    lines.push(`#    scp ${req.ca.bundlePath} <sandbox>:${req.remoteCaPath}`);
+    lines.push(`#    (or: docker cp ${req.ca.bundlePath} <container>:${req.remoteCaPath})`);
+    lines.push(`# 2. then, in the sandbox, before starting your agent:`);
+  } else {
+    lines.push(`# in the sandbox, before starting your agent:`);
+  }
+  for (const [name, value] of Object.entries(attachExports(req))) {
+    lines.push(`export ${name}=${shellQuote(value)}`);
+  }
+  return lines;
+}

--- a/packages/cli/src/commands/attach.ts
+++ b/packages/cli/src/commands/attach.ts
@@ -7,7 +7,7 @@ import type { Output } from '../out.js';
 import { advertisedUrl, attachExports, attachInstructions } from '../attach.js';
 import { ExchangeEventDeriver, appendDerivedEvents } from '../exchange-events.js';
 import { SerialQueue } from '../serial.js';
-import { recordedTlsHosts, setupTlsCapture } from '../tls-capture.js';
+import { planTlsCapture, recordedTlsHosts, setupTlsCapture } from '../tls-capture.js';
 import { loadExchanges } from './replay.js';
 import { upstreamPlan } from '../upstream.js';
 import { ORCA_VERSION } from '../version.js';
@@ -104,6 +104,14 @@ async function runAttached(
    * So replay attaches too: same proxy, same matcher, same blocked egress, and the operator points
    * the same remote agent at it.
    */
+  // The parser turns a flag with no value into `true`, so a bare `--replay` — or `--replay
+  // --tls-intercept`, where the next token is itself a flag — would read as absent and start a
+  // *recording* session against the live provider. That is the worst direction to fail in.
+  if (args.has('replay') && args.str('replay') === undefined) {
+    throw new Error(
+      '--replay needs the run to serve: orca attach --replay <run>, or --replay last',
+    );
+  }
   const replaySelector = args.str('replay');
   const replaying = replaySelector
     ? await (async () => {
@@ -128,6 +136,11 @@ async function runAttached(
   const adapterName = args.str('for') ?? replaying?.adapter ?? 'exec';
   const adapter = registry.get(adapterName);
 
+  // The last thing that can refuse the run, and it runs before the trace exists: a writer created
+  // first and abandoned by a throw leaves an unsealed run directory behind, which then wins `last`
+  // — so the next command someone types operates on the session that never happened.
+  planTlsCapture(args, replaying?.hosts);
+
   const dir = await ensureRunsDir(cwd);
   const writer = await TraceWriter.create(dir, {
     adapter: { id: adapter.id, version: ORCA_VERSION, harness_version: adapter.harnessVersions },
@@ -135,6 +148,10 @@ async function runAttached(
     cwd,
     orcaVersion: ORCA_VERSION,
   });
+
+  let modelExchanges = 0;
+  let turn = 0;
+  let unmatched = 0;
 
   const writes = new SerialQueue();
   const plan = await upstreamPlan(args);
@@ -144,13 +161,11 @@ async function runAttached(
     ...(replaying ? { recordedHosts: replaying.hosts } : {}),
     writer,
     writes,
-    turn: () => 0,
+    // Out-of-band traffic belongs to whichever turn was in progress when it happened, exactly as in
+    // a launched recording. A fixed 0 filed every net.* event against the start of the session.
+    turn: () => turn,
   });
   if (tls.ca) minted.push(tls.ca);
-
-  let modelExchanges = 0;
-  let turn = 0;
-  let unmatched = 0;
   // Read before the proxy closes: `stats()` is a snapshot of a live object, and the teardown in
   // `finally` is the last moment it is still meaningful.
   let stats = {
@@ -180,12 +195,14 @@ async function runAttached(
     },
   });
 
+  const advertised = advertisedUrl({
+    bind,
+    port: proxy.port,
+    ...(advertise === undefined ? {} : { advertise }),
+  });
+
   try {
-    const proxyUrl = advertisedUrl({
-      bind,
-      port: proxy.port,
-      ...(advertise === undefined ? {} : { advertise }),
-    });
+    const proxyUrl = advertised;
 
     // What the adapter would have put into a child's environment, pointed at the reachable
     // address rather than a loopback one. `runDir` is this machine's, and is only ever used by
@@ -329,7 +346,9 @@ async function runAttached(
     runDir: writer.runDir,
     modelExchanges,
     events: manifest.counts?.events ?? 0,
-    proxyUrl: proxy.url,
+    // The address the agent should use, not the one orca bound — a caller reading this from
+    // `--json` needs something it can connect to, which a wildcard bind is not.
+    proxyUrl: advertised,
     // Exact plus inexact: both were served from the recording, which is what "reused" means here.
     // The distinction between them is a divergence, and divergences are reported on their own.
     reused: replaying ? stats.matchedExact + stats.matchedInexact : 0,

--- a/packages/cli/src/commands/attach.ts
+++ b/packages/cli/src/commands/attach.ts
@@ -4,7 +4,7 @@ import { createProxy, type RecordedExchange, type RunCa } from '@orcareplay/prox
 import { defaultAdapters } from '@orcareplay/adapters';
 import type { ParsedArgs } from '../args.js';
 import type { Output } from '../out.js';
-import { advertisedUrl, attachInstructions } from '../attach.js';
+import { advertisedUrl, attachExports, attachInstructions } from '../attach.js';
 import { ExchangeEventDeriver, appendDerivedEvents } from '../exchange-events.js';
 import { SerialQueue } from '../serial.js';
 import { recordedTlsHosts, setupTlsCapture } from '../tls-capture.js';
@@ -40,6 +40,14 @@ export interface AttachResult {
   /** Replay sessions only: recorded exchanges served back, and requests nothing matched. */
   reused: number;
   unmatched: number;
+  /**
+   * Non-zero only when a replay session could not answer something the agent asked for.
+   *
+   * A recording session cannot fail this way: it ends because the operator stopped it, which is
+   * how it is meant to end. Whether it captured anything is reported by `capture.empty`, because
+   * an empty capture is a mistake to point at rather than an error to exit on.
+   */
+  exitCode: number;
 }
 
 export interface AttachOptions {
@@ -80,10 +88,13 @@ async function runAttached(
   const requestedPort = args.num('port') ?? 0;
 
   // Resolved before the run directory is made, so an invocation that cannot work — a wildcard bind
-  // with nothing to advertise — leaves nothing behind to clean up.
-  if (requestedPort === 0) {
-    advertisedUrl({ bind, port: 1, ...(advertise === undefined ? {} : { advertise }) });
-  }
+  // with nothing to advertise — leaves nothing behind to clean up. The port is not known yet when
+  // orca is choosing one, and does not need to be: only the host can make this fail.
+  advertisedUrl({
+    bind,
+    port: requestedPort === 0 ? 1 : requestedPort,
+    ...(advertise === undefined ? {} : { advertise }),
+  });
 
   /**
    * Serving a recording back instead of recording a new one.
@@ -225,6 +236,42 @@ async function runAttached(
         },
       });
     }
+    /**
+     * An instruction the operator cannot act on is worse than none: the block pastes cleanly, the
+     * session waits, and nothing ever connects. Both shapes of that are visible from here.
+     */
+    const exported = attachExports({
+      proxyUrl,
+      adapterEnv: launch.env,
+      ...(proxy.tls
+        ? {
+            ca: { certPath: proxy.tls.caCertPath, bundlePath: proxy.tls.caBundlePath },
+            remoteCaPath,
+          }
+        : {}),
+    });
+    if (Object.keys(exported).length === 0) {
+      out.warn('attach.nothing_to_set', {
+        for: adapter.id,
+        cause: `${adapter.id} redirects nothing, and this session is not intercepting`,
+        next: 'name the harness with --for <agent>, or add --tls-intercept',
+      });
+    }
+    // A path under the run directory exists on this machine and nowhere else. The fetch hook is
+    // the live example: `--for node` names a preload orca just wrote here, so the block would
+    // instrument nothing over there while looking exactly as though it had.
+    const local = Object.entries(exported)
+      .filter(([, value]) => value.includes(writer.runDir))
+      .map(([name]) => name);
+    if (local.length > 0) {
+      out.warn('attach.local_path', {
+        vars: local.join(','),
+        cause: `${adapter.id} instruments by writing a file here and naming it in the environment`,
+        effect: 'those paths do not exist in the sandbox, so that half of the capture will not run',
+        next: 'copy the named files across, or use --tls-intercept instead',
+      });
+    }
+
     out.plain('');
     for (const line of instructions) out.plain(`  ${line}`);
     out.plain('');
@@ -287,6 +334,7 @@ async function runAttached(
     // The distinction between them is a divergence, and divergences are reported on their own.
     reused: replaying ? stats.matchedExact + stats.matchedInexact : 0,
     unmatched: replaying ? stats.unmatched : unmatched,
+    exitCode: replaying && stats.unmatched > 0 ? 1 : 0,
   };
 }
 

--- a/packages/cli/src/commands/attach.ts
+++ b/packages/cli/src/commands/attach.ts
@@ -1,0 +1,296 @@
+import { once } from 'node:events';
+import { TraceReader, TraceWriter, ensureRunsDir, resolveRunSelector } from '@orcareplay/core';
+import { createProxy, type RecordedExchange, type RunCa } from '@orcareplay/proxy';
+import { defaultAdapters } from '@orcareplay/adapters';
+import type { ParsedArgs } from '../args.js';
+import type { Output } from '../out.js';
+import { advertisedUrl, attachInstructions } from '../attach.js';
+import { ExchangeEventDeriver, appendDerivedEvents } from '../exchange-events.js';
+import { SerialQueue } from '../serial.js';
+import { recordedTlsHosts, setupTlsCapture } from '../tls-capture.js';
+import { loadExchanges } from './replay.js';
+import { upstreamPlan } from '../upstream.js';
+import { ORCA_VERSION } from '../version.js';
+
+/**
+ * `orca attach` — record an agent this machine did not start.
+ *
+ * Everything else here launches the agent: an adapter builds an environment, orca spawns the
+ * process, and capture follows from that. It is a good design with one boundary it cannot cross —
+ * an agent that is not on this machine. A bot on a VPS, an agent inside a dev container or a cloud
+ * sandbox, a harness in someone else's CI: there is no process to spawn, so there is no
+ * environment to build and no way to say `orca record` at all.
+ *
+ * So this inverts it. Orca holds the proxy open, prints exactly what to export on the far side,
+ * and records whatever arrives until it is stopped. The recording that comes out is not a lesser
+ * one: same matcher, same events, same `orca replay`.
+ *
+ * The adapters are still what produce the variables — `--for claude` prints what the Claude Code
+ * adapter would have set, pointed at the advertised address instead of a loopback one. That keeps
+ * one source of truth for "which variable does this harness read", so a sandbox recording cannot
+ * drift from a local one.
+ */
+
+export interface AttachResult {
+  runId: string;
+  runDir: string;
+  modelExchanges: number;
+  events: number;
+  proxyUrl: string;
+  /** Replay sessions only: recorded exchanges served back, and requests nothing matched. */
+  reused: number;
+  unmatched: number;
+}
+
+export interface AttachOptions {
+  /**
+   * Resolves when the session should stop. Defaults to SIGINT — the operator pressing ctrl-C,
+   * which is how a session with no child process to wait on ends.
+   */
+  until?: Promise<void>;
+  /** Called once the proxy is listening, with the address a remote agent should use. */
+  onReady?: (info: { proxyUrl: string; runId: string }) => void;
+}
+
+export async function attachCommand(
+  args: ParsedArgs,
+  out: Output,
+  cwd = process.cwd(),
+  options: AttachOptions = {},
+): Promise<AttachResult> {
+  const minted: RunCa[] = [];
+  try {
+    return await runAttached(args, out, cwd, options, minted);
+  } catch (err) {
+    for (const ca of minted) await ca.dispose().catch(() => undefined);
+    throw err;
+  }
+}
+
+async function runAttached(
+  args: ParsedArgs,
+  out: Output,
+  cwd: string,
+  options: AttachOptions,
+  minted: RunCa[],
+): Promise<AttachResult> {
+  const registry = defaultAdapters();
+  const bind = args.str('bind') ?? '127.0.0.1';
+  const advertise = args.str('advertise');
+  const requestedPort = args.num('port') ?? 0;
+
+  // Resolved before the run directory is made, so an invocation that cannot work — a wildcard bind
+  // with nothing to advertise — leaves nothing behind to clean up.
+  if (requestedPort === 0) {
+    advertisedUrl({ bind, port: 1, ...(advertise === undefined ? {} : { advertise }) });
+  }
+
+  /**
+   * Serving a recording back instead of recording a new one.
+   *
+   * `orca replay` launches the agent, which is right for a run orca recorded by launching it and
+   * impossible for one that came from a sandbox — the agent may not exist on this machine at all.
+   * So replay attaches too: same proxy, same matcher, same blocked egress, and the operator points
+   * the same remote agent at it.
+   */
+  const replaySelector = args.str('replay');
+  const replaying = replaySelector
+    ? await (async () => {
+        const runDir = (await resolveRunSelector(cwd, replaySelector)).dir;
+        const reader = await TraceReader.open(runDir);
+        return {
+          exchanges: await loadExchanges(reader),
+          hosts: recordedTlsHosts(await reader.events()),
+          // Which harness made the recording. It will be the one connecting again, so it is the
+          // right default for the block the operator pastes.
+          adapter: reader.manifest().adapter?.id,
+        };
+      })()
+    : undefined;
+
+  /**
+   * `exec` is the honest default for a fresh session: orca does not know what will connect, and
+   * detecting an agent from this directory would be a guess about a machine it cannot see. For a
+   * replay it is the wrong default and a useless one — `exec` sets no variables, so the block the
+   * operator is meant to paste comes out empty. The recording names the harness, so use it.
+   */
+  const adapterName = args.str('for') ?? replaying?.adapter ?? 'exec';
+  const adapter = registry.get(adapterName);
+
+  const dir = await ensureRunsDir(cwd);
+  const writer = await TraceWriter.create(dir, {
+    adapter: { id: adapter.id, version: ORCA_VERSION, harness_version: adapter.harnessVersions },
+    argv: [adapterName],
+    cwd,
+    orcaVersion: ORCA_VERSION,
+  });
+
+  const writes = new SerialQueue();
+  const plan = await upstreamPlan(args);
+  const tls = await setupTlsCapture({
+    args,
+    out,
+    ...(replaying ? { recordedHosts: replaying.hosts } : {}),
+    writer,
+    writes,
+    turn: () => 0,
+  });
+  if (tls.ca) minted.push(tls.ca);
+
+  let modelExchanges = 0;
+  let turn = 0;
+  let unmatched = 0;
+  // Read before the proxy closes: `stats()` is a snapshot of a live object, and the teardown in
+  // `finally` is the last moment it is still meaningful.
+  let stats = {
+    matchedExact: 0,
+    matchedInexact: 0,
+    unmatched: 0,
+  } as ReturnType<Awaited<ReturnType<typeof createProxy>>['stats']>;
+  const deriver = new ExchangeEventDeriver();
+  const proxy = await createProxy({
+    // A replay session serves the recording and blocks egress, exactly as `orca replay` does. The
+    // only difference is which side starts the agent, and that is not a difference the proxy has.
+    mode: replaying ? 'replay' : 'record',
+    ...(replaying ? { exchanges: replaying.exchanges, loose: args.bool('loose') } : {}),
+    host: bind,
+    port: requestedPort,
+    upstream: plan.upstream,
+    upstreamHeaders: plan.headers,
+    ...tls.proxyOptions,
+    onUnmatched: () => {
+      unmatched += 1;
+    },
+    onExchange: (exchange: RecordedExchange) => {
+      modelExchanges += 1;
+      turn += 1;
+      const at = turn;
+      writes.push(() => appendDerivedEvents(writer, deriver, exchange, at));
+    },
+  });
+
+  try {
+    const proxyUrl = advertisedUrl({
+      bind,
+      port: proxy.port,
+      ...(advertise === undefined ? {} : { advertise }),
+    });
+
+    // What the adapter would have put into a child's environment, pointed at the reachable
+    // address rather than a loopback one. `runDir` is this machine's, and is only ever used by
+    // adapters that write a scratch file — none of which a remote agent would read, which is why
+    // `--for` is documented as the variables rather than as full instrumentation.
+    const launch = await adapter.prepare({
+      runId: writer.runId,
+      cwd,
+      runDir: writer.runDir,
+      proxyUrl,
+      userArgs: ['<your agent>'],
+      env: process.env,
+    });
+
+    const remoteCaPath = args.str('remote-ca-path') ?? '/tmp/orca-ca.crt';
+    const instructions = attachInstructions({
+      proxyUrl,
+      adapterEnv: launch.env,
+      ...(proxy.tls
+        ? {
+            ca: { certPath: proxy.tls.caCertPath, bundlePath: proxy.tls.caBundlePath },
+            remoteCaPath,
+          }
+        : {}),
+    });
+
+    out.phase('attached', {
+      run: writer.runId,
+      proxy: proxyUrl,
+      for: adapter.id,
+      ...(replaying
+        ? { serving: replaySelector, exchanges: replaying.exchanges.length, egress: 'blocked' }
+        : {}),
+    });
+    if (proxy.tls) {
+      out.warn('tls.intercepting', {
+        hosts: proxy.tls.hosts,
+        ca_sha256: proxy.tls.fingerprint,
+      });
+      await writer.append({
+        type: 'note',
+        actor: 'orca',
+        turn: 0,
+        attrs: {
+          rule: 'tls_intercept',
+          hosts: proxy.tls.hosts,
+          ca_sha256: proxy.tls.fingerprint,
+        },
+      });
+    }
+    out.plain('');
+    for (const line of instructions) out.plain(`  ${line}`);
+    out.plain('');
+    out.plain(
+      replaying
+        ? '  Serving the recording. Press ctrl-C when the agent is done.'
+        : '  Recording. Press ctrl-C when the agent is done.',
+    );
+
+    options.onReady?.({ proxyUrl, runId: writer.runId });
+    await (options.until ?? firstInterrupt());
+  } finally {
+    stats = proxy.stats();
+    await writes.drain();
+    // The proxy closes after the writes drain, for the same reason recording does: a tunnel record
+    // arriving after the writer shut would have nowhere to go.
+    await proxy.close();
+    await tls.ca?.dispose();
+  }
+
+  /**
+   * The same warning a launched run gets, and it matters more here. A remote agent that was never
+   * given the block — or was given it in a shell that had already started the agent — produces a
+   * session that ends cleanly and records nothing, and there is no exit code to hint at it.
+   */
+  if (modelExchanges === 0 && !replaying) {
+    out.warn('capture.empty', {
+      exchanges: 0,
+      cause: 'nothing connected to the proxy while the session was open',
+      next: 'check the sandbox can reach the advertised address, and that the exports were set',
+    });
+  }
+
+  const manifest = await writer.close(0);
+  // A replay session did not record a run, and saying it did would send someone looking for turns
+  // in a trace that holds none. It reports what it actually did: how much of the recording the
+  // agent asked for, and what it asked for that the recording could not answer.
+  if (replaying) {
+    out.info('served', {
+      serving: replaySelector,
+      reused: `${stats.matchedExact + stats.matchedInexact}/${replaying.exchanges.length}`,
+      unmatched: stats.unmatched,
+    });
+  } else {
+    out.info('recorded', {
+      run: writer.runId,
+      events: manifest.counts?.events ?? 0,
+      exchanges: modelExchanges,
+      dir: writer.runDir,
+    });
+  }
+
+  return {
+    runId: writer.runId,
+    runDir: writer.runDir,
+    modelExchanges,
+    events: manifest.counts?.events ?? 0,
+    proxyUrl: proxy.url,
+    // Exact plus inexact: both were served from the recording, which is what "reused" means here.
+    // The distinction between them is a divergence, and divergences are reported on their own.
+    reused: replaying ? stats.matchedExact + stats.matchedInexact : 0,
+    unmatched: replaying ? stats.unmatched : unmatched,
+  };
+}
+
+/** Ctrl-C, which is the only way an operator ends a session with no child process to wait on. */
+async function firstInterrupt(): Promise<void> {
+  await once(process, 'SIGINT');
+}

--- a/packages/cli/src/commands/replay.ts
+++ b/packages/cli/src/commands/replay.ts
@@ -308,12 +308,13 @@ async function replayExact(args: ParsedArgs, out: Output, ctx: Ctx): Promise<Rep
   // A subscription-backed harness does not use the ordinary base URL, so exact replay needs the
   // same per-run CA and HTTPS proxy as recording. The proxy's TLS hook then answers Codex's model
   // request from the trace before it can open an origin connection.
+  // A run recorded through interception is reproduced through it, without the operator having to
+  // remember which hosts they named. See `setupTlsCapture`.
+  const interceptedHosts = recordedTlsHosts(ctx.events);
   const tls = await setupTlsCapture({
     args,
     out,
-    // A run recorded through interception is reproduced through it, without the operator having to
-    // remember which hosts they named. See `setupTlsCapture`.
-    ...(recordedTlsHosts(ctx.events) ? { recordedHosts: recordedTlsHosts(ctx.events)! } : {}),
+    ...(interceptedHosts ? { recordedHosts: interceptedHosts } : {}),
     writer: trace,
     runDir: ctx.runDir,
     writes,
@@ -667,12 +668,13 @@ async function replayFork(
   // harness that talks to its own backend over TLS reads no base-URL variable and is invisible
   // without interception. The flag was parsed here and silently discarded, which is the worse
   // half — the operator believes they captured that traffic.
+  // Same for a fork: it continues a recorded conversation, so its prefix is replayed and the
+  // requests carrying it arrive by the same intercepted transport they were recorded on.
+  const forkInterceptedHosts = recordedTlsHosts(ctx.events);
   const tls = await setupTlsCapture({
     args,
     out,
-    // Same for a fork: it continues a recorded conversation, so its prefix is replayed and the
-    // requests carrying it arrive by the same intercepted transport they were recorded on.
-    ...(recordedTlsHosts(ctx.events) ? { recordedHosts: recordedTlsHosts(ctx.events)! } : {}),
+    ...(forkInterceptedHosts ? { recordedHosts: forkInterceptedHosts } : {}),
     writer,
     writes,
     turn: () => turn,

--- a/packages/cli/src/commands/replay.ts
+++ b/packages/cli/src/commands/replay.ts
@@ -22,7 +22,7 @@ import type { ParsedArgs } from '../args.js';
 import { SerialQueue } from '../serial.js';
 import { appendSnapshot } from '../fs-events.js';
 import { drainMcpFrames, mcpForReplay, pointAtMcpConfig } from '../mcp.js';
-import { setupTlsCapture, trustRunCa } from '../tls-capture.js';
+import { recordedTlsHosts, setupTlsCapture, trustRunCa } from '../tls-capture.js';
 import { upstreamPlan } from '../upstream.js';
 import { ORCA_VERSION } from '../version.js';
 
@@ -311,6 +311,9 @@ async function replayExact(args: ParsedArgs, out: Output, ctx: Ctx): Promise<Rep
   const tls = await setupTlsCapture({
     args,
     out,
+    // A run recorded through interception is reproduced through it, without the operator having to
+    // remember which hosts they named. See `setupTlsCapture`.
+    ...(recordedTlsHosts(ctx.events) ? { recordedHosts: recordedTlsHosts(ctx.events)! } : {}),
     writer: trace,
     runDir: ctx.runDir,
     writes,
@@ -664,7 +667,16 @@ async function replayFork(
   // harness that talks to its own backend over TLS reads no base-URL variable and is invisible
   // without interception. The flag was parsed here and silently discarded, which is the worse
   // half — the operator believes they captured that traffic.
-  const tls = await setupTlsCapture({ args, out, writer, writes, turn: () => turn });
+  const tls = await setupTlsCapture({
+    args,
+    out,
+    // Same for a fork: it continues a recorded conversation, so its prefix is replayed and the
+    // requests carrying it arrive by the same intercepted transport they were recorded on.
+    ...(recordedTlsHosts(ctx.events) ? { recordedHosts: recordedTlsHosts(ctx.events)! } : {}),
+    writer,
+    writes,
+    turn: () => turn,
+  });
 
   // A fork continues the run live past the checkpoint, so its MCP traffic is new and belongs in the
   // fork's own trace. Without this the layer simply stopped at the fork point.

--- a/packages/cli/src/flags.ts
+++ b/packages/cli/src/flags.ts
@@ -22,6 +22,17 @@ const TLS = ['tls-intercept', 'tls-hosts'] as const;
 
 export const BY_COMMAND: Record<string, readonly string[]> = {
   record: ['fs', 'shell', 'mcp-config', ...TLS, ...UPSTREAM],
+  attach: [
+    'for',
+    'bind',
+    'advertise',
+    'port',
+    'remote-ca-path',
+    'replay',
+    'loose',
+    ...TLS,
+    ...UPSTREAM,
+  ],
   replay: [
     'from',
     'model',

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -82,6 +82,8 @@ reaches an agent orca did not launch — record the editor, and the agent it spa
 capture.
 
   --tls-intercept              decrypt HTTPS for the hosts below, for this run only
+                               replay and fork turn this back on by themselves, using the
+                               hosts the recording names; --no-tls-intercept refuses
   --tls-hosts a,b,c            decrypt exactly these, replacing the default list
   --tls-hosts +a,+b            decrypt these *as well as* the default model API hosts
                                everything else is tunnelled unread; "*" is refused

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -71,10 +71,19 @@ Flags
   --port <n>     port for --ui and orca ui (default: any free port)
 
 A harness that reads no base-URL variable cannot be captured that way at all — a Codex CLI signed
-in with a ChatGPT subscription is the case. For that, and only for that:
+in with a ChatGPT subscription, a bot with its origin hardcoded, an agent in a language the fetch
+hook cannot reach. Capture those below the agent instead, at the socket:
+
+  orca record exec --tls-intercept -- <command> [args...]
+
+exec (or "any") launches your command and redirects nothing: no origin and no credential are
+invented, so an agent recorded this way still talks to whoever it was already talking to. It also
+reaches an agent orca did not launch — record the editor, and the agent it spawns inherits the
+capture.
 
   --tls-intercept              decrypt HTTPS for the hosts below, for this run only
-  --tls-hosts a,b,c            which hosts to decrypt (default: model API hosts)
+  --tls-hosts a,b,c            decrypt exactly these, replacing the default list
+  --tls-hosts +a,+b            decrypt these *as well as* the default model API hosts
                                everything else is tunnelled unread; "*" is refused
 
   It mints a certificate authority in the run directory, trusts it to the agent through that

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -159,10 +159,7 @@ export async function main(argv: string[], cwd = process.cwd()): Promise<number>
       case 'record':
         return (await recordCommand(args, out, cwd)).exitCode;
       case 'attach':
-        // Always 0: the session ended because the operator stopped it, which is not a failure.
-        // Whether anything was captured is reported by `capture.empty`, not by an exit code.
-        await attachCommand(args, out, cwd);
-        return 0;
+        return (await attachCommand(args, out, cwd)).exitCode;
       case 'replay':
         return (await replayCommand(args, out, cwd)).exitCode;
       case 'compare':
@@ -276,7 +273,7 @@ async function jsonMain(args: ParsedArgs, cwd: string): Promise<number> {
       case 'attach': {
         const result = await attachCommand(args, out, cwd);
         emit(result);
-        return 0;
+        return result.exitCode;
       }
       case 'record': {
         const result = await recordCommand(args, out, cwd);

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -3,6 +3,7 @@ import { parseArgs, type ParsedArgs } from './args.js';
 import { Orca } from './api.js';
 import { serveMcp } from './mcp-server.js';
 import { Output } from './out.js';
+import { attachCommand } from './commands/attach.js';
 import { recordCommand } from './commands/record.js';
 import { replayCommand } from './commands/replay.js';
 import {
@@ -23,6 +24,14 @@ import { ORCA_VERSION } from './version.js';
 const HELP = `orca ${ORCA_VERSION} — record, replay and fork debugger for AI agents
 
   orca record <agent>            run an agent and capture everything
+  orca attach                    record an agent orca does not launch — one in a sandbox,
+                                 a container, or on another machine
+        --for <agent>            print the variables that agent reads (default: exec)
+        --bind <addr>            address to listen on (default: 127.0.0.1)
+        --advertise <host>       how the sandbox reaches this machine, when they differ
+        --remote-ca-path <p>     where the CA will live over there (default: /tmp/orca-ca.crt)
+        --replay <run>           serve a recording back to that agent instead of recording,
+                                 for a run whose agent is not on this machine
   orca replay [run]              reproduce a run exactly, network off
         --ui                     open the timeline when it finishes
   orca replay [run] --from N     fork from a checkpoint and continue live
@@ -149,6 +158,11 @@ export async function main(argv: string[], cwd = process.cwd()): Promise<number>
     switch (args.command) {
       case 'record':
         return (await recordCommand(args, out, cwd)).exitCode;
+      case 'attach':
+        // Always 0: the session ended because the operator stopped it, which is not a failure.
+        // Whether anything was captured is reported by `capture.empty`, not by an exit code.
+        await attachCommand(args, out, cwd);
+        return 0;
       case 'replay':
         return (await replayCommand(args, out, cwd)).exitCode;
       case 'compare':
@@ -259,6 +273,11 @@ async function jsonMain(args: ParsedArgs, cwd: string): Promise<number> {
           }),
         );
         return 0;
+      case 'attach': {
+        const result = await attachCommand(args, out, cwd);
+        emit(result);
+        return 0;
+      }
       case 'record': {
         const result = await recordCommand(args, out, cwd);
         emit(result);

--- a/packages/cli/src/tls-capture.ts
+++ b/packages/cli/src/tls-capture.ts
@@ -103,6 +103,10 @@ export async function setupTlsCapture(req: TlsCaptureRequest): Promise<TlsCaptur
   if (!runDir) throw new Error('TLS interception needs a run directory');
   const ca = await RunCa.create({ runDir });
 
+  // One line per path, not per call: an agent that posts to the same endpoint every turn would
+  // otherwise bury the run in a warning the operator already read.
+  const reported = new Set<string>();
+
   return {
     ca,
     proxyOptions: {
@@ -110,13 +114,10 @@ export async function setupTlsCapture(req: TlsCaptureRequest): Promise<TlsCaptur
         ca,
         hosts: [...hosts],
         trustedOriginCerts,
-        ...(writer
-          ? {
-              onNetExchange: (exchange: NetExchange) => {
-                writes.push(() => persistNetExchange(writer, req.turn(), exchange));
-              },
-            }
-          : {}),
+        onNetExchange: (exchange: NetExchange) => {
+          warnUnclaimed(out, reported, exchange);
+          if (writer) writes.push(() => persistNetExchange(writer, req.turn(), exchange));
+        },
         onTunnel: (tunnel: TunnelRecord) => {
           if (writer) writes.push(() => persistTunnel(writer, req.turn(), tunnel));
         },
@@ -124,6 +125,44 @@ export async function setupTlsCapture(req: TlsCaptureRequest): Promise<TlsCaptur
       },
     },
   };
+}
+
+/**
+ * An intercepted call that looked like a model request and was not understood.
+ *
+ * Traffic on a path no dialect claims is recorded as `net.*`: orca holds the bytes but not their
+ * meaning, so it can neither match the request on replay nor rewrite its model on a fork. Strict
+ * replay says so plainly — and says it one command too late, after the agent has finished and the
+ * chance to record the run properly has gone. This is the same fact, delivered while it is still
+ * actionable.
+ *
+ * Deliberately narrow. A GET, or a POST whose body is not JSON, is ordinary traffic that was never
+ * a model call, and warning about it would teach the operator to ignore the warning that matters.
+ */
+function warnUnclaimed(out: Output, reported: Set<string>, exchange: NetExchange): void {
+  if (exchange.method !== 'POST') return;
+  const body = exchange.requestBody.trim();
+  if (!body.startsWith('{')) return;
+  try {
+    const parsed: unknown = JSON.parse(body);
+    if (typeof parsed !== 'object' || parsed === null) return;
+  } catch {
+    // A body orca could not even parse is not a model call it failed to recognise.
+    return;
+  }
+
+  const path = exchange.path.split('?')[0] ?? exchange.path;
+  const key = `${exchange.host}:${exchange.port}${path}`;
+  if (reported.has(key)) return;
+  reported.add(key);
+
+  out.warn('tls.unclaimed_path', {
+    host: exchange.host,
+    path: exchange.path,
+    detail: 'decrypted and recorded, but no wire dialect claims this path',
+    consequence: 'it replays as opaque network traffic and cannot be forked to another model',
+    next: 'docs/plugins.md to add a dialect for it',
+  });
 }
 
 /**

--- a/packages/cli/src/tls-capture.ts
+++ b/packages/cli/src/tls-capture.ts
@@ -57,31 +57,45 @@ export interface TlsCapture {
   proxyOptions: Record<string, unknown>;
 }
 
+/**
+ * Everything `setupTlsCapture` can refuse, without creating anything.
+ *
+ * A caller that has a trace directory to lose needs the refusal to happen first: a run abandoned
+ * by a throw leaves an unsealed directory behind, and an unsealed directory wins `last`.
+ */
+export function planTlsCapture(args: ParsedArgs, recordedHosts?: readonly string[]): void {
+  if (!interceptionRequested(args, recordedHosts)) return;
+  HostPolicy.from([...resolveTlsHosts(args.list('tls-hosts'), recordedHosts)]);
+}
+
+/**
+ * Is this run intercepting?
+ *
+ * A run recorded through interception has to be replayed through it. The agent this exists for
+ * talks to its own backend over TLS it establishes itself, so without interception the replay
+ * proxy never sees the request at all: it tunnels the CONNECT to an origin that is offline or,
+ * worse, live. That failed as `reused=0/n` — which reads as a broken recording rather than as a
+ * missing flag, and the flag is one nobody thinks to repeat when the command they type is
+ * `orca replay last`.
+ *
+ * So the recording decides. It already knows: every intercepted run writes a `tls_intercept` note
+ * naming the hosts it decrypted. Nothing is inferred and nothing is widened — an operator who
+ * never turned interception on gets a replay that never turns it on either, and
+ * `--no-tls-intercept` refuses outright.
+ */
+function interceptionRequested(args: ParsedArgs, recordedHosts?: readonly string[]): boolean {
+  const askedFor = args.bool('tls-intercept');
+  // `--no-tls-intercept` is the only way to tell "left unset" apart from "explicitly refused", and
+  // the difference matters: absence means orca may decide, refusal means it may not.
+  const refused = args.has('tls-intercept') && !askedFor;
+  return askedFor || (!refused && recordedHosts !== undefined);
+}
+
 export async function setupTlsCapture(req: TlsCaptureRequest): Promise<TlsCapture> {
   const { args, out, writer, writes, recordedHosts } = req;
 
-  const askedFor = args.bool('tls-intercept');
-  // `--no-tls-intercept` is the only way to tell "left unset" apart from "explicitly refused", and
-  // the difference matters below: absence means orca may decide, refusal means it may not.
-  const refused = args.has('tls-intercept') && !askedFor;
   const tlsHosts = args.list('tls-hosts');
-
-  /**
-   * A run that was recorded through interception has to be replayed through it.
-   *
-   * The agent this exists for talks to its own backend over TLS it establishes itself, so without
-   * interception the replay proxy never sees the request at all: it tunnels the CONNECT to an
-   * origin that is offline or, worse, live. That failed as `reused=0/n` — which reads as a broken
-   * recording rather than as a missing flag, and the flag is one nobody thinks to repeat when the
-   * command they type is `orca replay last`.
-   *
-   * So the recording decides. It already knows: every intercepted run writes a `tls_intercept`
-   * note naming the hosts it decrypted, and that list is exactly the one the replay needs. Nothing
-   * is inferred and nothing is widened — an operator who never turned interception on gets a
-   * replay that never turns it on either.
-   */
-  const inherited = !askedFor && !refused && recordedHosts !== undefined;
-  const interceptTls = askedFor || inherited;
+  const interceptTls = interceptionRequested(args, recordedHosts);
 
   // Naming hosts without asking for interception captures nothing and says nothing, which reads
   // as "orca ignored my traffic" rather than as "orca ignored my flag".
@@ -90,13 +104,9 @@ export async function setupTlsCapture(req: TlsCaptureRequest): Promise<TlsCaptur
   }
   if (!interceptTls) return { proxyOptions: {} };
 
-  // An explicit list always wins, so a replay can be narrowed or widened by hand. Falling back to
-  // the recorded list rather than to the defaults keeps the reproduction faithful: replaying with
-  // a *different* policy than the recording used is how a run stops reproducing itself.
   // Resolved before anything is minted, so a contradictory list — one that both replaces the
   // defaults and adds to them — fails while the run directory still holds no private key.
-  const hosts =
-    tlsHosts.length > 0 ? resolveTlsHosts(tlsHosts) : (recordedHosts ?? resolveTlsHosts([]));
+  const hosts = resolveTlsHosts(tlsHosts, recordedHosts);
   HostPolicy.from([...hosts]);
   const trustedOriginCerts = await extraOriginRoots();
   const runDir = writer?.runDir ?? req.runDir;
@@ -143,12 +153,17 @@ function warnUnclaimed(out: Output, reported: Set<string>, exchange: NetExchange
   if (exchange.method !== 'POST') return;
   const body = exchange.requestBody.trim();
   if (!body.startsWith('{')) return;
-  try {
-    const parsed: unknown = JSON.parse(body);
-    if (typeof parsed !== 'object' || parsed === null) return;
-  } catch {
-    // A body orca could not even parse is not a model call it failed to recognise.
-    return;
+  // A truncated body cannot parse — it was cut mid-JSON at the capture limit. Requiring a parse
+  // would suppress the warning for exactly the requests it exists for, since a long conversation
+  // is the one most likely to exceed the limit and the most expensive to have to record again.
+  if (!exchange.requestTruncated) {
+    try {
+      const parsed: unknown = JSON.parse(body);
+      if (typeof parsed !== 'object' || parsed === null) return;
+    } catch {
+      // A body orca could not even parse is not a model call it failed to recognise.
+      return;
+    }
   }
 
   const path = exchange.path.split('?')[0] ?? exchange.path;

--- a/packages/cli/src/tls-capture.ts
+++ b/packages/cli/src/tls-capture.ts
@@ -1,6 +1,7 @@
 import { readFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import type { TraceWriter } from '@orcareplay/core';
+import type { TraceEvent } from '@orcareplay/schema';
 import {
   HostPolicy,
   RunCa,
@@ -31,6 +32,12 @@ import type { SerialQueue } from './serial.js';
 export interface TlsCaptureRequest {
   args: ParsedArgs;
   out: Output;
+  /**
+   * Hosts the run being reproduced decrypted, recovered from its own trace.
+   *
+   * Present for replay and fork, absent for a fresh recording. See `recordedTlsHosts`.
+   */
+  recordedHosts?: readonly string[];
   writer?: TraceWriter;
   /** Used by an exact replay running with --no-trace, where there is no writer to own the CA. */
   runDir?: string;
@@ -51,10 +58,31 @@ export interface TlsCapture {
 }
 
 export async function setupTlsCapture(req: TlsCaptureRequest): Promise<TlsCapture> {
-  const { args, out, writer, writes } = req;
+  const { args, out, writer, writes, recordedHosts } = req;
 
-  const interceptTls = args.bool('tls-intercept');
+  const askedFor = args.bool('tls-intercept');
+  // `--no-tls-intercept` is the only way to tell "left unset" apart from "explicitly refused", and
+  // the difference matters below: absence means orca may decide, refusal means it may not.
+  const refused = args.has('tls-intercept') && !askedFor;
   const tlsHosts = args.list('tls-hosts');
+
+  /**
+   * A run that was recorded through interception has to be replayed through it.
+   *
+   * The agent this exists for talks to its own backend over TLS it establishes itself, so without
+   * interception the replay proxy never sees the request at all: it tunnels the CONNECT to an
+   * origin that is offline or, worse, live. That failed as `reused=0/n` — which reads as a broken
+   * recording rather than as a missing flag, and the flag is one nobody thinks to repeat when the
+   * command they type is `orca replay last`.
+   *
+   * So the recording decides. It already knows: every intercepted run writes a `tls_intercept`
+   * note naming the hosts it decrypted, and that list is exactly the one the replay needs. Nothing
+   * is inferred and nothing is widened — an operator who never turned interception on gets a
+   * replay that never turns it on either.
+   */
+  const inherited = !askedFor && !refused && recordedHosts !== undefined;
+  const interceptTls = askedFor || inherited;
+
   // Naming hosts without asking for interception captures nothing and says nothing, which reads
   // as "orca ignored my traffic" rather than as "orca ignored my flag".
   if (!interceptTls && tlsHosts.length > 0) {
@@ -62,10 +90,14 @@ export async function setupTlsCapture(req: TlsCaptureRequest): Promise<TlsCaptur
   }
   if (!interceptTls) return { proxyOptions: {} };
 
+  // An explicit list always wins, so a replay can be narrowed or widened by hand. Falling back to
+  // the recorded list rather than to the defaults keeps the reproduction faithful: replaying with
+  // a *different* policy than the recording used is how a run stops reproducing itself.
   // Resolved before anything is minted, so a contradictory list — one that both replaces the
   // defaults and adds to them — fails while the run directory still holds no private key.
-  const hosts = resolveTlsHosts(tlsHosts);
-  HostPolicy.from(hosts);
+  const hosts =
+    tlsHosts.length > 0 ? resolveTlsHosts(tlsHosts) : (recordedHosts ?? resolveTlsHosts([]));
+  HostPolicy.from([...hosts]);
   const trustedOriginCerts = await extraOriginRoots();
   const runDir = writer?.runDir ?? req.runDir;
   if (!runDir) throw new Error('TLS interception needs a run directory');
@@ -76,7 +108,7 @@ export async function setupTlsCapture(req: TlsCaptureRequest): Promise<TlsCaptur
     proxyOptions: {
       tls: {
         ca,
-        hosts,
+        hosts: [...hosts],
         trustedOriginCerts,
         ...(writer
           ? {
@@ -92,6 +124,28 @@ export async function setupTlsCapture(req: TlsCaptureRequest): Promise<TlsCaptur
       },
     },
   };
+}
+
+/**
+ * The hosts a recorded run decrypted, read back out of its own trace.
+ *
+ * `trustRunCa` writes this note on every intercepted run — a digest and a host list, never the
+ * certificate and never the key — so the trace is self-describing about the one thing a faithful
+ * replay cannot guess. Returns undefined for a run recorded without interception, which is the
+ * signal that the replay must not turn it on either.
+ */
+export function recordedTlsHosts(events: readonly TraceEvent[]): readonly string[] | undefined {
+  for (const event of events) {
+    if (event.type !== 'note' || event.attrs?.['rule'] !== 'tls_intercept') continue;
+    const hosts = event.attrs['hosts'];
+    if (typeof hosts !== 'string') continue;
+    const parsed = hosts
+      .split(',')
+      .map((h) => h.trim())
+      .filter((h) => h !== '');
+    if (parsed.length > 0) return parsed;
+  }
+  return undefined;
 }
 
 /**

--- a/packages/cli/src/tls-capture.ts
+++ b/packages/cli/src/tls-capture.ts
@@ -2,10 +2,10 @@ import { readFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import type { TraceWriter } from '@orcareplay/core';
 import {
-  DEFAULT_TLS_HOSTS,
   HostPolicy,
   RunCa,
   type InterceptFailure,
+  resolveTlsHosts,
   type NetExchange,
   type TlsInterceptInfo,
   type TunnelRecord,
@@ -62,7 +62,9 @@ export async function setupTlsCapture(req: TlsCaptureRequest): Promise<TlsCaptur
   }
   if (!interceptTls) return { proxyOptions: {} };
 
-  const hosts = tlsHosts.length > 0 ? tlsHosts : DEFAULT_TLS_HOSTS;
+  // Resolved before anything is minted, so a contradictory list — one that both replaces the
+  // defaults and adds to them — fails while the run directory still holds no private key.
+  const hosts = resolveTlsHosts(tlsHosts);
   HostPolicy.from(hosts);
   const trustedOriginCerts = await extraOriginRoots();
   const runDir = writer?.runDir ?? req.runDir;

--- a/packages/cli/test/attach-command.test.ts
+++ b/packages/cli/test/attach-command.test.ts
@@ -1,0 +1,213 @@
+import { execFile } from 'node:child_process';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { TraceReader } from '@orcareplay/core';
+import { parseArgs } from '../src/args.js';
+import { Output } from '../src/out.js';
+import { attachCommand } from '../src/commands/attach.js';
+import { replayCommand } from '../src/commands/replay.js';
+import { startFakeModel } from './fixtures/fake-model.mjs';
+
+const run = promisify(execFile);
+
+/**
+ * `orca attach` — a recording session for an agent orca did not start.
+ *
+ * The command holds a proxy open, prints what to export, and records whatever arrives until it is
+ * told to stop. That makes it the answer for an agent in a sandbox, on a VPS, or in someone's CI:
+ * places where there is no process for orca to spawn and therefore no environment for it to build.
+ *
+ * These tests stand in for the sandbox with an ordinary `fetch` from this process. The distance
+ * does not change anything that could break — what matters is that the run is driven entirely from
+ * the outside, and that the trace it leaves behind replays like any other.
+ */
+describe('orca attach', () => {
+  let workspace: string;
+  let out: Output;
+  let lines: string[];
+  let model: Awaited<ReturnType<typeof startFakeModel>>;
+
+  beforeEach(async () => {
+    workspace = await mkdtemp(join(tmpdir(), 'orca-attach-'));
+    model = await startFakeModel();
+    lines = [];
+    out = new Output({ write: (s) => void lines.push(s), isTTY: false });
+    await run('git', ['init', '-q'], { cwd: workspace });
+    await run('git', ['config', 'user.email', 'test@example.com'], { cwd: workspace });
+    await run('git', ['config', 'user.name', 'Test'], { cwd: workspace });
+  });
+  afterEach(async () => {
+    await model.close();
+    await rm(workspace, { recursive: true, force: true });
+  });
+
+  /** Runs an attach session, handing the caller the live proxy url to drive it with. */
+  function session(
+    argv: string[],
+    drive: (proxyUrl: string) => Promise<void>,
+  ): ReturnType<typeof attachCommand> {
+    let release: () => void = () => {};
+    const until = new Promise<void>((resolve) => (release = resolve));
+    return attachCommand(
+      parseArgs(['attach', '--upstream-anthropic', model.url, ...argv]),
+      out,
+      workspace,
+      {
+        until,
+        onReady: (info) => {
+          void drive(info.proxyUrl).finally(release);
+        },
+      },
+    );
+  }
+
+  it('prints the block to paste, pointed at the address it is reachable on', async () => {
+    await session(['--for', 'claude'], async () => {});
+    const printed = lines.join('');
+    expect(printed).toContain('export ANTHROPIC_BASE_URL=');
+    expect(printed).toMatch(/http:\/\/127\.0\.0\.1:\d+/);
+  });
+
+  it('refuses a wildcard bind with no advertised host, rather than printing an unusable url', async () => {
+    await expect(session(['--bind', '0.0.0.0'], async () => {})).rejects.toThrow(/--advertise/);
+  });
+
+  it('advertises the host the operator names, not the one it bound', async () => {
+    await session(
+      ['--for', 'claude', '--bind', '0.0.0.0', '--advertise', 'host.docker.internal'],
+      async () => {},
+    );
+    expect(lines.join('')).toContain('http://host.docker.internal:');
+  });
+
+  it('records what an agent it never launched sends, and writes a trace', async () => {
+    const result = await session(['--for', 'claude'], async (proxyUrl) => {
+      await fetch(`${proxyUrl}/v1/messages`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          model: 'claude-opus-5',
+          messages: [{ role: 'user', content: 'hello from the sandbox' }],
+        }),
+      });
+    });
+
+    expect(result.modelExchanges).toBe(1);
+    const events = await (await TraceReader.open(result.runDir)).events();
+    expect(events.filter((e) => e.type === 'model.request')).toHaveLength(1);
+  });
+
+  /**
+   * Replaying a run whose agent is somewhere else.
+   *
+   * `orca replay` launches the agent, which is the right thing for a run orca recorded by
+   * launching it — and impossible for one that came from a sandbox, where the agent may not exist
+   * on this machine at all. So replay attaches too: the proxy serves the recording, the operator
+   * points the same remote agent at it, and no model is called.
+   *
+   * Asserting on `reused` rather than on `unmatched` is deliberate. A replay nothing ever connects
+   * to reports zero unmatched requests, because zero requests arrived — an assertion that passes
+   * for a session that did nothing at all.
+   */
+  it('serves a recording back to an agent it does not launch', async () => {
+    const recorded = await session(['--for', 'claude'], async (proxyUrl) => {
+      await fetch(`${proxyUrl}/v1/messages`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          model: 'claude-opus-5',
+          messages: [{ role: 'user', content: 'hello from the sandbox' }],
+        }),
+      });
+    });
+
+    let body = '';
+    const replayed = await session(['--replay', recorded.runId], async (proxyUrl) => {
+      const res = await fetch(`${proxyUrl}/v1/messages`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          model: 'claude-opus-5',
+          messages: [{ role: 'user', content: 'hello from the sandbox' }],
+        }),
+      });
+      body = await res.text();
+    });
+
+    expect(replayed.reused).toBe(1);
+    expect(replayed.unmatched).toBe(0);
+    // A replay session reports what it served, not a recording it did not make.
+    expect(lines.join('')).toContain('info served');
+    expect(lines.join('')).toContain('reused=1/1');
+    // Served from the trace, so the model this test stood up was never called a second time.
+    expect(model.calls).toHaveLength(1);
+    expect(body).toContain('editing auth.ts');
+  });
+
+  /**
+   * A replay session has to hand the operator something to paste, and `exec` — the honest default
+   * when orca does not know what will connect — sets nothing at all. For a replay it does know:
+   * the trace records which adapter made the recording, so the variables that agent reads are the
+   * variables it will read again.
+   */
+  it('takes the agent from the recording, so the block is not empty', async () => {
+    const recorded = await session(['--for', 'claude'], async (proxyUrl) => {
+      await fetch(`${proxyUrl}/v1/messages`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          model: 'claude-opus-5',
+          messages: [{ role: 'user', content: 'x' }],
+        }),
+      });
+    });
+    lines.length = 0;
+
+    await session(['--replay', recorded.runId], async () => {});
+
+    expect(lines.join('')).toContain('export ANTHROPIC_BASE_URL=');
+  });
+
+  it('still lets --for override the agent the recording names', async () => {
+    const recorded = await session(['--for', 'claude'], async (proxyUrl) => {
+      await fetch(`${proxyUrl}/v1/messages`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          model: 'claude-opus-5',
+          messages: [{ role: 'user', content: 'x' }],
+        }),
+      });
+    });
+    lines.length = 0;
+
+    await session(['--replay', recorded.runId, '--for', 'generic-openai'], async () => {});
+
+    expect(lines.join('')).toContain('export OPENAI_BASE_URL=');
+  });
+
+  it('says the recording is being served, not recorded, so nothing looks like a fresh run', async () => {
+    const recorded = await session(['--for', 'claude'], async (proxyUrl) => {
+      await fetch(`${proxyUrl}/v1/messages`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          model: 'claude-opus-5',
+          messages: [{ role: 'user', content: 'x' }],
+        }),
+      });
+    });
+    lines.length = 0;
+    await session(['--replay', recorded.runId], async () => {});
+    expect(lines.join('')).toContain('egress=blocked');
+  });
+
+  it('says so plainly when the session ended having captured nothing', async () => {
+    const result = await session([], async () => {});
+    expect(result.modelExchanges).toBe(0);
+    expect(lines.join('')).toContain('capture.empty');
+  });
+});

--- a/packages/cli/test/attach-command.test.ts
+++ b/packages/cli/test/attach-command.test.ts
@@ -109,6 +109,47 @@ describe('orca attach', () => {
     expect(lines.join('')).toContain('attach.local_path');
   });
 
+  it('never prints the operator’s own credential', async () => {
+    const before = process.env.ANTHROPIC_API_KEY;
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-REAL-SECRET';
+    try {
+      await session(['--for', 'claude'], async () => {});
+    } finally {
+      if (before === undefined) delete process.env.ANTHROPIC_API_KEY;
+      else process.env.ANTHROPIC_API_KEY = before;
+    }
+    expect(lines.join('')).not.toContain('sk-ant-REAL-SECRET');
+  });
+
+  /**
+   * The result is what `--json` prints and what a script reads. Returning the bind address there
+   * hands a caller the exact unusable URL `advertisedUrl` throws to prevent.
+   */
+  it('reports the address the agent should use, not the one it bound', async () => {
+    const result = await session(
+      ['--for', 'claude', '--bind', '0.0.0.0', '--advertise', 'host.docker.internal'],
+      async () => {},
+    );
+    expect(result.proxyUrl).toMatch(/^http:\/\/host\.docker\.internal:\d+$/);
+  });
+
+  /**
+   * `--replay` takes a run, and the parser turns a valueless flag into `true` — so a bare
+   * `orca attach --replay`, or `--replay --tls-intercept`, silently became a fresh *recording*
+   * session pointed at the live provider. Exactly the wrong direction to fail in.
+   */
+  it('refuses --replay with no run rather than recording instead', async () => {
+    await expect(session(['--replay'], async () => {})).rejects.toThrow(/--replay/);
+  });
+
+  it('leaves no half-made run behind when the session cannot start', async () => {
+    await expect(
+      session(['--tls-intercept', '--tls-hosts', 'api.openai.com,+grok.example'], async () => {}),
+    ).rejects.toThrow(/\+/);
+    const runs = await readdir(join(workspace, '.orca', 'runs')).catch(() => []);
+    expect(runs).toEqual([]);
+  });
+
   it('advertises the host the operator names, not the one it bound', async () => {
     await session(
       ['--for', 'claude', '--bind', '0.0.0.0', '--advertise', 'host.docker.internal'],

--- a/packages/cli/test/attach-command.test.ts
+++ b/packages/cli/test/attach-command.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from 'node:child_process';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp, readdir, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
@@ -73,6 +73,40 @@ describe('orca attach', () => {
 
   it('refuses a wildcard bind with no advertised host, rather than printing an unusable url', async () => {
     await expect(session(['--bind', '0.0.0.0'], async () => {})).rejects.toThrow(/--advertise/);
+  });
+
+  /**
+   * The refusal has to happen before anything is created, not merely before anything is printed.
+   * Validating only in the default-port path meant `--port` skipped the check entirely: the run
+   * directory, the trace and (with --tls-intercept) a private key were all created for a session
+   * that was about to throw.
+   */
+  it('refuses a wildcard bind before it creates a run, whatever the port', async () => {
+    await expect(session(['--bind', '0.0.0.0', '--port', '18771'], async () => {})).rejects.toThrow(
+      /--advertise/,
+    );
+    const runs = await readdir(join(workspace, '.orca', 'runs')).catch(() => []);
+    expect(runs).toEqual([]);
+  });
+
+  /**
+   * A session nobody can connect to is the failure this command exists to prevent, and the empty
+   * block is the one form of it orca can see coming: `exec` sets no variables, so with no
+   * interception either there is literally nothing for the operator to paste.
+   */
+  it('says so when there is nothing to paste, instead of printing an empty block', async () => {
+    await session([], async () => {});
+    expect(lines.join('')).toContain('attach.nothing_to_set');
+  });
+
+  /**
+   * Some adapters instrument by writing a file into the run directory and naming it in the
+   * environment — the fetch hook is the live example. Those paths exist on this machine and not in
+   * the sandbox, so printing them yields a block that runs cleanly and instruments nothing.
+   */
+  it('flags an instruction that names a file only this machine has', async () => {
+    await session(['--for', 'node'], async () => {});
+    expect(lines.join('')).toContain('attach.local_path');
   });
 
   it('advertises the host the operator names, not the one it bound', async () => {
@@ -187,6 +221,67 @@ describe('orca attach', () => {
     await session(['--replay', recorded.runId, '--for', 'generic-openai'], async () => {});
 
     expect(lines.join('')).toContain('export OPENAI_BASE_URL=');
+  });
+
+  /**
+   * A replay session that could not answer the agent has to be detectable by a script, not only
+   * by a human reading the log — CI is exactly where a sandbox replay runs.
+   */
+  it('reports a request the recording could not answer', async () => {
+    const recorded = await session(['--for', 'claude'], async (proxyUrl) => {
+      await fetch(`${proxyUrl}/v1/messages`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          model: 'claude-opus-5',
+          messages: [{ role: 'user', content: 'x' }],
+        }),
+      });
+    });
+
+    const replayed = await session(['--replay', recorded.runId], async (proxyUrl) => {
+      // A question the recording never held an answer for.
+      await fetch(`${proxyUrl}/v1/messages`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          model: 'claude-opus-5',
+          messages: [{ role: 'user', content: 'something else entirely' }],
+        }),
+      });
+    });
+
+    expect(replayed.unmatched).toBeGreaterThan(0);
+    expect(replayed.exitCode).toBe(1);
+  });
+
+  it('exits zero for a session that served everything it was asked for', async () => {
+    const recorded = await session(['--for', 'claude'], async (proxyUrl) => {
+      await fetch(`${proxyUrl}/v1/messages`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          model: 'claude-opus-5',
+          messages: [{ role: 'user', content: 'x' }],
+        }),
+      });
+    });
+    const replayed = await session(['--replay', recorded.runId], async (proxyUrl) => {
+      await fetch(`${proxyUrl}/v1/messages`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          model: 'claude-opus-5',
+          messages: [{ role: 'user', content: 'x' }],
+        }),
+      });
+    });
+    expect(replayed.exitCode).toBe(0);
+  });
+
+  it('exits zero for a recording session, which cannot fail by being stopped', async () => {
+    const result = await session(['--for', 'claude'], async () => {});
+    expect(result.exitCode).toBe(0);
   });
 
   it('says the recording is being served, not recorded, so nothing looks like a fresh run', async () => {

--- a/packages/cli/test/attach.test.ts
+++ b/packages/cli/test/attach.test.ts
@@ -99,6 +99,41 @@ describe('what a remote agent has to be told', () => {
   });
 
   /**
+   * The block is printed to a terminal, and a terminal is scrollback, a screen share, a pasted
+   * ticket and a CI log. The operator's own credential must never appear in it.
+   *
+   * Nor should a placeholder: adapters substitute `orca-recorded` for a key the local environment
+   * does not have, and exporting that in a sandbox would *overwrite* a real key the agent already
+   * had, turning a working setup into a 401. The agent over there keeps whatever credential it
+   * has, and orca forwards it upstream — so the right number of credential lines is none.
+   */
+  it('exports no credential, neither a real one nor a placeholder', () => {
+    const env = attachExports({
+      proxyUrl,
+      adapterEnv: {
+        ANTHROPIC_BASE_URL: proxyUrl,
+        ANTHROPIC_API_KEY: 'sk-ant-REAL-SECRET',
+        OPENAI_API_KEY: 'orca-recorded',
+        GITHUB_TOKEN: 'ghp_secret',
+      },
+    });
+    expect(env.ANTHROPIC_BASE_URL).toBe(proxyUrl);
+    expect(env.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(env.OPENAI_API_KEY).toBeUndefined();
+    expect(env.GITHUB_TOKEN).toBeUndefined();
+  });
+
+  it('leaves no trace of a secret in the printed block', () => {
+    const text = attachInstructions({
+      proxyUrl,
+      adapterEnv: { ANTHROPIC_BASE_URL: proxyUrl, ANTHROPIC_API_KEY: 'sk-ant-REAL-SECRET' },
+    }).join('\n');
+    expect(text).not.toContain('sk-ant-REAL-SECRET');
+    // And says why a key is missing, so nobody concludes the block is incomplete.
+    expect(text).toMatch(/credential/i);
+  });
+
+  /**
    * A sandbox that cannot reach the proxy is the failure this whole command exists to avoid, and
    * `NO_PROXY` inherited from the operator's shell is a good way to cause it silently.
    */

--- a/packages/cli/test/attach.test.ts
+++ b/packages/cli/test/attach.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest';
+import { advertisedUrl, attachExports, attachInstructions } from '../src/attach.js';
+
+/**
+ * Recording an agent orca does not launch.
+ *
+ * Every capture mechanism here so far ends in a child process: the adapter builds an environment
+ * and orca spawns the agent inside it. That is the whole design, and it has one boundary it cannot
+ * cross — an agent that is not on this machine. A bot on a VPS, an agent inside a dev container or
+ * a cloud sandbox, a harness someone else's CI runs: orca has no process to spawn, so it has no
+ * environment to build.
+ *
+ * What it can still do is be *reachable*, and say exactly what to set. The proxy already accepts a
+ * bind address; what was missing was the other half — the block of variables the operator pastes
+ * on the far side, which is the part that has to be right or the run records nothing.
+ */
+describe('the address a remote agent is told to use', () => {
+  it('uses the bind address when it is one an agent could dial', () => {
+    expect(advertisedUrl({ bind: '10.0.0.5', port: 8080 })).toBe('http://10.0.0.5:8080');
+  });
+
+  /**
+   * `0.0.0.0` means "every interface I have", which is a statement about listening. As an address
+   * to connect *to* it is meaningless, and an agent handed `http://0.0.0.0:8080` fails in a way
+   * that looks like orca is broken rather than like the flag was incomplete.
+   */
+  it('refuses to advertise a wildcard, which is not an address anything can reach', () => {
+    expect(() => advertisedUrl({ bind: '0.0.0.0', port: 8080 })).toThrow(/--advertise/);
+    expect(() => advertisedUrl({ bind: '::', port: 8080 })).toThrow(/--advertise/);
+  });
+
+  it('takes an explicit advertised host over the bind address', () => {
+    expect(advertisedUrl({ bind: '0.0.0.0', port: 8080, advertise: 'orca.internal' })).toBe(
+      'http://orca.internal:8080',
+    );
+  });
+
+  it('keeps a port the operator wrote into the advertised host', () => {
+    // Behind a port-mapped container the outside port is not the one orca bound.
+    expect(advertisedUrl({ bind: '0.0.0.0', port: 8080, advertise: 'localhost:19000' })).toBe(
+      'http://localhost:19000',
+    );
+  });
+
+  it('brackets a bare IPv6 literal, which is not a URL host without them', () => {
+    expect(advertisedUrl({ bind: 'fd00::1', port: 8080 })).toBe('http://[fd00::1]:8080');
+  });
+});
+
+describe('what a remote agent has to be told', () => {
+  const proxyUrl = 'http://10.0.0.5:8080';
+
+  it('points the agent at the proxy through the ordinary variables', () => {
+    const env = attachExports({ proxyUrl, adapterEnv: { OPENAI_BASE_URL: `${proxyUrl}/v1` } });
+    expect(env.OPENAI_BASE_URL).toBe('http://10.0.0.5:8080/v1');
+  });
+
+  it('adds the proxy and the CA when the run is intercepting', () => {
+    const env = attachExports({
+      proxyUrl,
+      adapterEnv: {},
+      ca: { certPath: '/runs/r1/tls/ca.crt', bundlePath: '/runs/r1/tls/ca-bundle.crt' },
+      remoteCaPath: '/tmp/orca-ca.crt',
+    });
+    expect(env.HTTPS_PROXY).toBe(proxyUrl);
+    expect(env.https_proxy).toBe(proxyUrl);
+    // Every path is the one the file will have *there*, never the one it has here. Printing this
+    // machine's path would produce a block that runs cleanly and trusts nothing.
+    expect(env.NODE_EXTRA_CA_CERTS).toBe('/tmp/orca-ca.crt');
+    expect(env.SSL_CERT_FILE).toBe('/tmp/orca-ca.crt');
+    expect(env.REQUESTS_CA_BUNDLE).toBe('/tmp/orca-ca.crt');
+    expect(env.CURL_CA_BUNDLE).toBe('/tmp/orca-ca.crt');
+  });
+
+  it('sets no CA variable when nothing is being intercepted', () => {
+    const env = attachExports({ proxyUrl, adapterEnv: { OPENAI_BASE_URL: `${proxyUrl}/v1` } });
+    expect(env.NODE_EXTRA_CA_CERTS).toBeUndefined();
+    expect(env.HTTPS_PROXY).toBeUndefined();
+  });
+
+  /**
+   * A sandbox that cannot reach the proxy is the failure this whole command exists to avoid, and
+   * `NO_PROXY` inherited from the operator's shell is a good way to cause it silently.
+   */
+  it('does not carry the local NO_PROXY into the sandbox', () => {
+    const env = attachExports({
+      proxyUrl,
+      adapterEnv: {},
+      ca: { certPath: '/a/ca.crt', bundlePath: '/a/b.crt' },
+      remoteCaPath: '/tmp/ca.crt',
+    });
+    expect(env.NO_PROXY).toBeUndefined();
+  });
+});
+
+describe('the block the operator pastes', () => {
+  it('is shell-pasteable, one export per line', () => {
+    const lines = attachInstructions({
+      proxyUrl: 'http://10.0.0.5:8080',
+      adapterEnv: { OPENAI_BASE_URL: 'http://10.0.0.5:8080/v1' },
+    });
+    expect(lines).toContain("export OPENAI_BASE_URL='http://10.0.0.5:8080/v1'");
+  });
+
+  it('quotes a value so a shell cannot reinterpret it', () => {
+    const lines = attachInstructions({
+      proxyUrl: 'http://h:1',
+      adapterEnv: { WEIRD: "a b$(echo hi)'c" },
+    });
+    expect(lines.join('\n')).toContain(`'a b$(echo hi)'\\''c'`);
+  });
+
+  /**
+   * The bundle rather than the bare certificate, and the distinction is not cosmetic.
+   *
+   * `SSL_CERT_FILE` and its siblings *replace* an OpenSSL client's trust store rather than adding
+   * to it. A sandbox handed only `ca.crt` would trust the run CA and nothing else, so every host
+   * orca deliberately does not intercept — the package index, the git remote — would stop
+   * verifying. The bundle is the run CA plus the public roots, which is why one file is safe to
+   * ship and safe to point all of them at.
+   */
+  it('says to copy the CA bundle across first, because the paths are remote', () => {
+    const lines = attachInstructions({
+      proxyUrl: 'http://10.0.0.5:8080',
+      adapterEnv: {},
+      ca: { certPath: '/runs/r1/tls/ca.crt', bundlePath: '/runs/r1/tls/ca-bundle.crt' },
+      remoteCaPath: '/tmp/orca-ca.crt',
+    });
+    const text = lines.join('\n');
+    expect(text).toContain('/runs/r1/tls/ca-bundle.crt');
+    expect(text).not.toContain('/runs/r1/tls/ca.crt ');
+    expect(text).toContain('/tmp/orca-ca.crt');
+    expect(text).toMatch(/copy/i);
+  });
+
+  it('mentions no certificate authority when there is none to copy', () => {
+    const text = attachInstructions({
+      proxyUrl: 'http://h:1',
+      adapterEnv: { OPENAI_BASE_URL: 'http://h:1/v1' },
+    }).join('\n');
+    expect(text).not.toMatch(/ca-bundle\.crt/);
+  });
+});

--- a/packages/cli/test/attach.test.ts
+++ b/packages/cli/test/attach.test.ts
@@ -45,6 +45,26 @@ describe('the address a remote agent is told to use', () => {
   it('brackets a bare IPv6 literal, which is not a URL host without them', () => {
     expect(advertisedUrl({ bind: 'fd00::1', port: 8080 })).toBe('http://[fd00::1]:8080');
   });
+
+  /**
+   * An IPv6 literal is mostly colons, so "does this host already carry a port" cannot be answered
+   * by looking for the last one. Getting it wrong drops the port entirely and hands the sandbox
+   * `http://fd00::1`, which resolves to port 80 and connects to nothing.
+   */
+  it('does not mistake the tail of a bare IPv6 address for a port', () => {
+    expect(advertisedUrl({ bind: '0.0.0.0', port: 8080, advertise: 'fd00::1' })).toBe(
+      'http://[fd00::1]:8080',
+    );
+    expect(advertisedUrl({ bind: '0.0.0.0', port: 8080, advertise: '::1' })).toBe(
+      'http://[::1]:8080',
+    );
+  });
+
+  it('keeps a port written after a bracketed IPv6 host', () => {
+    expect(advertisedUrl({ bind: '0.0.0.0', port: 8080, advertise: '[fd00::1]:19000' })).toBe(
+      'http://[fd00::1]:19000',
+    );
+  });
 });
 
 describe('what a remote agent has to be told', () => {

--- a/packages/cli/test/fixtures/ide-parent.mjs
+++ b/packages/cli/test/fixtures/ide-parent.mjs
@@ -1,0 +1,34 @@
+/**
+ * An editor that spawns the real agent, which is the shape of Codex-in-the-IDE.
+ *
+ * The VS Code and Cursor extensions do not make model calls themselves — they run a agent binary
+ * as a child process and talk to it over a pipe. Orca cannot launch that child, because the editor
+ * launches it. What orca can launch is the editor, and everything it needs then reaches the agent
+ * by inheritance: `HTTPS_PROXY`, the run CA, and the base-URL variables alike.
+ *
+ * So this fixture makes no model call of its own. It exists to put one process between orca and
+ * the agent, and to fail loudly if that gap is where the capture environment goes missing.
+ */
+import { spawn } from 'node:child_process';
+
+const [, , child, ...rest] = process.argv;
+if (!child) {
+  console.error('ide-parent: needs the agent to spawn');
+  process.exit(2);
+}
+
+console.log('ide-parent: launching the agent, having asked no model anything');
+
+// `env` is deliberately not passed: inheriting the parent's environment untouched is the property
+// under test. Passing `{...process.env}` would test the same thing, but it would also hide a
+// regression where orca stopped putting the capture into the environment in the first place.
+const agent = spawn(process.execPath, [child, ...rest], { stdio: 'inherit' });
+
+agent.on('exit', (code, signal) => {
+  console.log(`ide-parent: agent exited code=${code ?? 'null'} signal=${signal ?? 'none'}`);
+  process.exit(code ?? 1);
+});
+agent.on('error', (err) => {
+  console.error(`ide-parent: could not spawn the agent: ${String(err)}`);
+  process.exit(3);
+});

--- a/packages/cli/test/grok-bot-e2e.test.ts
+++ b/packages/cli/test/grok-bot-e2e.test.ts
@@ -1,0 +1,308 @@
+import { execFile } from 'node:child_process';
+import { createServer as createHttpsServer } from 'node:https';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import type { AddressInfo } from 'node:net';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { TraceReader } from '@orcareplay/core';
+import { RunCa } from '@orcareplay/proxy';
+import { parseArgs } from '../src/args.js';
+import { Output } from '../src/out.js';
+import { recordCommand } from '../src/commands/record.js';
+import { replayCommand } from '../src/commands/replay.js';
+
+const run = promisify(execFile);
+const here = dirname(fileURLToPath(import.meta.url));
+const IDE_PARENT = join(here, 'fixtures', 'ide-parent.mjs');
+const PROXY_CALL = join(here, 'fixtures', 'proxy-call.mjs');
+
+/**
+ * A Grok bot, and any other agent whose origin is a string in its own source.
+ *
+ * Every capture mechanism orca had before this needed the agent's cooperation: a base-URL variable
+ * it reads, or a `fetch` it inherits. A bot with `https://api.x.ai/v1` typed into it has neither,
+ * and there are a great many of those — it is what someone writes in an afternoon, and it is what
+ * the "grok bot" people ask about usually is.
+ *
+ * `--tls-intercept` was already able to record such a thing. What was missing was a way to say so:
+ * `generic-openai` would have injected `OPENAI_BASE_URL` and repointed an agent that never asked,
+ * and no test proved the intercept-only path worked end to end for an agent orca knows nothing
+ * about. These are that proof, and they are deliberately end to end — a real child process, a real
+ * CONNECT, real TLS, and a replay with the origin taken away.
+ *
+ * The bot's origin is written into its source by the test rather than read from the environment.
+ * That is the property under test, so it is asserted directly: the generated source is checked to
+ * contain no base-URL variable at all. A test cannot dial `api.x.ai`, so the literal is a local
+ * address — the hostname was never the point, the absence of a redirect is.
+ */
+describe('end to end: an agent whose origin is hardcoded', () => {
+  let workspace: string;
+  let originDir: string;
+  let originCa: RunCa;
+  let xai: { port: number; calls: unknown[]; close: () => Promise<void> };
+  let out: Output;
+  let lines: string[];
+  let botPath: string;
+
+  /** An xAI-shaped origin: OpenAI chat completions, served over TLS, deterministic. */
+  async function startXai(): Promise<typeof xai> {
+    const calls: unknown[] = [];
+    const issued = originCa.issue('127.0.0.1');
+    const server = createHttpsServer({ key: issued.keyPem, cert: issued.certPem }, (req, res) => {
+      const chunks: Buffer[] = [];
+      req.on('data', (c: Buffer) => void chunks.push(c));
+      req.on('end', () => {
+        let body: Record<string, unknown> = {};
+        try {
+          body = JSON.parse(Buffer.concat(chunks).toString('utf8')) as Record<string, unknown>;
+        } catch {
+          /* an unparseable body still gets a well-formed reply */
+        }
+        calls.push({ url: req.url, body });
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(
+          JSON.stringify({
+            id: 'chatcmpl-grok-1',
+            object: 'chat.completion',
+            created: 1,
+            model: body.model ?? 'grok-4',
+            choices: [
+              {
+                index: 0,
+                message: { role: 'assistant', content: 'rejecting tokens under 8 characters' },
+                finish_reason: 'stop',
+              },
+            ],
+            usage: { prompt_tokens: 11, completion_tokens: 7, total_tokens: 18 },
+          }),
+        );
+      });
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    return {
+      port: (server.address() as AddressInfo).port,
+      calls,
+      close: () => new Promise<void>((resolve) => void server.close(() => resolve())),
+    };
+  }
+
+  /**
+   * The bot, with its origin baked in as a literal exactly as a real one has.
+   *
+   * It CONNECTs through `HTTPS_PROXY` by hand because Node's own client does not honour proxy
+   * environment variables before v24 — the same reason the other TLS fixtures here do. That is not
+   * a concession: a bot written against `curl`, `requests` or `httpx` gets this behaviour from its
+   * HTTP library, and doing it by hand is what keeps this a test of orca rather than of Node.
+   */
+  function botSource(port: number): string {
+    return `import { callThroughProxy } from ${JSON.stringify(PROXY_CALL)};
+import { writeFileSync } from 'node:fs';
+
+// Typed into the source, the way a real bot's origin usually is. Nothing below reads it from the
+// environment, which is the whole reason this agent needs interception to be recorded at all.
+const XAI_HOST = '127.0.0.1';
+const XAI_PORT = ${port};
+const XAI_PATH = '/v1/chat/completions';
+
+const reply = await callThroughProxy({
+  host: XAI_HOST,
+  port: XAI_PORT,
+  path: XAI_PATH,
+  method: 'POST',
+  body: JSON.stringify({
+    model: 'grok-4',
+    messages: [{ role: 'user', content: 'reject tokens shorter than 8 characters' }],
+  }),
+});
+
+console.log('grok-bot: ' + JSON.parse(reply.body).choices[0].message.content);
+if (process.env.ORCA_TEST_RESULT_OUT) {
+  writeFileSync(process.env.ORCA_TEST_RESULT_OUT, JSON.stringify(reply, null, 2));
+}
+`;
+  }
+
+  beforeEach(async () => {
+    workspace = await mkdtemp(join(tmpdir(), 'orca-grokbot-'));
+    originDir = await mkdtemp(join(tmpdir(), 'orca-grokorigin-'));
+    originCa = await RunCa.create({ runDir: originDir });
+    xai = await startXai();
+    botPath = join(workspace, 'grok-bot.mjs');
+    await writeFile(botPath, botSource(xai.port));
+
+    lines = [];
+    out = new Output({ write: (s) => void lines.push(s), isTTY: false });
+    await run('git', ['init', '-q'], { cwd: workspace });
+    await run('git', ['config', 'user.email', 'test@example.com'], { cwd: workspace });
+    await run('git', ['config', 'user.name', 'Test'], { cwd: workspace });
+
+    // The origin is signed by a CA no machine trusts. Real interception verifies the origin it
+    // re-encrypts to, so the proxy is told about that root the way a corporate one would be.
+    process.env.ORCA_TLS_UPSTREAM_CA = originCa.certPath;
+  });
+
+  afterEach(async () => {
+    delete process.env.ORCA_TLS_UPSTREAM_CA;
+    delete process.env.ORCA_TEST_RESULT_OUT;
+    await xai.close();
+    await originCa.dispose();
+    await rm(originDir, { recursive: true, force: true });
+    await rm(workspace, { recursive: true, force: true });
+  });
+
+  const record = (...extra: string[]) =>
+    recordCommand(
+      parseArgs([
+        'record',
+        'exec',
+        '--tls-intercept',
+        '--tls-hosts',
+        `127.0.0.1:${xai.port}`,
+        ...extra,
+        '--',
+        process.execPath,
+        botPath,
+      ]),
+      out,
+      workspace,
+    );
+
+  it('reads no base-url variable, which is what makes it need interception', async () => {
+    const source = await readFile(botPath, 'utf8');
+    expect(source).not.toMatch(/_BASE_URL|_API_BASE/);
+    expect(source).toContain('/v1/chat/completions');
+  });
+
+  it('records the call as a model exchange, not as opaque traffic', async () => {
+    const result = await record();
+
+    expect(result.exitCode).toBe(0);
+    // The assertion that matters. Intercepted bytes on a path no dialect claims land as `net.*`
+    // and can never be replayed; the openai dialect claiming `/v1/chat/completions` is what makes
+    // this a recording rather than a transcript.
+    expect(result.modelExchanges).toBe(1);
+    expect(lines.find((l) => l.includes('capture.empty'))).toBeUndefined();
+
+    const events = await (await TraceReader.open(result.runDir)).events();
+    expect(events.filter((e) => e.type === 'model.request')).toHaveLength(1);
+    expect(events.filter((e) => e.type === 'net.request')).toHaveLength(0);
+  });
+
+  it('never repoints the bot at a provider it did not choose', async () => {
+    await record();
+    // `exec` injects no origin, so the only reason the call was captured is that orca terminated
+    // the TLS the bot established itself. An adapter that started setting OPENAI_BASE_URL here
+    // would still make this test pass on exchange count — and would have changed where a bot with
+    // its own OpenAI client sent its traffic. The origin's own call log is what proves it did not.
+    expect(xai.calls).toHaveLength(1);
+    expect((xai.calls[0] as { url: string }).url).toBe('/v1/chat/completions');
+  });
+
+  it('replays the bot offline, with the origin taken away', async () => {
+    const result = await record();
+    const before = xai.calls.length;
+    await xai.close();
+
+    const replay = await replayCommand(parseArgs(['replay', result.runId]), out, workspace);
+
+    expect(replay.exitCode).toBe(0);
+    expect(replay.matchedExact).toBe(1);
+    expect(replay.unmatched).toBe(0);
+    expect(xai.calls.length).toBe(before);
+  });
+
+  /**
+   * Replaying an intercepted run without having to remember how it was recorded.
+   *
+   * Interception is two flags, and a replay that dropped them did not fail loudly — it started a
+   * proxy with no interception, tunnelled the bot's CONNECT to an origin that was gone, and
+   * reported `reused=0/1` as though the recording were at fault. The recording already knew: the
+   * run writes a `tls_intercept` note naming the hosts it decrypted. Reading it back is what makes
+   * `orca replay last` work on an intercepted run, which is the only thing anyone types.
+   */
+  it('re-establishes interception from the recording, with no flags repeated', async () => {
+    const result = await record();
+    await xai.close();
+    lines.length = 0;
+
+    const replay = await replayCommand(parseArgs(['replay', result.runId]), out, workspace);
+
+    expect(replay.exitCode).toBe(0);
+    // Minting a CA is never silent, even when orca decided on it rather than the operator.
+    expect(lines.join('')).toContain('tls.intercepting');
+    expect(lines.join('')).toContain(`127.0.0.1:${xai.port}`);
+  });
+
+  it('still lets the operator refuse, and says why the replay then cannot match', async () => {
+    const result = await record();
+    await xai.close();
+    lines.length = 0;
+
+    const replay = await replayCommand(
+      parseArgs(['replay', result.runId, '--no-tls-intercept']),
+      out,
+      workspace,
+    );
+
+    expect(lines.join('')).not.toContain('tls.intercepting');
+    expect(replay.matchedExact).toBe(0);
+  });
+
+  /**
+   * Codex-in-the-IDE, and the reason it is not above the ceiling.
+   *
+   * The editor spawns the agent, so orca never gets to build that process's environment. It does
+   * not need to: the editor inherits the capture and passes it on. This is the same property the
+   * gateway test pins for base-URL variables, checked here for the interception half — `HTTPS_PROXY`
+   * and the run CA have to survive the same hop, and nothing guarantees that but a test.
+   */
+  it('reaches an agent two processes down, which is how an IDE spawns one', async () => {
+    const result = await recordCommand(
+      parseArgs([
+        'record',
+        'exec',
+        '--tls-intercept',
+        '--tls-hosts',
+        `127.0.0.1:${xai.port}`,
+        '--',
+        process.execPath,
+        IDE_PARENT,
+        botPath,
+      ]),
+      out,
+      workspace,
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.modelExchanges).toBe(1);
+    expect(xai.calls).toHaveLength(1);
+  });
+
+  it('replays the IDE-spawned agent offline too', async () => {
+    const result = await recordCommand(
+      parseArgs([
+        'record',
+        'exec',
+        '--tls-intercept',
+        '--tls-hosts',
+        `127.0.0.1:${xai.port}`,
+        '--',
+        process.execPath,
+        IDE_PARENT,
+        botPath,
+      ]),
+      out,
+      workspace,
+    );
+    await xai.close();
+
+    const replay = await replayCommand(parseArgs(['replay', result.runId]), out, workspace);
+
+    expect(replay.exitCode).toBe(0);
+    expect(replay.matchedExact).toBe(1);
+    expect(replay.unmatched).toBe(0);
+  });
+});

--- a/packages/cli/test/tls-intercept.test.ts
+++ b/packages/cli/test/tls-intercept.test.ts
@@ -198,6 +198,35 @@ describe('orca record --tls-intercept', () => {
     expect(await grepRunDir(result.runDir, 'BANK-BODY-MARKER')).toEqual([]);
   });
 
+  /**
+   * The additive form, end to end. The unit tests in @orcareplay/proxy cover the resolution; this
+   * one exists because the flag is where the mistake was actually made — someone naming the one
+   * endpoint their agent talks to, and losing the twelve model APIs they still needed.
+   */
+  it('keeps the default hosts when a named host is marked with +', async () => {
+    await record(['--tls-intercept', '--tls-hosts', '+grok.example']);
+    const printed = lines.join('');
+    expect(printed).toContain('grok.example');
+    expect(printed).toContain('api.anthropic.com');
+    expect(printed).toContain('api.x.ai');
+  });
+
+  it('still replaces the defaults for a plain list, as it always has', async () => {
+    await record(['--tls-intercept', '--tls-hosts', 'api.openai.com']);
+    const printed = lines.join('');
+    expect(printed).toContain('api.openai.com');
+    expect(printed).not.toContain('api.anthropic.com');
+  });
+
+  it('refuses a list that both replaces and adds, before minting anything', async () => {
+    await expect(
+      record(['--tls-intercept', '--tls-hosts', 'api.openai.com,+grok.example']),
+    ).rejects.toThrow(/api\.openai\.com.*\+grok\.example/s);
+    // Rejected before `RunCa.create`, so the run that is not going to happen leaves no private key
+    // anywhere under the runs root — the same guarantee `--tls-hosts '*'` already has.
+    expect(await grepRunDir(join(workspace, '.orca'), 'PRIVATE KEY')).toEqual([]);
+  });
+
   it('warns rather than silently ignoring hosts named without the flag', async () => {
     await record(['--tls-hosts', 'api.openai.com']);
     expect(lines.join('')).toContain('tls.hosts_ignored');

--- a/packages/cli/test/tls-intercept.test.ts
+++ b/packages/cli/test/tls-intercept.test.ts
@@ -227,6 +227,59 @@ describe('orca record --tls-intercept', () => {
     expect(await grepRunDir(join(workspace, '.orca'), 'PRIVATE KEY')).toEqual([]);
   });
 
+  /**
+   * Telling the operator at record time that a capture is meaningless.
+   *
+   * Intercepted bytes on a path no dialect claims are written as `net.*` — orca holds them but not
+   * their meaning, so they can never be matched on replay or forked to another model. That was
+   * only discoverable one command later, from the 502 that strict replay raises, by which point
+   * the agent has finished and the opportunity to record it properly is gone.
+   */
+  it('says at record time when intercepted traffic was not a model call it understands', async () => {
+    process.env.ORCA_TEST_TARGETS = JSON.stringify([
+      {
+        host: '127.0.0.1',
+        port: bank.port,
+        path: '/v3/converse',
+        method: 'POST',
+        body: JSON.stringify({ prompt: 'hello' }),
+      },
+    ]);
+    await record(['--tls-intercept', '--tls-hosts', `127.0.0.1:${bank.port}`]);
+
+    const printed = lines.join('');
+    expect(printed).toContain('tls.unclaimed_path');
+    expect(printed).toContain('/v3/converse');
+    // The operator needs to know what to do about it, not merely that it happened.
+    expect(printed).toContain('plugins.md');
+  });
+
+  it('says it once for a path an agent calls repeatedly, not once per turn', async () => {
+    const call = {
+      host: '127.0.0.1',
+      port: bank.port,
+      path: '/v3/converse',
+      method: 'POST',
+      body: JSON.stringify({ prompt: 'hello' }),
+    };
+    process.env.ORCA_TEST_TARGETS = JSON.stringify([call, call, call]);
+    await record(['--tls-intercept', '--tls-hosts', `127.0.0.1:${bank.port}`]);
+
+    const warnings = lines.join('').match(/tls\.unclaimed_path/g) ?? [];
+    expect(warnings).toHaveLength(1);
+  });
+
+  it('stays quiet about traffic that was never a model call to begin with', async () => {
+    // A GET, and a body that is not JSON. Warning here would train the operator to ignore the
+    // warning that matters, which is worse than not printing one.
+    process.env.ORCA_TEST_TARGETS = JSON.stringify([
+      { host: '127.0.0.1', port: bank.port, path: '/accounts' },
+    ]);
+    await record(['--tls-intercept', '--tls-hosts', `127.0.0.1:${bank.port}`]);
+
+    expect(lines.join('')).not.toContain('tls.unclaimed_path');
+  });
+
   it('warns rather than silently ignoring hosts named without the flag', async () => {
     await record(['--tls-hosts', 'api.openai.com']);
     expect(lines.join('')).toContain('tls.hosts_ignored');

--- a/packages/plugin-api/src/plugins.ts
+++ b/packages/plugin-api/src/plugins.ts
@@ -38,6 +38,19 @@ export interface Adapter {
   aliases?: readonly string[];
   /** Semver range of harness versions this adapter is tested against. */
   harnessVersions?: string;
+  /**
+   * How this adapter gets the agent's traffic to orca.
+   *
+   * `env` — the default, and what every harness-specific adapter does: point a base-URL variable
+   * at the proxy, or install the fetch hook, so the agent connects to a local origin in plaintext.
+   *
+   * `transport` — the adapter redirects nothing and relies on `--tls-intercept`, which is applied
+   * to the launched child by the run rather than by the adapter. Declared rather than inferred,
+   * because "sets no base-URL variable" is otherwise indistinguishable from the broken adapter the
+   * contract's `redirects-model-traffic` check exists to catch. An adapter that says `transport`
+   * is asserting that pointing nowhere is the intent, and takes the check's exemption in exchange.
+   */
+  capture?: 'env' | 'transport';
   detect(cwd: string): Promise<boolean>;
   prepare(ctx: RecordContext): Promise<Launch>;
   /**

--- a/packages/proxy/src/tls-hosts.ts
+++ b/packages/proxy/src/tls-hosts.ts
@@ -51,9 +51,20 @@ export const DEFAULT_TLS_HOSTS: readonly string[] = [
  * because the two readings disagree about every host the operator did not name, and guessing would
  * produce a policy nobody asked for.
  */
-export function resolveTlsHosts(requested: readonly string[]): string[] {
+export function resolveTlsHosts(
+  requested: readonly string[],
+  /**
+   * What `+host` adds to, and what an empty request falls back to.
+   *
+   * Defaults to the model API hosts. A replay passes the list its recording decrypted instead, so
+   * `--tls-hosts '+extra'` on a run recorded with a custom list adds to *that* list rather than
+   * silently swapping it for the defaults — which would stop decrypting the host the recording
+   * needs and report `reused=0/n`.
+   */
+  base: readonly string[] = DEFAULT_TLS_HOSTS,
+): string[] {
   const entries = requested.map((h) => h.trim()).filter((h) => h !== '');
-  if (entries.length === 0) return [...DEFAULT_TLS_HOSTS];
+  if (entries.length === 0) return [...base];
 
   const additive = entries.filter((h) => h.startsWith('+'));
   if (additive.length === 0) return entries;
@@ -69,7 +80,7 @@ export function resolveTlsHosts(requested: readonly string[]): string[] {
   // A bare `+` names nothing; dropping it beats minting an empty pattern that `HostPolicy` would
   // then reject with an error about a list the operator never typed.
   const added = additive.map((h) => h.slice(1).trim()).filter((h) => h !== '');
-  const seen = new Set(DEFAULT_TLS_HOSTS.map((h) => h.toLowerCase()));
+  const seen = new Set(base.map((h) => h.toLowerCase()));
   const extra: string[] = [];
   for (const host of added) {
     const key = host.toLowerCase();
@@ -77,7 +88,7 @@ export function resolveTlsHosts(requested: readonly string[]): string[] {
     seen.add(key);
     extra.push(host);
   }
-  return [...DEFAULT_TLS_HOSTS, ...extra];
+  return [...base, ...extra];
 }
 
 interface Pattern {

--- a/packages/proxy/src/tls-hosts.ts
+++ b/packages/proxy/src/tls-hosts.ts
@@ -38,6 +38,48 @@ export const DEFAULT_TLS_HOSTS: readonly string[] = [
   'openrouter.ai',
 ];
 
+/**
+ * What the operator asked for, resolved against the defaults.
+ *
+ * `--tls-hosts a,b` has always meant "decrypt exactly these", which is the right default for a
+ * feature whose safety argument is the list itself. It is the wrong shape for the commonest real
+ * request — "the usual model APIs, plus the one endpoint my agent talks to" — and someone who
+ * reached for that got the strict reading instead: naming one host dropped the other twelve, and
+ * the run under-captured in silence.
+ *
+ * A leading `+` asks for the other meaning. Mixing the two forms is refused rather than resolved,
+ * because the two readings disagree about every host the operator did not name, and guessing would
+ * produce a policy nobody asked for.
+ */
+export function resolveTlsHosts(requested: readonly string[]): string[] {
+  const entries = requested.map((h) => h.trim()).filter((h) => h !== '');
+  if (entries.length === 0) return [...DEFAULT_TLS_HOSTS];
+
+  const additive = entries.filter((h) => h.startsWith('+'));
+  if (additive.length === 0) return entries;
+  if (additive.length !== entries.length) {
+    const plain = entries.filter((h) => !h.startsWith('+'));
+    throw new Error(
+      `--tls-hosts mixes "${plain[0]}" with "${additive[0]}": a bare host replaces the default ` +
+        'list and a "+host" adds to it, so together they disagree about every host you did not ' +
+        'name. Mark all of them with + to add, or none to replace.',
+    );
+  }
+
+  // A bare `+` names nothing; dropping it beats minting an empty pattern that `HostPolicy` would
+  // then reject with an error about a list the operator never typed.
+  const added = additive.map((h) => h.slice(1).trim()).filter((h) => h !== '');
+  const seen = new Set(DEFAULT_TLS_HOSTS.map((h) => h.toLowerCase()));
+  const extra: string[] = [];
+  for (const host of added) {
+    const key = host.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    extra.push(host);
+  }
+  return [...DEFAULT_TLS_HOSTS, ...extra];
+}
+
 interface Pattern {
   /** Lower-case host, or the suffix after `*.` for a wildcard. */
   host: string;

--- a/packages/proxy/test/tls-hosts.test.ts
+++ b/packages/proxy/test/tls-hosts.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { DEFAULT_TLS_HOSTS, HostPolicy } from '../src/tls-hosts.js';
+import { DEFAULT_TLS_HOSTS, HostPolicy, resolveTlsHosts } from '../src/tls-hosts.js';
 
 /**
  * Which hosts a `--tls-intercept` run is allowed to decrypt.
@@ -72,5 +72,70 @@ describe('TLS interception host policy', () => {
     expect(HostPolicy.from(['api.openai.com', '*.chatgpt.com']).describe()).toBe(
       'api.openai.com, *.chatgpt.com',
     );
+  });
+});
+
+/**
+ * Adding to the default list instead of replacing it.
+ *
+ * `--tls-hosts` replaced the defaults outright, which is the right shape for "decrypt exactly
+ * these and nothing else" and the wrong one for the far more common "decrypt the usual model APIs,
+ * plus this one endpoint my agent talks to". Someone reaching for the second got the first: naming
+ * one host silently dropped the other twelve, and the run under-captured without saying so.
+ *
+ * A leading `+` is the difference, and the mistake it prevents is the reason the resolution lives
+ * here rather than in the CLI — the policy and the meaning of the flag that builds it are one
+ * decision.
+ */
+describe('resolving the requested host list', () => {
+  it('falls back to the defaults when nothing is asked for', () => {
+    expect(resolveTlsHosts([])).toEqual([...DEFAULT_TLS_HOSTS]);
+  });
+
+  it('replaces the defaults for a plain list, which is what naming hosts has always meant', () => {
+    expect(resolveTlsHosts(['api.openai.com', 'api.x.ai'])).toEqual(['api.openai.com', 'api.x.ai']);
+  });
+
+  it('adds to the defaults when an entry is marked with +', () => {
+    const hosts = resolveTlsHosts(['+grok.com']);
+    expect(hosts).toEqual([...DEFAULT_TLS_HOSTS, 'grok.com']);
+    // The point of the feature: the defaults survive.
+    expect(HostPolicy.from(hosts).allows('api.anthropic.com', 443)).toBe(true);
+    expect(HostPolicy.from(hosts).allows('grok.com', 443)).toBe(true);
+  });
+
+  it('adds several, and keeps them in the order they were named', () => {
+    expect(resolveTlsHosts(['+grok.com', '+*.grok.com'])).toEqual([
+      ...DEFAULT_TLS_HOSTS,
+      'grok.com',
+      '*.grok.com',
+    ]);
+  });
+
+  it('never lists a default twice when one is added back explicitly', () => {
+    const hosts = resolveTlsHosts(['+api.x.ai', '+grok.com']);
+    expect(hosts.filter((h) => h === 'api.x.ai')).toHaveLength(1);
+    expect(hosts).toContain('grok.com');
+  });
+
+  /**
+   * Mixing the two is a contradiction — "use only these" and "keep the defaults too" in one flag —
+   * and guessing which was meant would produce a policy the operator did not ask for. In a feature
+   * whose entire safety argument is the host list, that is the one thing not to be clever about.
+   */
+  it('refuses a list that both replaces and adds, rather than picking one', () => {
+    expect(() => resolveTlsHosts(['api.openai.com', '+grok.com'])).toThrow(/\+/);
+    expect(() => resolveTlsHosts(['api.openai.com', '+grok.com'])).toThrow(
+      /every host|all of them|mix/i,
+    );
+  });
+
+  it('still refuses a wildcard that asks for everything, marked or not', () => {
+    expect(() => HostPolicy.from(resolveTlsHosts(['+*']))).toThrow(/every host/);
+    expect(() => HostPolicy.from(resolveTlsHosts(['*']))).toThrow(/every host/);
+  });
+
+  it('ignores a bare + with no host after it rather than adding an empty pattern', () => {
+    expect(resolveTlsHosts(['+grok.com', '+'])).toEqual([...DEFAULT_TLS_HOSTS, 'grok.com']);
   });
 });

--- a/packages/proxy/test/tls-hosts.test.ts
+++ b/packages/proxy/test/tls-hosts.test.ts
@@ -130,6 +130,29 @@ describe('resolving the requested host list', () => {
     );
   });
 
+  /**
+   * A replay adds to what its recording decrypted, not to the defaults.
+   *
+   * Resolving `+extra` against `DEFAULT_TLS_HOSTS` on a run recorded with a custom list swaps that
+   * list for the defaults, so the host the recording actually needs stops being decrypted and the
+   * replay reports `reused=0/n` — the same confusing failure the inheritance was added to remove.
+   */
+  it('adds to the list a recording used, when one is given', () => {
+    const recorded = ['127.0.0.1:8443'];
+    expect(resolveTlsHosts(['+grok.example'], recorded)).toEqual([
+      '127.0.0.1:8443',
+      'grok.example',
+    ]);
+  });
+
+  it('falls back to the recorded list when nothing is asked for', () => {
+    expect(resolveTlsHosts([], ['127.0.0.1:8443'])).toEqual(['127.0.0.1:8443']);
+  });
+
+  it('still lets a plain list replace the recorded one, for narrowing by hand', () => {
+    expect(resolveTlsHosts(['api.openai.com'], ['127.0.0.1:8443'])).toEqual(['api.openai.com']);
+  });
+
   it('still refuses a wildcard that asks for everything, marked or not', () => {
     expect(() => HostPolicy.from(resolveTlsHosts(['+*']))).toThrow(/every host/);
     expect(() => HostPolicy.from(resolveTlsHosts(['*']))).toThrow(/every host/);


### PR DESCRIPTION
## What this changes

Three kinds of agent that had no entry point can now be recorded, replayed offline and forked:

- **An agent whose origin is a string in its own source** — a Grok bot posting to `https://api.x.ai/v1` because someone typed it. `orca record exec --tls-intercept -- python bot.py`.
- **An agent orca did not launch but something it launched did** — the shape of Codex-in-the-IDE. `orca record exec --tls-intercept -- code .`; the extension's child inherits the capture.
- **An agent that is not on this machine at all** — a sandbox, a container, a VPS. `orca attach` holds the proxy open and prints what to export; `orca attach --replay <run>` serves a recording back to it.

Plus the fix that made the first two actually usable: **replaying an intercepted run no longer requires repeating `--tls-intercept --tls-hosts`.**

## Why

`--tls-intercept` could already record all of these. Nothing could *express* it. The only escape hatch was `generic-openai`, which injects `OPENAI_BASE_URL`, `OPENAI_API_BASE` and `ANTHROPIC_BASE_URL` — right when you know your agent reads one of them, and actively wrong when you do not: an injected origin silently repoints a harness that would otherwise have called somewhere else, and the trace then describes a run the user never asked for.

`docs/plugins.md` still told anyone writing an adapter that "base-URL injection is the only capture mechanism there is; there is no CA mode to fall back on" and "a harness that reads no base-URL variable cannot be recorded today". Both predate interception and the fetch hook, and the second is the exact question people read that page to answer — so the docs were turning them away from a case that works.

Two bugs found while writing the tests, both of which made the feature useless in practice:

- **Replaying an intercepted run failed as `reused=0/1`** unless the operator repeated both TLS flags. The replay proxy did no interception, tunnelled the agent's CONNECT to an origin that was gone, and reported a number that reads as a broken recording rather than a missing flag. Nobody repeats those flags — the command people type is `orca replay last`. The recording already knew: every intercepted run writes a `tls_intercept` note naming the hosts it decrypted, so replay and fork read it back and re-establish exactly that policy.
- **`--tls-hosts` replaced the default list rather than adding to it**, so naming the one endpoint your agent talks to silently dropped the other twelve.

## Tests

TDD throughout — every change below was a red test first. **1466 → 1543 passing.**

The test that earned its keep is `packages/cli/test/grok-bot-e2e.test.ts`: a bot generated with its origin as a source literal, asserted to contain no base-URL variable, recorded through a real child process, a real CONNECT and real TLS, then replayed with the origin server shut down. Writing it is what surfaced the `reused=0/1` replay bug — which no unit test would have found, because both halves were individually correct.

It also caught **my own test being vacuous**: an earlier version asserted `unmatched === 0` on a replay, which passes when nothing ever connects. Replaced with an assertion on `reused`.

A second suite (`attach-command.test.ts`, `attach.test.ts`) covers the sandbox path, including the instruction-building as pure functions — the failure mode there is a *wrong instruction* (a path that exists here and not there, a wildcard address nothing can dial), which is only testable if the strings are values rather than printed output.

**A review pass then found seven more defects, each reproduced before it was fixed:**

| | |
|---|---|
| **`orca attach` printed the operator's real API key in cleartext** | adapters pass the credential into `launch.env` and every entry was rendered as an `export` line — to a terminal, which is scrollback, a screen share and a CI log |
| `--replay` with no run parsed as boolean `true` | so `orca attach --replay` silently started a fresh **recording** against the live provider |
| `AttachResult.proxyUrl` returned the bind address | `--json --bind 0.0.0.0 --advertise …` handed callers the exact unusable URL the code throws to prevent |
| A bare IPv6 advertised host lost its port | `fd00::1` ends in `:1`, which read as a port |
| `--tls-hosts '+extra'` on a replay resolved against the defaults | dropping the host the recording actually needed |
| The trace was created before the last thing that can refuse the run | leaving an unsealed run directory that then wins `last` |
| `tls.unclaimed_path` required the body to parse as JSON | suppressing the warning for bodies truncated at the 1 MiB cap — the longest conversations, the most expensive to re-record |

### End-to-end, against a clean install of the packed tarballs

Not the test suite — `npm pack --workspaces`, installed into an empty project, driving a **Python** bot so the language-agnostic claim is demonstrated rather than asserted:

```console
$ orca record exec --tls-intercept --tls-hosts '+api.grok.test:8901' -- python3 grok_bot.py
warn tls.intercepting hosts="api.openai.com, chatgpt.com, …, api.grok.test:8901"   # 13 defaults kept + 1 added
grok-bot: reject tokens shorter than 8 characters
info recorded run=run_1ca278602117 events=8 exit=0

$ # origin killed — ConnectionRefusedError — and no flags repeated
$ orca replay last --in-place
warn tls.intercepting hosts="…, api.grok.test:8901"        # re-established from the recording
grok-bot: reject tokens shorter than 8 characters
info replay.done reused=1/1 exact=1 divergences=0 unmatched=0 exit=0
```

The trace holds `MODEL grok-4` events, not `net.*` — the openai dialect claims the path, so it is a recording rather than a transcript. Also verified end to end: the IDE-inheritance case through a shell script that spawns the bot; `orca attach` driven by an agent started in a clean `env -i` shell using only the printed block; `orca attach --replay` answering that agent with the model server refusing connections; and the credential leak confirmed gone.

One deliberate finding worth recording: `NO_PROXY` excludes loopback (so the agent's plaintext calls to the proxy do not loop), which means a model origin on `127.0.0.1` is never intercepted. Correct behaviour, but it is why the e2e above uses a hostname.

## Checklist

- [x] `npm run check` passes locally — plus `conformance.mjs` and `check-neutrality.mjs`
- [x] Tests were written before the implementation
- [x] Spec and schema unchanged — `net.*` and `note` already existed
- [x] No new runtime dependencies
- [ ] Commits signed off — **not done deliberately.** DCO is a personal certification and these commits are authored by `Claude <noreply@anthropic.com>`; forging a human sign-off is not mine to do. `git rebase --signoff origin/main` before merge if you want it.

## Not included

`orca import` for hosted agent loops, pluggable dialects, and the npm publish are all still open — the publish is the highest-leverage of the three and needs an `NPM_TOKEN` rather than code. Cursor's own protocol and vendor-hosted loops (Cursor Grok Bot, Codex cloud) remain out of reach by construction, and the README now says so rather than letting people discover it with an empty trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LMp1tTcaUkoZfr59tYQQcr

---
_Generated by [Claude Code](https://claude.ai/code/session_01LMp1tTcaUkoZfr59tYQQcr)_