### PR TITLE
stop the attention wash from covering the row it is drawing attention to

### DIFF
--- a/packages/viewer/src/css.ts
+++ b/packages/viewer/src/css.ts
@@ -350,13 +350,22 @@ footer {
 
 /* One-shot wash when playback lands on something that needs attention. No shadow — the design
    system uses hairlines and weight, never depth — and no hue, since state here is carried by
-   form. An overlay whose opacity animates stays on the compositor and never repaints the row. */
+   form. An overlay whose opacity animates stays on the compositor and never repaints the row.
+
+   opacity:0 is the base, and it is load-bearing rather than decorative. The overlay covers the
+   whole row in solid --ink; without a base it inherits the default of 1, and the only thing
+   holding it invisible is an animation that has not finished. When the animation ends the
+   opacity falls back to 1 and the row becomes a solid black bar with its text underneath —
+   permanently, because data-pulse is never taken off again. The rows this lands on are the
+   failures, which are the ones worth reading, so the wash meant to draw the eye to them hid
+   them instead. */
 .row { position: relative; }
 .row[data-pulse='true']::after {
   content: '';
   position: absolute;
   inset: 0;
   background: var(--ink);
+  opacity: 0;
   pointer-events: none;
   animation: orca-attention 420ms ease-out;
 }

--- a/packages/viewer/test/html.test.ts
+++ b/packages/viewer/test/html.test.ts
@@ -419,3 +419,33 @@ describe('detail panes', () => {
     expect(html).toContain('class="del"');
   });
 });
+
+/**
+ * A full-bleed overlay is invisible only while something holds it down. If that something is an
+ * animation, the element is opaque before the animation starts and again after it ends, because
+ * opacity falls back to its default of 1.
+ *
+ * That is not hypothetical. The attention wash on a timeline row covered the whole row in solid
+ * `--ink` and set its opacity only in `@keyframes`. Once playback landed on a row the animation
+ * ran for 420ms and then the row stayed a solid black bar with its text underneath — and
+ * `data-pulse` is never removed, so it never recovered. The rows it lands on are the failures,
+ * which are the ones worth reading.
+ */
+describe('full-bleed overlays', () => {
+  /** Every rule body in the stylesheet, paired with its selector. */
+  const rules = (): { selector: string; body: string }[] => {
+    const found: { selector: string; body: string }[] = [];
+    for (const m of VIEWER_CSS.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
+      found.push({ selector: m[1]!.trim(), body: m[2]! });
+    }
+    return found;
+  };
+
+  it('gives every one an explicit opacity, not one an animation happens to supply', () => {
+    const bare = rules()
+      .filter((r) => /inset:\s*0/.test(r.body) && /background:/.test(r.body))
+      .filter((r) => !/(^|[;\s])opacity\s*:/.test(r.body))
+      .map((r) => r.selector);
+    expect(bare).toEqual([]);
+  });
+});


### PR DESCRIPTION
<!-- orca-cr-summary:start -->
<!-- orca-code-review-summary -->
<!-- orca-cr-state: {"p0":0,"p1":0,"p2":0,"p3":0,"push":1} -->

## Orca-Code-Review — push 1

| Severity | Count |
|---|---|
| P0 | 0 |
| P1 | 0 |
| P2 | 0 |
| P3 | 0 |

✅ no blocking findings
<!-- orca-cr-summary:end -->

## What this changes

One base declaration on the timeline row's attention overlay, and a test for the shape of the mistake.

```diff
 .row[data-pulse='true']::after {
   content: '';
   position: absolute;
   inset: 0;
   background: var(--ink);
+  opacity: 0;
   pointer-events: none;
   animation: orca-attention 420ms ease-out;
 }
```

## Why

The overlay fills the whole row with solid `--ink` and sets its opacity only inside `@keyframes orca-attention` (`0.14` → `0`). An element's opacity defaults to `1` and there is no `animation-fill-mode`, so the wash is opaque before the animation starts and opaque again the instant it ends. Nothing takes `data-pulse` off again — `pulse()` only removes it to restart the animation on the same row — so the row stays a solid black bar with its text underneath, permanently.

The rows this lands on are the ones marked `data-tone="attention"`. In the example trace shipped in `examples/traces/` those are:

```
16  SHELL  shell result exit 1   8.4s
17  ERROR  error
```

The failure, and the command that caused it. The wash meant to draw the eye to them is what hides them.

Reproduced against an exported `run.html` by doing what a reader does — pressing play and waiting:

```
attention rows: 3
after playback: 2 rows still carry data-pulse
  ::after computed opacity = [ '1', '1' ]
```

With the fix, same state, `opacity = [ '0', '0' ]`, and both rows read normally.

### Why not white text on the bar

That was the first idea and it treats the symptom. The wash is specified as a 420 ms flash at 14 % opacity, not a block — painting the text to match would leave those rows looking permanently selected, and would invert in dark mode, where `--ink` is near-white and the bar is a white slab over dark text. The bug is that the overlay is visible at all once the animation is over.

## Tests

`html.test.ts` already checks stylesheet invariants as text (theme token parity, the `data-theme="light"` escape hatch, `body` painting its own ground), so the new one lives there:

**`full-bleed overlays > gives every one an explicit opacity, not one an animation happens to supply`** — any rule whose body sets `inset: 0` and a `background` must also set `opacity`. It asserts the general shape rather than this one selector, because the failure mode is structural: an overlay held down only by an animation is opaque whenever the animation is not running, which includes before it starts, after it ends, and under `prefers-reduced-motion` where the stylesheet disables animations outright.

Proven red without the fix, naming the offender:

```
× gives every one an explicit opacity, not one an animation happens to supply
  → expected [ ".row[data-pulse='true']::after" ] to deeply equal []
```

`npm run fmt:check` clean, `tsc --build` 0 errors, `packages/viewer` 123 passed.

## Checklist

- [x] `npm run check` passes locally
- [ ] Tests were written before the implementation — no. A reader reported the black bar; the fix and the test came after, and the test was proven red without the fix
- [x] Spec and schema updated together, if the trace format changed — n/a
- [x] No new runtime dependencies
- [x] Commits signed off
