### PR TITLE
make a row that needs attention a band, and keep every other state readable on it

### DIFF
--- a/packages/viewer/src/css.ts
+++ b/packages/viewer/src/css.ts
@@ -348,18 +348,53 @@ footer {
 .pane[data-dir='down'] { animation: orca-enter-down 130ms cubic-bezier(0.2, 0, 0, 1); }
 .pane[data-dir='up'] { animation: orca-enter-up 130ms cubic-bezier(0.2, 0, 0, 1); }
 
-/* One-shot wash when playback lands on something that needs attention. No shadow — the design
-   system uses hairlines and weight, never depth — and no hue, since state here is carried by
-   form. An overlay whose opacity animates stays on the compositor and never repaints the row. */
+/* A row that needs attention is a band: the ground and the ink trade places. Keyed on data-tone,
+   which is what the row *is*, rather than on data-pulse, which only says playback happened to land
+   here — two failures otherwise render differently depending on how far someone pressed play.
+
+   Every state that the rest of the table carries in background has to be restated here, because a
+   band already owns that channel: selection moves to the rail, hover lifts the band rather than
+   replacing it, and the wash inverts. Leaving any of them out makes the row that matters most the
+   one you cannot tell anything about. */
 .row { position: relative; }
+.row[data-tone='attention'] { background: var(--ink); }
+.row[data-tone='attention'],
+.row[data-tone='attention'] .label,
+.row[data-tone='attention'] .detail,
+.row[data-tone='attention'] .meta,
+.row[data-tone='attention'] .seq { color: var(--ground); }
+/* The chip is already inverted against the paper, so on a band it inverts back. */
+.row[data-tone='attention'] .chip.attention { background: var(--ground); color: var(--ink); }
+.row[data-tone='attention'] .chip.normal,
+.row[data-tone='attention'] .chip.quiet { border-color: var(--ink-3); color: var(--ground); }
+
+/* Selection: the rail, not the ground. --ink on --ink is invisible. */
+.row[data-tone='attention'][aria-selected='true'] {
+  background: var(--ink);
+  border-left-color: var(--ground);
+  color: var(--ground);
+}
+/* Hover lifts the band instead of replacing it with --sunk, which would read as un-erroring it. */
+.row[data-tone='attention']:hover { background: var(--ink-2); }
+.row[data-tone='attention']:focus-visible { outline-color: var(--ground); }
+
+/* The playback wash, inverted so it reads on a band as it does on paper. No shadow — the design
+   system uses hairlines and weight, never depth — and no hue, since state here is carried by form.
+   An overlay whose opacity animates stays on the compositor and never repaints the row.
+
+   opacity:0 is the base and it is load-bearing: without it the element inherits the default of 1
+   and the only thing holding it invisible is an animation that has not finished, so the wash goes
+   solid the moment the animation ends and stays there, because data-pulse is never removed. */
 .row[data-pulse='true']::after {
   content: '';
   position: absolute;
   inset: 0;
   background: var(--ink);
+  opacity: 0;
   pointer-events: none;
   animation: orca-attention 420ms ease-out;
 }
+.row[data-tone='attention'][data-pulse='true']::after { background: var(--ground); }
 @keyframes orca-attention {
   from { opacity: 0.14; }
   to { opacity: 0; }


### PR DESCRIPTION
<!-- orca-cr-summary:start -->
<!-- orca-code-review-summary -->
<!-- orca-cr-state: {"p0":0,"p1":0,"p2":0,"p3":0,"push":1} -->

## Orca-Code-Review — push 1

| Severity | Count |
|---|---|
| P0 | 0 |
| P1 | 0 |
| P2 | 0 |
| P3 | 0 |

✅ no blocking findings
<!-- orca-cr-summary:end -->

## What this changes

A timeline row that needs attention is drawn as a band — the ground and the ink trade places — and
every other state the row can be in is restated so it survives on top of it.

`packages/viewer/src/css.ts` only. 38 lines added, 3 removed.

## Why

Two things, and they have to be done together.

**The wash was covering the rows it existed to point at.** `.row[data-pulse='true']::after` fills the
row with solid `--ink` and sets its opacity only inside `@keyframes`. An element's opacity defaults
to `1` and there is no `animation-fill-mode`, so the overlay is opaque before the animation starts
and opaque again the moment it ends. Nothing removes `data-pulse` afterwards, so the row stays a
solid black bar with its text underneath, permanently. Reproduced by pressing play on an exported
`run.html` and waiting: two rows keep `data-pulse` and their `::after` computes to `opacity: 1`.

**And the wash was the wrong place for the state anyway.** `data-pulse` means playback landed here.
The thing that means "this row is a failure" is `data-tone="attention"`. Keying the appearance on
the former makes two identical rows look different depending on how far someone pressed play — in
the trace shipped in `examples/traces/`, `shell result exit 1` and `error` come out banded while
`run ended exit 1`, the same kind of row, stays plain:

```
attention rows:
  seq 16  banded   shell result exit 1
  seq 17  banded   error
  seq 25  plain    run ended exit 1     ← playback had not reached it
```

## The part that took the work

A band owns the background channel, and the table was using that channel for everything else. Each
one had to move somewhere the band does not sit, or it is lost on precisely the row worth reading:

| state | before | now |
|---|---|---|
| selected | `background: var(--paper)` + `border-left-color: var(--ink)` | rail in `--ground`; `--ink` on `--ink` was invisible, so a selected failure gave no sign at all |
| hover | `background: var(--sunk)` | band lifts to `--ink-2`; `--sunk` would read as the row un-erroring itself |
| chips | `.chip.attention` already inverts against paper | inverts back on a band, so it does not vanish |
| the wash | `--ink` | `--ground`, so it still reads |
| focus ring | `outline: 2px solid var(--ink)` | `--ground` |

Measured rather than eyeballed, in both themes:

```
[light]  band  bg=rgb(10,12,13)     text=rgb(243,245,245)
         sel   rail=rgb(243,245,245)
         hover bg=rgb(85,93,96)
[dark]   band  bg=rgb(233,237,237)  text=rgb(17,21,23)
         sel   rail=rgb(17,21,23)
         hover bg=rgb(152,162,165)
```

Every value comes from a token, so the dark theme is the same design with the pair swapped rather
than a second design that happens to look right.

## Tests

`packages/viewer` passes (122). No new test in this commit, and that is worth saying plainly: the
invariant worth adding is that a rule which paints `background` on a row must also name `color`,
which is the shape of the bug this replaces — a background set without the foreground that has to
survive it. It belongs in `html.test.ts` beside the existing stylesheet invariants. Say the word
and I will add it here rather than as a follow-up.

`tsc --build` 0 errors, `fmt:check` clean.

## Two judgement calls for the reviewer

**How much black is too much.** The example trace is 3 banded rows out of 26. A run that failed
repeatedly will be a lot of band. Narrowing this to `error` rows only, rather than every
`attention` row, is a one-selector change if that reads better on a real failing run.

**Hover on a selected band.** `:hover` comes after the selected rule, so a selected row under the
cursor takes the hover background and keeps its rail. That seemed right — the rail is the selection
signal — but it is a choice, not a law.

## Checklist

- [x] `npm run check` passes locally
- [ ] Tests were written before the implementation — no, and none added; see Tests above
- [x] Spec and schema updated together, if the trace format changed — n/a
- [x] No new runtime dependencies
- [x] Commits signed off
