### PR TITLE
name the repository in every package, so provenance can sign them

### DIFF
--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.1",
   "type": "module",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Continuum-AI-Corp/OrcaReplay.git",
+    "directory": "packages/adapters"
+  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,7 +32,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/Continuum-AI-Corp/OrcaReplay.git"
+    "url": "https://github.com/Continuum-AI-Corp/OrcaReplay.git",
+    "directory": "packages/cli"
   },
   "dependencies": {
     "@orcareplay/schema": "0.1.1",

--- a/packages/cli/test/publish-order.test.ts
+++ b/packages/cli/test/publish-order.test.ts
@@ -12,8 +12,12 @@ const order = (): string[] =>
 
 const manifest = (
   dir: string,
-): { name: string; version: string; dependencies?: Record<string, string> } =>
-  JSON.parse(readFileSync(join(repoRoot, dir, 'package.json'), 'utf8'));
+): {
+  name: string;
+  version: string;
+  dependencies?: Record<string, string>;
+  repository?: { url?: string; directory?: string };
+} => JSON.parse(readFileSync(join(repoRoot, dir, 'package.json'), 'utf8'));
 
 /**
  * The release workflow publishes in this order and only ever runs on a tag, so a mistake here is
@@ -39,6 +43,25 @@ describe('publish order', () => {
     expect(listed).toContain('orcareplay');
     expect(listed).toContain('@orcareplay/core');
     expect(listed).not.toContain('orcareplay-monorepo');
+  });
+
+  /**
+   * `--provenance` refuses to sign a package whose `package.json` does not name the repository the
+   * build claims to come from, and the registry rejects the upload with a 422. Eleven of the twelve
+   * packages had no `repository` field at all, which nothing noticed until a tag was pushed and the
+   * release died on the first package — the exact moment this file exists to protect.
+   */
+  it('names the repository in every package, which provenance signing requires', () => {
+    const expected = 'https://github.com/Continuum-AI-Corp/OrcaReplay.git';
+    for (const dir of order()) {
+      const pkg = manifest(dir);
+      expect(pkg.repository?.url, `${pkg.name} declares no repository.url`).toBe(expected);
+      // The directory too, so npm links at the package rather than the monorepo root. The
+      // script prints native separators; a `package.json` path is always forward slashes.
+      expect(pkg.repository?.directory, `${pkg.name} declares no repository.directory`).toBe(
+        dir.split(/[\\\\/]/).join('/'),
+      );
+    }
   });
 
   it('pins internal dependencies to an exact version, never a range', () => {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.1",
   "type": "module",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Continuum-AI-Corp/OrcaReplay.git",
+    "directory": "packages/core"
+  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/fs-capture/package.json
+++ b/packages/fs-capture/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.1",
   "type": "module",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Continuum-AI-Corp/OrcaReplay.git",
+    "directory": "packages/fs-capture"
+  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/mcp-shim/package.json
+++ b/packages/mcp-shim/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.1",
   "type": "module",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Continuum-AI-Corp/OrcaReplay.git",
+    "directory": "packages/mcp-shim"
+  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/node-instrument/package.json
+++ b/packages/node-instrument/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.1",
   "type": "module",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Continuum-AI-Corp/OrcaReplay.git",
+    "directory": "packages/node-instrument"
+  },
   "description": "Capture model traffic from a JS agent that reads no base-URL variable",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/plugin-api/package.json
+++ b/packages/plugin-api/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.1",
   "type": "module",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Continuum-AI-Corp/OrcaReplay.git",
+    "directory": "packages/plugin-api"
+  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.1",
   "type": "module",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Continuum-AI-Corp/OrcaReplay.git",
+    "directory": "packages/providers"
+  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.1",
   "type": "module",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Continuum-AI-Corp/OrcaReplay.git",
+    "directory": "packages/proxy"
+  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.1",
   "type": "module",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Continuum-AI-Corp/OrcaReplay.git",
+    "directory": "packages/schema"
+  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/shell-shim/package.json
+++ b/packages/shell-shim/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.1",
   "type": "module",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Continuum-AI-Corp/OrcaReplay.git",
+    "directory": "packages/shell-shim"
+  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.1",
   "type": "module",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Continuum-AI-Corp/OrcaReplay.git",
+    "directory": "packages/viewer"
+  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {


### PR DESCRIPTION
## What this changes

Adds `repository` (url + `directory`) to the eleven packages that had none, and `directory` to the CLI, which had the url already. Plus a test that keeps it that way.

## Why

The `v0.1.1` tag fired `release.yml` and it failed on the first package:

```
npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/@orcareplay%2fnode-instrument
npm error Error verifying sigstore provenance bundle: Failed to validate repository information:
  package.json: "repository.url" is "", expected to match
  "https://github.com/Continuum-AI-Corp/OrcaReplay" from provenance
```

`npm publish --provenance` signs an attestation naming the repository, commit and workflow the build came from, and the registry refuses the upload unless the manifest agrees. An empty `repository.url` cannot agree with anything.

Nothing was published — the failure came first in the dependency order, so the registry is still on 0.1.0 and the state is clean.

This has been latent since the packages were written. It could not surface earlier because the only release so far was run by hand from a laptop, where `--provenance` is unavailable, so the field was never read.

## Tests

`publish-order.test.ts` gains `names the repository in every package, which provenance signing requires`. It walks the real publish order, and asserts each manifest declares the repository url and its own directory.

That file is the right home for it — its existing doc comment says a mistake in this area is "discovered at the worst possible moment — halfway through pushing irreversible versions to a public registry", which is precisely where this one surfaced.

Verified the way the rest of this branch's tests were: removing `repository` from one package reddens it for the stated reason —

```
× names the repository in every package, which provenance signing requires
  → @orcareplay/schema declares no repository.url: expected undefined to be 'https://github.com/…'
```

One wrinkle worth naming: `publish-order.mjs` prints native path separators, so on Windows the directory comparison needs normalising — a `package.json` path is always forward slashes. The test does that rather than assuming a platform.

## Checklist

- [x] `npm run check` passes locally
- [ ] Tests were written before the implementation — no. The failed release found it; the test was written straight after and proven red without the fix
- [x] Spec and schema updated together, if the trace format changed — n/a
- [x] No new runtime dependencies
- [x] Commits signed off

---

`v0.1.1` currently points at `bf478cc`, which cannot publish. After this merges the tag needs re-pointing at the new tip — nothing was published under it, so re-pointing costs nothing.
