### PR TITLE
refuse a positional argument the command does not read

### DIFF
--- a/packages/cli/src/flags.ts
+++ b/packages/cli/src/flags.ts
@@ -104,3 +104,74 @@ export function assertKnownFlags(args: ParsedArgs): void {
       `\n  flags for this command: ${allowed.length === 0 ? '(none)' : allowed.map((f) => `--${f}`).join(' ')}`,
   );
 }
+
+/**
+ * How many positional arguments each command reads.
+ *
+ * Counted from the `positionals[0]` call sites, the same way the flag list above is counted from
+ * the `args.*` ones. `record` reads an agent name and the run commands read a selector; the seven
+ * that read none genuinely take none — `attach` is configured entirely by flags, and `list`, `gc`,
+ * `doctor`, `setup`, `models` and `mcp` take nothing at all.
+ */
+const POSITIONALS: Record<string, number> = {
+  record: 1,
+  replay: 1,
+  compare: 1,
+  show: 1,
+  events: 1,
+  checkpoints: 1,
+  graph: 1,
+  export: 1,
+  ui: 1,
+  scrub: 1,
+  attach: 0,
+  list: 0,
+  gc: 0,
+  doctor: 0,
+  setup: 0,
+  models: 0,
+  mcp: 0,
+  help: 0,
+};
+
+/** Exposed so a test can hold {@link POSITIONALS} against the source it mirrors. */
+export const POSITIONAL_COUNTS: Readonly<Record<string, number>> = POSITIONALS;
+
+/**
+ * Reject a positional argument the command does not read.
+ *
+ * The parser collects every token that is not a flag, and each command reads at most the first.
+ * Anything past that was dropped in silence — and for `record` that is the worst shape available:
+ * the arguments meant for the agent never reach it, the harness starts with none, and orca reports
+ * a successful recording of a run that was never asked to do anything.
+ *
+ *   orca record codex exec "fix auth.ts"    ->  manifest argv: ["codex"]
+ *
+ * The agent's own arguments go after `--`, which is the one thing that message has to say. Counting
+ * per command rather than allowing one everywhere matters for the seven that read none: `orca
+ * attach claude` looks like it names the agent, and `--for` is what actually does.
+ */
+export function assertNoStrayPositionals(args: ParsedArgs): void {
+  // An unknown command is the dispatcher's to report, as above.
+  const takes = POSITIONALS[args.command];
+  if (takes === undefined) return;
+  const stray = args.positionals.slice(takes);
+  if (stray.length === 0) return;
+
+  const quote = (a: string): string => (/\s/.test(a) ? `"${a}"` : a);
+  const listed = stray.map(quote).join(' ');
+  const takesLine =
+    takes === 0
+      ? `\n  "orca ${args.command}" takes no arguments; everything it needs is a flag`
+      : `\n  "orca ${args.command}" takes one: ${quote(args.positionals[0]!)}`;
+  // Only `record` hands its tail to something else, so only `record` can say where the tail goes.
+  const forAgent =
+    args.command === 'record'
+      ? `\n  arguments for the agent go after --: orca record ${quote(args.positionals[0]!)} -- ${listed}`
+      : '';
+  throw new Error(
+    `unexpected argument${stray.length > 1 ? 's' : ''} for "orca ${args.command}": ${listed}` +
+      takesLine +
+      forAgent,
+  );
+}

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -1,4 +1,4 @@
-import { assertKnownFlags } from './flags.js';
+import { assertKnownFlags, assertNoStrayPositionals } from './flags.js';
 import { parseArgs, type ParsedArgs } from './args.js';
 import { Orca } from './api.js';
 import { serveMcp } from './mcp-server.js';
@@ -154,6 +154,9 @@ export async function main(argv: string[], cwd = process.cwd()): Promise<number>
     // silently ignored, and a run that quietly did something else is the failure orca exists to
     // surface. Inside the try so it is reported the same way every other failure is.
     assertKnownFlags(args);
+    // Same reasoning, other half of the command line: an argument nothing reads is an
+    // instruction that went nowhere, and for `record` it is the agent's own arguments.
+    assertNoStrayPositionals(args);
 
     switch (args.command) {
       case 'record':

--- a/packages/cli/test/flags.test.ts
+++ b/packages/cli/test/flags.test.ts
@@ -1,9 +1,15 @@
-import { readFileSync, readdirSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { parseArgs } from '../src/args.js';
-import { BY_COMMAND, GLOBAL, assertKnownFlags } from '../src/flags.js';
+import {
+  BY_COMMAND,
+  GLOBAL,
+  POSITIONAL_COUNTS,
+  assertKnownFlags,
+  assertNoStrayPositionals,
+} from '../src/flags.js';
 
 /**
  * A flag is an instruction. The parser takes any it is given, which is right for parsing and wrong
@@ -107,5 +113,119 @@ describe('the allowlist against the source it mirrors', () => {
     // silently, which is the failure this whole file exists to prevent.
     const unvalidated = dispatched.filter((c) => BY_COMMAND[c] === undefined).sort();
     expect(unvalidated).toEqual([]);
+  });
+});
+
+/**
+ * The other half of the command line. `orca record codex exec "fix auth.ts"` recorded
+ * `argv: ["codex"]` — the agent started with no arguments at all, did nothing it was asked, and
+ * the run was reported as a success. Nothing in the output said the words had been dropped.
+ */
+describe('assertNoStrayPositionals', () => {
+  const check = (argv: string[]) => () => assertNoStrayPositionals(parseArgs(argv));
+
+  it('rejects the agent arguments that were silently dropped, and shows where they go', () => {
+    expect(check(['record', 'codex', 'exec', 'fix auth.ts'])).toThrow(
+      /unexpected arguments for "orca record": exec "fix auth\.ts"/,
+    );
+    expect(check(['record', 'codex', 'exec', 'fix auth.ts'])).toThrow(
+      /orca record codex -- exec "fix auth\.ts"/,
+    );
+  });
+
+  it('leaves the correct form alone, because that is where the agent arguments belong', () => {
+    expect(check(['record', 'codex', '--', 'exec', 'fix auth.ts'])).not.toThrow();
+    expect(check(['record', 'claude'])).not.toThrow();
+    expect(check(['record'])).not.toThrow();
+  });
+
+  it('rejects a stray on a read command too, without offering the -- advice', () => {
+    expect(check(['show', 'last', 'extra'])).toThrow(/unexpected argument for "orca show": extra/);
+    expect(check(['show', 'last', 'extra'])).not.toThrow(/--/);
+  });
+
+  /**
+   * Seven commands read no positional at all, so allowing one everywhere would have left the same
+   * silence in place for them. `orca attach claude` reads as naming the agent and does not: the
+   * flag that names it is `--for`.
+   */
+  it('rejects the first argument on a command that reads none', () => {
+    expect(check(['attach', 'claude'])).toThrow(/unexpected argument for "orca attach": claude/);
+    expect(check(['attach', 'claude'])).toThrow(
+      /takes no arguments; everything it needs is a flag/,
+    );
+    expect(check(['list', 'foo'])).toThrow(/unexpected argument for "orca list": foo/);
+    expect(check(['doctor', 'foo'])).toThrow(/unexpected argument/);
+  });
+
+  it('leaves those commands alone when they are given none', () => {
+    expect(check(['attach', '--for', 'claude'])).not.toThrow();
+    expect(check(['list'])).not.toThrow();
+    expect(check(['gc', '--older-than', '7d'])).not.toThrow();
+  });
+
+  it('says nothing about an unknown command, which the dispatcher reports better', () => {
+    expect(check(['bogus', 'a', 'b'])).not.toThrow();
+  });
+
+  /**
+   * The rule is "one positional", and it holds only while no command reads further. Asserted
+   * against the source rather than trusted, so a command that starts taking two arguments fails
+   * here instead of having them rejected at the door.
+   */
+  it('holds because no command reads past the first positional', () => {
+    const src = join(dirname(fileURLToPath(import.meta.url)), '..', 'src');
+    const beyondFirst: string[] = [];
+    const walk = (dir: string): void => {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const path = join(dir, entry.name);
+        if (entry.isDirectory()) walk(path);
+        else if (entry.name.endsWith('.ts')) {
+          for (const m of readFileSync(path, 'utf8').matchAll(/positionals\[(\d+)\]/g)) {
+            if (Number(m[1]) > 0) beyondFirst.push(`${entry.name}: positionals[${m[1]}]`);
+          }
+        }
+      }
+    };
+    walk(src);
+    expect(beyondFirst).toEqual([]);
+  });
+});
+
+/**
+ * The counts are hand-written and the code they describe is not. These hold one against the other
+ * so a command that starts or stops reading a positional fails here rather than silently dropping
+ * an argument again.
+ */
+describe('the positional counts against the source they mirror', () => {
+  const SRC = join(dirname(fileURLToPath(import.meta.url)), '..', 'src');
+
+  it('gives a count to every command the flag list knows', () => {
+    const missing = Object.keys(BY_COMMAND)
+      .filter((c) => POSITIONAL_COUNTS[c] === undefined)
+      .sort();
+    expect(missing).toEqual([]);
+  });
+
+  it('never claims a command reads more than the source does', () => {
+    // A count above 1 would mean somewhere reads `positionals[1]`, and nothing does.
+    const overclaimed = Object.entries(POSITIONAL_COUNTS)
+      .filter(([, n]) => n > 1)
+      .map(([c]) => c);
+    expect(overclaimed).toEqual([]);
+  });
+
+  it('claims zero only for commands whose implementation reads none', () => {
+    // One file per command where the mapping is one to one; inspect.ts and main.ts serve several,
+    // so they are excluded rather than guessed at.
+    const wrong: string[] = [];
+    for (const [command, n] of Object.entries(POSITIONAL_COUNTS)) {
+      const file = join(SRC, 'commands', `${command}.ts`);
+      if (!existsSync(file)) continue;
+      const reads = readFileSync(file, 'utf8').includes('positionals[0]');
+      if (reads !== (n === 1))
+        wrong.push(`${command}: table says ${n}, source ${reads ? 'reads' : 'does not read'} one`);
+    }
+    expect(wrong).toEqual([]);
   });
 });


### PR DESCRIPTION
<!-- orca-cr-summary:start -->
<!-- orca-code-review-summary -->
<!-- orca-cr-state: {"p0":0,"p1":0,"p2":0,"p3":0,"push":1} -->

## Orca-Code-Review — push 1

| Severity | Count |
|---|---|
| P0 | 0 |
| P1 | 0 |
| P2 | 0 |
| P3 | 0 |

✅ no blocking findings
<!-- orca-cr-summary:end -->

## What this changes

`orca` now refuses a positional argument the command does not read, instead of dropping it.

`packages/cli/src/flags.ts`, one call in `main.ts` beside `assertKnownFlags`, and the test.

## Why

The parser collects every token that is not a flag; each command reads at most the first. Everything
past that went nowhere, silently. For `record` that is the worst shape available:

```
$ orca record codex exec "fix auth.ts"
info recording run=run_f8d69aa7a669 adapter=codex ...
info recorded  run=run_f8d69aa7a669 events=3 exit=1
```

```json
{ "argv": ["codex"] }
```

The agent starts with no arguments at all, does nothing it was asked, and the run is reported as
recorded. Nothing in the output says the words were dropped. It cost me most of an afternoon and I
only found it by reading a manifest.

Now:

```
$ orca record codex exec "fix auth.ts"
error record.failed
  unexpected arguments for "orca record": exec "fix auth.ts"
  "orca record" takes one: codex
  arguments for the agent go after --: orca record codex -- exec "fix auth.ts"
```

Same reasoning as `assertKnownFlags` sitting next to it, other half of the command line: *a flag is
an instruction, and carrying on having ignored one produces a run that did something other than
what was asked while reporting success.* An argument is an instruction too.

## Counted per command, not "one everywhere"

Seven commands read no positional at all — `attach` is configured entirely by flags, and `list`,
`gc`, `doctor`, `setup`, `models` and `mcp` take nothing. Allowing one everywhere would have left
the silence in place for exactly the case most likely to be typed:

```
$ orca attach claude
error attach.failed
  unexpected argument for "orca attach": claude
  "orca attach" takes no arguments; everything it needs is a flag
```

`orca attach claude` reads as naming the agent. `--for` is what actually names it.

Only `record` hands its tail to something else, so only `record` prints where the tail goes.

## Tests

The counts are hand-written and the code they describe is not, so three tests hold one against the
other rather than trusting the table:

- every command in the flag list has a count
- no count claims more than one, because nothing reads `positionals[1]`
- a count of zero is claimed only for a command whose file does not read one

Each was checked by breaking it: setting `attach: 1` reddens two, removing `scrub` from the table
reddens the first. Removing the call from `main.ts` puts the original behaviour back — `orca record
codex exec "..."` records `argv: ["codex"]` and reports success, which is how the fix was confirmed
to be the thing doing the work.

Verified against the real command surface, not only in unit tests: a Claude Code run recorded end to
end, then `list`, `show`, `checkpoints`, `graph`, `graph --to`, `replay`, `export` (html, `--card`,
`--graph-card`), `scrub --dry-run`, `gc --dry-run`, `models` and `mcp` all still behave. Docs were
checked too — `orca export last -o run.html` passes one positional, since `run.html` is the flag's
value.

`packages/cli/test/flags.test.ts`: 21 passed. `tsc --build` 0 errors, `fmt:check` clean, and no
failure on this branch is absent from `main`.

## One thing left alone

`orca record claude -p "hello"` is rejected by the flag check with `did you mean --mcp-config?`,
which is not useful — `-p` is Claude Code's flag, and the answer is `--` again. That is the other
half of the same confusion and it predates this change, so it is not touched here.

## Checklist

- [x] `npm run check` passes locally
- [ ] Tests were written before the implementation — no. The bug was found by reading a manifest after a recording that looked fine; the tests came after and were each proven red without the fix
- [x] Spec and schema updated together, if the trace format changed — n/a
- [x] No new runtime dependencies
- [x] Commits signed off
