### PR TITLE
give the npm page something to say, and stop telling people it is unpublished

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ orca replay last --from 4 --model claude-haiku-4-5 --ui
 The third line is the one people stay for: same files, same conversation prefix, different model
 from step 4 onward. The model is the only variable, which is what makes the answer mean anything.
 
-Not on npm yet — [install from source](#install), it takes about a minute.
+```console
+npm i -g orcareplay
+```
 
 ## Why this exists
 
@@ -592,21 +594,28 @@ exactly. Reading a run is unaffected either way: `orca show` and the viewer are 
 
 ## Install
 
-Not on npm yet — the packages are built and verified for it, but nothing has been published, so
-today it is from source:
+```console
+npm i -g orcareplay
+orca doctor                       # checks node, git, and which agents it can find
+```
+
+Node 20 or newer. No native dependencies, so there is nothing to compile and nothing fetched at
+install time beyond the tarballs themselves.
+
+Every release from 0.1.1 onward is published by the tagged workflow in
+[`RELEASING.md`](RELEASING.md), with a provenance attestation naming the commit and the run that
+built it — npm shows it on the package page, and `npm audit signatures` checks it.
+
+**From source**, to work on it or to run an unreleased commit:
 
 ```console
 git clone https://github.com/Continuum-AI-Corp/OrcaReplay && cd OrcaReplay
 npm ci && npm run build
 npm install -g ./packages/cli     # puts `orca` (and `orcareplay`) on PATH
-orca doctor                       # checks node, git, and which agents it can find
 ```
 
 `npm install -g .` from the repository root installs nothing: the root is a workspace with no
 binary of its own, and `orca` lives in `packages/cli`.
-
-The moment `v0` is published, `npx orcareplay doctor` is the whole install and this section will say
-so instead. The release is a tagged, gated workflow — see [`RELEASING.md`](RELEASING.md).
 
 **Node 20+ to run it** (the CLI's own `engines` says `>=20.0.0`). Contributing needs `^20.19.0 ||
 >=22.12.0`, because the test toolchain does; the root `package.json` declares that separately so

--- a/docs/i18n/README.ar.md
+++ b/docs/i18n/README.ar.md
@@ -43,7 +43,9 @@ orca replay last --from 4 --model claude-haiku-4-5 --ui
 السطر الثالث هو ما يجعل الناس يبقون: الملفات نفسها، وبادئة المحادثة نفسها، ونموذج مختلف ابتداءً من
 الخطوة 4. النموذج هو المتغيّر الوحيد، وهذا ما يجعل للإجابة معنى.
 
-ليس على npm بعد — [ثبّته من المصدر](#التثبيت)، يستغرق نحو دقيقة.
+```console
+npm i -g orcareplay
+```
 
 ## لماذا وُجد هذا
 
@@ -466,7 +468,10 @@ const timeline = await orca.show('last');
 
 ## التثبيت
 
-ليس على npm بعد — الحزم مبنيّة ومُتحقَّق منها لذلك، لكن لم يُنشر شيء، فاليوم يكون التثبيت من المصدر:
+```console
+npm i -g orcareplay
+orca doctor
+```
 
 ```console
 git clone https://github.com/Continuum-AI-Corp/OrcaReplay && cd OrcaReplay

--- a/docs/i18n/README.de.md
+++ b/docs/i18n/README.de.md
@@ -43,7 +43,9 @@ Die dritte Zeile ist die, wegen der man bleibt: dieselben Dateien, dasselbe Gesp
 Schritt 4 ein anderes Modell. Das Modell ist die einzige Variable — und genau das gibt der Antwort
 ihre Bedeutung.
 
-Noch nicht auf npm — [aus dem Quellcode installieren](#installation), dauert etwa eine Minute.
+```console
+npm i -g orcareplay
+```
 
 ## Warum es das gibt
 
@@ -505,8 +507,10 @@ Früh. `v0` ist das lauffähige Gerüst der drei Befehle oben.
 
 ## Installation
 
-Noch nicht auf npm — die Pakete sind gebaut und dafür geprüft, aber nichts ist veröffentlicht, also
-heute aus dem Quellcode:
+```console
+npm i -g orcareplay
+orca doctor
+```
 
 ```console
 git clone https://github.com/Continuum-AI-Corp/OrcaReplay && cd OrcaReplay

--- a/docs/i18n/README.es.md
+++ b/docs/i18n/README.es.md
@@ -44,7 +44,9 @@ La tercera línea es por la que la gente se queda: los mismos archivos, el mismo
 conversación, otro modelo a partir del paso 4. El modelo es la única variable, y eso es lo que hace
 que la respuesta signifique algo.
 
-Todavía no está en npm — [instálalo desde el código](#instalación), tarda cosa de un minuto.
+```console
+npm i -g orcareplay
+```
 
 ## Por qué existe
 
@@ -500,8 +502,10 @@ Temprano. `v0` es el esqueleto que camina de los tres comandos de arriba.
 
 ## Instalación
 
-Todavía no está en npm — los paquetes están construidos y verificados para ello, pero no se ha
-publicado nada, así que hoy es desde el código:
+```console
+npm i -g orcareplay
+orca doctor
+```
 
 ```console
 git clone https://github.com/Continuum-AI-Corp/OrcaReplay && cd OrcaReplay

--- a/docs/i18n/README.fr.md
+++ b/docs/i18n/README.fr.md
@@ -44,7 +44,9 @@ C'est la troisième ligne qui retient les gens : mêmes fichiers, même préfixe
 modèle différent à partir de l'étape 4. Le modèle est la seule variable, et c'est ce qui donne un
 sens à la réponse.
 
-Pas encore sur npm — [installez depuis les sources](#installation), il faut une minute environ.
+```console
+npm i -g orcareplay
+```
 
 ## Pourquoi cet outil existe
 
@@ -506,8 +508,10 @@ Précoce. `v0` est le squelette qui marche des trois commandes ci-dessus.
 
 ## Installation
 
-Pas encore sur npm — les paquets sont construits et vérifiés pour, mais rien n'est publié ;
-aujourd'hui c'est donc depuis les sources :
+```console
+npm i -g orcareplay
+orca doctor
+```
 
 ```console
 git clone https://github.com/Continuum-AI-Corp/OrcaReplay && cd OrcaReplay

--- a/docs/i18n/README.ja.md
+++ b/docs/i18n/README.ja.md
@@ -41,7 +41,9 @@ orca replay last --from 4 --model claude-haiku-4-5 --ui
 人が留まる理由は3行目にある。同じファイル、同じ会話の前半、ステップ4から先だけ別のモデル。
 変数はモデルだけ——だからこそ答えに意味が出る。
 
-npm 未公開——[ソースからインストール](#インストール)、1分ほど。
+```console
+npm i -g orcareplay
+```
 
 ## なぜ作ったのか
 
@@ -476,7 +478,10 @@ const timeline = await orca.show('last');
 
 ## インストール
 
-npm 未公開——パッケージはビルドも検証も済んでいるが公開はしていないので、今日のところはソースから:
+```console
+npm i -g orcareplay
+orca doctor
+```
 
 ```console
 git clone https://github.com/Continuum-AI-Corp/OrcaReplay && cd OrcaReplay

--- a/docs/i18n/README.ko.md
+++ b/docs/i18n/README.ko.md
@@ -41,7 +41,9 @@ orca replay last --from 4 --model claude-haiku-4-5 --ui
 사람들이 머무는 이유는 세 번째 줄이다. 같은 파일, 같은 대화 앞부분, 4단계부터만 다른 모델.
 변수는 모델 하나뿐이고, 그래서 답에 의미가 생긴다.
 
-아직 npm에 없다 — [소스에서 설치](#설치), 1분쯤 걸린다.
+```console
+npm i -g orcareplay
+```
 
 ## 왜 만들었나
 
@@ -469,7 +471,10 @@ const timeline = await orca.show('last');
 
 ## 설치
 
-아직 npm에 없다 — 패키지는 빌드와 검증까지 끝났지만 게시하지 않았으므로 오늘은 소스에서:
+```console
+npm i -g orcareplay
+orca doctor
+```
 
 ```console
 git clone https://github.com/Continuum-AI-Corp/OrcaReplay && cd OrcaReplay

--- a/docs/i18n/README.zh-CN.md
+++ b/docs/i18n/README.zh-CN.md
@@ -40,7 +40,9 @@ orca replay last --from 4 --model claude-haiku-4-5 --ui
 第三行才是让人留下来的那条：同样的文件、同样的对话前缀，从第 4 步起换一个模型。模型是唯一的变量，
 这正是答案有意义的原因。
 
-还没发到 npm——请[从源码安装](#安装)，大约一分钟。
+```console
+npm i -g orcareplay
+```
 
 ## 为什么会有这个东西
 

--- a/docs/launch-path.md
+++ b/docs/launch-path.md
@@ -53,10 +53,12 @@ traffic is captured too, through the runtime hook in W3.4.
 
 ## 1. One-command install
 
-The cheapest blocker on the list. What is missing is the npm name, a token and a tag.
+The cheapest blocker on the list. **W1.1 is done**: `orcareplay` and the `@orcareplay` scope are
+claimed, `NPM_TOKEN` is in place, and 0.1.1 was published by the tagged workflow with a provenance
+attestation. `npm i -g orcareplay` is the install.
 
-The README says "Not on npm yet" twice in the first screen. For a tool asking to sit inside an
-agent loop, that line costs more trust than the install friction it explains.
+The README used to say "Not on npm yet" twice in the first screen, and the seven translations said
+it too. Those lines are gone. What is left of this section is W1.2 to W1.4.
 
 | | Work | Done when |
 |---|---|---|

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,104 @@
+# OrcaReplay
+
+### Your agent broke something at 2am. Replay it at 9am — exactly, offline, as many times as you like.
+
+Record any coding agent. Reproduce the run byte-for-byte with the network off. Fork it from any
+step onto a different model and see who gets it right.
+
+<a href="https://www.orcarouter.ai">
+  <img src="https://raw.githubusercontent.com/Continuum-AI-Corp/OrcaReplay/main/docs/orcarouter.svg" alt="OrcaRouter" height="28" align="left" hspace="10">
+</a>
+
+**Built by the team behind [OrcaRouter](https://www.orcarouter.ai)** — one API key and one endpoint
+for Claude, GPT, Gemini, Grok, DeepSeek, Qwen and the rest. It is what `orca setup` points at by
+default, and what makes `orca compare` a single command instead of four provider accounts.
+
+[All models](https://www.orcarouter.ai/models) · [OrcaCode Review](https://www.orcarouter.ai/code-review) · [X](https://x.com/OrcaRouter) · [Hugging Face](https://huggingface.co/orcarouter)
+
+<br clear="left">
+
+![Recording a Claude Code run, replaying it offline, then forking it onto two models](https://raw.githubusercontent.com/Continuum-AI-Corp/OrcaReplay/main/docs/demo-cli.gif)
+
+<sup>Real output from one session — a Claude Code run recorded, replayed with the network off, then
+forked at checkpoint 4 onto two models and graded by `npx tsc --noEmit`. Nothing here is mocked
+up.</sup>
+
+## Install
+
+```console
+npm i -g orcareplay
+orca doctor          # checks this machine can record at all
+```
+
+Node 20 or newer. No native dependencies — nothing to compile, nothing to download at install time.
+
+## Three commands
+
+```console
+orca record claude              # your agent, unmodified, doing whatever it does
+orca replay last                # the same run again — no network, no tokens, no charge
+orca replay last --from 4 --model claude-haiku-4-5 --ui
+```
+
+The third line is the one people stay for: same files, same conversation prefix, different model
+from step 4 onward. The model is the only variable, which is what makes the answer mean anything.
+
+## What it gives you
+
+**A timeline of what actually happened.** Every model turn with its token counts and stop reason,
+every tool call with its arguments and result, every shell command with its exit code, every file
+the run touched.
+
+```console
+$ orca show last
+SEQ  KIND   WHAT                          DETAIL
+12   TOOL   edit_file
+14   FILE   src/auth.ts                   modified +18 −4
+15   SHELL  ["npm","test","--","auth"]    /home/dev/api
+16   SHELL  shell result                  exit 1 · 8.4s
+17   ERROR  error
+```
+
+**What caused what.** Every edge says whether the recorder watched it happen or orca derived it
+just now, and names the rule either way.
+
+```console
+$ orca graph last --to 17
+FROM              TO                KIND      WHY
+12 tool.call      15 shell.exec     recorded  causes
+15 shell.exec     16 shell.result   recorded  shell result answers its exec
+16 shell.result   17 error          recorded  causes
+```
+
+**The same task on several models, graded by a command you choose.** Not a model marking its own
+homework — the verdict is the exit code of whatever you tell it to run, so the same prompt costs
+you a number you can act on rather than an opinion.
+
+```console
+$ orca compare last --from 4 --models claude-sonnet-5,claude-haiku-4-5 --verify "npx tsc --noEmit"
+MODEL                      VERDICT  TOKENS   COST       WALL
+claude-sonnet-5            pass     124/429  $0.006807  12.2s
+claude-haiku-4-5-20251001  pass     184/650  $0.003434  14.3s
+```
+
+Both passed here; the interesting column is what each one cost to get there.
+
+Plus a browser timeline (`orca ui`), a single self-contained HTML file you can attach to an issue
+(`orca export`), and shareable cards of one causal chain (`orca export --card`).
+
+## Which agents
+
+Claude Code, Codex, OpenCode, grok-cli, the Anthropic and OpenAI Agents SDKs, the Vercel AI SDK,
+and any harness that reads a base-URL environment variable — including ones this project has never
+heard of, via `ORCA_BASE_URL_VARS`. Harnesses that refuse to be redirected can be captured through
+TLS interception with a certificate authority minted for that one run and thrown away after it.
+
+`orca doctor` reports which of them it can find on your machine.
+
+## Full documentation
+
+**[github.com/Continuum-AI-Corp/OrcaReplay](https://github.com/Continuum-AI-Corp/OrcaReplay)** —
+the worked bug hunt, the trace format spec, the programmatic API, CI usage, what is stored and
+where, and the privacy model.
+
+Apache-2.0. The trace format spec is CC BY 4.0, so anything can read or write these traces.


### PR DESCRIPTION
<!-- orca-cr-summary:start -->
<!-- orca-code-review-summary -->
<!-- orca-cr-state: {"p0":0,"p1":0,"p2":0,"p3":0,"push":1} -->

## Orca-Code-Review — push 1

| Severity | Count |
|---|---|
| P0 | 0 |
| P1 | 0 |
| P2 | 0 |
| P3 | 0 |

✅ no blocking findings
<!-- orca-cr-summary:end -->

## What this changes

Two things, both documentation:

1. **`packages/cli/README.md`** — new. The npm package page for `orcareplay` was blank.
2. **"Not on npm yet"** — removed from the English README and all seven translations, because it stopped being true when 0.1.1 published.

## Why the npm page was blank

npm reads the README from the package's own directory. The repository README lives at the root, and `packages/cli/` had none, so the registry recorded:

```
readme: "ERROR: No README data found!"
```

The `description` and `keywords` fields were present, which is why the page had a title, a link and no body. `files: ["dist"]` was not the cause — npm includes a README regardless of `files`; there simply was not one to include. `npm pack --dry-run` now lists `4.6kB README.md`.

It is written for the npm page rather than copied from the root:

- **Absolute URLs.** npm does not resolve repository-relative image paths, so the OrcaRouter mark and the demo animation point at `raw.githubusercontent.com`.
- **OrcaRouter**, in the same words the root README uses — it is what `orca setup` points at by default and what makes `orca compare` a single command instead of four provider accounts, so a reader who lands on npm first should meet it there.
- **Real output only.** The timeline and the causal chain are from the trace in `examples/traces/`; the compare table is the transcript behind the README animation. An earlier draft of this file invented a failing row to make the comparison look more interesting, which is precisely what the animation's own caption ("Nothing here is mocked up") forbids. It was replaced with what the run actually printed — both models passed, and the column worth reading is cost.

## Why the stale claim mattered

`docs/launch-path.md` already names it:

> The README says "Not on npm yet" twice in the first screen. For a tool asking to sit inside an agent loop, that line costs more trust than the install friction it explains.

Both occurrences are gone, along with the equivalent in `ar`, `de`, `es`, `fr`, `ja`, `ko` and `zh-CN`. The install section leads with `npm i -g orcareplay` and mentions the provenance attestation; the source instructions are kept, framed as how to work on the project or run an unreleased commit.

`launch-path.md`'s W1.1 — claim the name and the scope, add `NPM_TOKEN`, dry-run the workflow, tag — is what shipped this morning, so that section says so instead of describing it as pending.

### Note on the translations

The false sentence is replaced by a console block, which reads the same in every language. The surrounding prose in six of them was written when source install was the only path and would benefit from a pass by someone who reads those languages; this change only removes the statement that is now wrong.

## Tests

None — documentation. Checked what could be checked:

- `npm pack --dry-run` in `packages/cli` lists the README; package goes from 132.7 kB to 148.9 kB.
- Every console block in the new README matched against the run that produced it.
- `tsc --build` 0 errors, `fmt:check` clean, `publish-order` and `viewer` suites pass (127).
- No occurrence of the stale claim left anywhere under `--include=*.md`.

## Checklist

- [x] `npm run check` passes locally
- [ ] Tests were written before the implementation — n/a, documentation
- [x] Spec and schema updated together, if the trace format changed — n/a
- [x] No new runtime dependencies
- [x] Commits signed off
