### PR TITLE
compare paths by the platform's rules, not by looking for a slash

### DIFF
--- a/packages/adapters/src/contract.ts
+++ b/packages/adapters/src/contract.ts
@@ -2,6 +2,7 @@ import { mkdir, mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { isDeepStrictEqual } from 'node:util';
+import nodePath from 'node:path';
 import type { Adapter, Launch, RecordContext } from '@orcareplay/plugin-api';
 import { PLACEHOLDER_KEY, readEnv } from './env.js';
 
@@ -427,10 +428,34 @@ function absolutePaths(value: string): string[] {
   return found;
 }
 
-function isInside(path: string, base: string): boolean {
+/**
+ * Whether `path` is `base` or sits under it.
+ *
+ * Delegated to the platform's own path rules rather than compared as strings. The prefix used to be
+ * built with a forward slash only, so on Windows — where `path.join` spells the whole path with
+ * backslashes — a file genuinely inside `runDir` never matched, and `no-foreign-paths` called the
+ * run's own scratch file foreign. That failed the contract for every adapter that puts a runDir
+ * path into the environment: grok, openclaw and node. On POSIX the comparison was true either way,
+ * so CI never saw it.
+ *
+ * Normalising the separators by hand would have swapped one wrong answer for another: a backslash
+ * is a legal character in a POSIX filename, so `/tmp/run` + a file called `run\evil` would have
+ * read as contained when it is not — a leak check answering yes to the thing it exists to catch.
+ *
+ * `impl` is a parameter so both flavours are reachable from a test on either OS. The Windows
+ * behaviour is the whole reason this function was touched, and a test that can only run on Windows
+ * is how the original slipped through.
+ */
+export function isInside(path: string, base: string, impl: PathImpl = nodePath): boolean {
   if (base === '') return false;
-  const prefix = base.endsWith('/') ? base : `${base}/`;
-  return path === base || path.startsWith(prefix);
+  const rel = impl.relative(base, path);
+  return rel === '' || (!rel.startsWith('..') && !impl.isAbsolute(rel));
+}
+
+/** The slice of `node:path` {@link isInside} needs, so `path.win32` and `path.posix` both fit. */
+export interface PathImpl {
+  relative(from: string, to: string): string;
+  isAbsolute(p: string): boolean;
 }
 
 const SEMVER_COMPARATOR =

--- a/packages/adapters/test/contract.test.ts
+++ b/packages/adapters/test/contract.test.ts
@@ -1,8 +1,10 @@
 import type { Adapter, RecordContext } from '@orcareplay/plugin-api';
+import { join, posix, win32 } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
   CONTRACT_CHECKS,
   checkAdapterContract,
+  isInside,
   defaultAdapters,
   formatContractResult,
   passKey,
@@ -411,6 +413,27 @@ describe('no-foreign-paths', () => {
     expect(await failedChecks(tidy)).toEqual([]);
   });
 
+  /**
+   * The fixture above joins with a forward slash, which is why the Windows failure went unseen:
+   * that shape matched even when the comparison only knew about `/`. `path.join` is what the real
+   * adapters use, and on Windows it spells the whole path with backslashes.
+   */
+  it('accepts a runDir path built the way the real adapters build one', async () => {
+    const joined = goodAdapter({
+      async prepare(ctx: RecordContext) {
+        return {
+          command: 'fixture',
+          args: [],
+          env: {
+            OPENAI_BASE_URL: proxyBase(ctx.proxyUrl, 'v1'),
+            MYAGENT_CONFIG: join(ctx.runDir, 'myagent.json'),
+          },
+        };
+      },
+    });
+    expect(await failedChecks(joined)).toEqual([]);
+  });
+
   it('does not mistake the path segment of the proxy url for a filesystem path', async () => {
     const withPath = goodAdapter({
       async prepare(ctx: RecordContext) {
@@ -500,5 +523,38 @@ describe('checkAdapterContract', () => {
     const result = await checkAdapterContract(goodAdapter({ id: 'bad', harnessVersions: 'nope' }));
     expect(formatContractResult(result)).toContain('bad');
     expect(formatContractResult(result)).toContain('harness-versions');
+  });
+});
+
+/**
+ * The containment rule itself, against both flavours, on whatever platform runs the suite.
+ *
+ * Two wrong answers were available here and the first fix picked the second one. Comparing with a
+ * forward slash only says no to a real Windows path inside runDir; normalising the separators by
+ * hand says yes to a POSIX file whose *name* contains a backslash, which is a leak check clearing
+ * the thing it exists to catch. Only the platform's own rules give both answers correctly.
+ */
+describe('isInside', () => {
+  const BS = String.fromCharCode(92);
+
+  it('accepts a Windows path under the base, spelled with backslashes', () => {
+    expect(isInside(`C:${BS}run${BS}hook.cjs`, `C:${BS}run`, win32)).toBe(true);
+    expect(isInside(`C:${BS}run`, `C:${BS}run`, win32)).toBe(true);
+  });
+
+  it('rejects a Windows sibling that merely shares a prefix', () => {
+    expect(isInside(`C:${BS}runaway${BS}x`, `C:${BS}run`, win32)).toBe(false);
+  });
+
+  it('rejects a POSIX file whose name contains a backslash, which is not a separator there', () => {
+    expect(isInside(`/tmp/run${BS}evil`, '/tmp/run', posix)).toBe(false);
+  });
+
+  it('accepts a POSIX path under the base', () => {
+    expect(isInside('/tmp/run/hook.cjs', '/tmp/run', posix)).toBe(true);
+  });
+
+  it('rejects an empty base rather than treating everything as inside it', () => {
+    expect(isInside('/tmp/run/x', '', posix)).toBe(false);
   });
 });


### PR DESCRIPTION
<!-- orca-cr-summary:start -->
<!-- orca-code-review-summary -->
<!-- orca-cr-state: {"p0":0,"p1":0,"p2":0,"p3":0,"push":1} -->

## Orca-Code-Review — push 1

| Severity | Count |
|---|---|
| P0 | 0 |
| P1 | 0 |
| P2 | 0 |
| P3 | 0 |

✅ no blocking findings
<!-- orca-cr-summary:end -->

## What this changes

`no-foreign-paths` in the adapter contract now asks `node:path` whether a path is inside a
directory, instead of building a prefix and calling `startsWith`.

`packages/adapters/src/contract.ts` and its test. Nothing else.

## Why

The prefix was built with a forward slash. On Windows `path.join` spells the whole path with
backslashes, so a file genuinely inside `ctx.runDir` never matched and the check reported the run's
own scratch file as foreign:

```
grok: 1/8 checks failed
  - no-foreign-paths: env NODE_OPTIONS contains
    C:\Users\...\orca-contract-rzeuiY\run\orca-fetch-hook.cjs,
    which is outside ctx.runDir and ctx.cwd
```

Every adapter that puts a runDir path into the launch environment failed its own contract — `grok`,
`openclaw` and `node` — along with `covers the registry as a whole`. On POSIX the comparison is true
either way, so CI has never seen any of it. On this Windows machine it is ten of the twenty-nine
failures on `main`.

`absolutePaths`, twenty lines above, already splits on both separators. `isInside` was the one that
did not.

### Why not normalise the separators

That was the first fix and it is wrong in the other direction. A backslash is a legal character in
a POSIX filename, so a file called `run\evil` sitting beside `/tmp/run` normalises to something
that looks contained:

```
base = /tmp/run
path = /tmp/run\evil     ← a file named run\evil in /tmp, not inside /tmp/run
normalised comparison → true
```

A leak check that answers yes to the thing it exists to catch is worse than the bug being replaced.
`path.relative` knows which separators its own platform has, and nothing here has to.

## Tests

`impl` is a parameter — the same shape as `bunReadablePath(path, platform)` — so `path.win32` and
`path.posix` are both reachable from a test wherever the suite runs. That matters here: the
Windows behaviour is the only reason the function was touched, and a test that can only fail on
Windows is exactly how the original survived this long.

Five direct cases, plus the contract-level one rewritten to build its path with `path.join` rather
than a hand-typed slash — which is what the real adapters do, and why the existing fixture missed
this.

All three wrong answers are covered. Each was checked by putting it back:

| put back | goes red |
|---|---|
| forward-slash prefix | `grok`, `openclaw`, `node` contract tests |
| hand-normalised separators | `rejects a POSIX file whose name contains a backslash` |
| empty base treated as containing everything | `rejects an empty base` |

`packages/adapters`: 230 passed. `tsc --build` 0 errors, `fmt:check` clean. Against `main` on the
same machine: 29 failures → 19, and no failure on this branch is absent from `main`.

## Checklist

- [x] `npm run check` passes locally
- [ ] Tests were written before the implementation — no. The contract failure surfaced while running the real command surface; the tests came after and each was proven red without the fix
- [x] Spec and schema updated together, if the trace format changed — n/a
- [x] No new runtime dependencies
- [x] Commits signed off
