### PR TITLE
proxy: decrypt HTTP/2 in tls-intercept

### DIFF
--- a/packages/cli/src/tls-capture.ts
+++ b/packages/cli/src/tls-capture.ts
@@ -288,6 +288,7 @@ export async function persistNetExchange(
       port: exchange.port,
       method: exchange.method,
       path: exchange.path,
+      ...(exchange.alpn === undefined ? {} : { alpn: exchange.alpn }),
       intercepted: true,
       headers: exchange.requestHeaders,
       truncated: exchange.requestTruncated,

--- a/packages/core/src/redaction.ts
+++ b/packages/core/src/redaction.ts
@@ -55,6 +55,14 @@ interface Rule {
  * Order matters: a PEM block or a JWT contains base64 that the narrower rules would otherwise
  * chew into pieces, leaving fragments of key material on disk.
  */
+/**
+ * Marks a recorded body held as base64 rather than as text.
+ *
+ * Written by the proxy when a body is not valid UTF-8, and honoured here so the encoding survives
+ * the trace. Kept in this module because the redactor and the proxy have to agree on it.
+ */
+export const BINARY_BODY_PREFIX = 'orca-base64:';
+
 const RULES: Rule[] = [
   {
     kind: 'private_key',
@@ -229,6 +237,15 @@ export class Redactor {
     for (const rule of RULES) {
       value = value.replace(rule.pattern, (m) => this.#hit(rule.kind, m, context, hits));
     }
+    // A body recorded as base64 is one long high-entropy run by construction, and the entropy
+    // scanner shredded a 14 KB Connect/protobuf response into 226 placeholders -- destroying it
+    // outright while protecting nothing, since a credential inside a binary body is not matchable
+    // once encoded anyway. The named rules above still run: those look for shapes, not randomness.
+    // `includes`, not `startsWith`: a body reaches the trace inside a JSON-encoded blob, so the
+    // marker sits one quote in. The marker is only ever written by the proxy around a body it
+    // base64-encoded itself, so its presence identifies the value rather than merely appearing in
+    // it.
+    if (value.includes(BINARY_BODY_PREFIX)) return value;
     return this.#scanEntropy(value, context, hits);
   }
 

--- a/packages/proxy/src/intercept.ts
+++ b/packages/proxy/src/intercept.ts
@@ -366,8 +366,19 @@ export function attachTlsIntercept(
 
     server.on('stream', (stream: ServerHttp2Stream, headers) => {
       void forwardH2(stream, headers).catch((err: unknown) => {
-        if (!stream.headersSent) stream.respond({ ':status': 502 });
-        stream.end(JSON.stringify({ error: { message: `orca tls-intercept h2: ${String(err)}` } }));
+        // Reported as well as answered, because the guard below returns without writing anything
+        // when the client has already gone -- and a failure nobody is left to receive is exactly
+        // the one worth having in the run's failure list.
+        reportH2(stream.session?.socket, err, 'forward');
+        // Guarded for the same reason as the response path: by the time a failure surfaces the
+        // client may be gone, and respond/end would then throw out of a rejection handler.
+        if (stream.destroyed) return;
+        try {
+          if (!stream.headersSent) stream.respond({ ':status': 502 });
+          stream.end(JSON.stringify({ error: { message: `orca tls-intercept h2: ${String(err)}` } }));
+        } catch {
+          stream.destroy();
+        }
       });
     });
 
@@ -391,12 +402,12 @@ export function attachTlsIntercept(
    * complaining -- "HTTP/2 keepalive ping timed out" -- with nothing on this side saying why, which
    * is the same blindness the HTTP/1.1 path avoids by reporting handshake failures.
    */
-  const reportH2 = (socket: unknown, reason: unknown): void => {
+  const reportH2 = (socket: unknown, reason: unknown, what = 'session'): void => {
     const target = targetOf(socket);
     options.onFailure?.({
       host: target?.host ?? 'unknown',
       port: target?.port ?? 0,
-      reason: `h2 session: ${String(reason)}`,
+      reason: `h2 ${what}: ${String(reason)}`,
     });
   };
   /**
@@ -439,18 +450,77 @@ export function attachTlsIntercept(
 
     const requestBody = new Capture(maxCaptured);
     const responseBody = new Capture(maxCaptured);
+    const contentEncoding =
+      typeof headers['content-encoding'] === 'string' ? headers['content-encoding'] : undefined;
+
+    // Replay answers from the recording and must never reach the origin. The HTTP/1.1 twin has
+    // consulted this hook since interception existed; without the same call here, a run recorded
+    // over HTTP/1.1 and replayed by a client that now negotiates h2 would be forwarded live --
+    // real model calls, on the caller's own credential, during what the operator ran offline.
+    if (options.onRequest) {
+      for await (const chunk of stream) requestBody.add(Buffer.from(chunk as Buffer));
+      const reply = await options.onRequest({
+        host: target.host,
+        port: target.port,
+        method,
+        path,
+        requestHeaders: recordableHeaders,
+        requestBytes: requestBody.buffer(),
+        requestTruncated: requestBody.truncated,
+      });
+      if (reply) {
+        if (stream.destroyed) return;
+        stream.respond({ ':status': reply.status, ...(reply.headers ?? {}) });
+        stream.end(reply.body);
+        counters.intercepted += 1;
+        return;
+      }
+      // The bounded capture size is also the maximum replayable request size: forwarding a
+      // truncated body upstream is worse than refusing clearly, which is what HTTP/1.1 does.
+      if (requestBody.truncated) {
+        throw new Error(`request exceeded capture limit of ${maxCaptured} bytes`);
+      }
+    }
 
     await new Promise<void>((resolve, reject) => {
       const upstream = upstreamH2(target).request(outbound);
+      let settled = false;
+      const finish = (): void => {
+        if (settled) return;
+        settled = true;
+        resolve();
+      };
 
-      stream.on('data', (chunk: Buffer) => {
-        requestBody.add(chunk);
-        if (!upstream.write(chunk)) {
-          stream.pause();
-          upstream.once('drain', () => stream.resume());
-        }
-      });
-      stream.on('end', () => upstream.end());
+      /**
+       * The client can go at any point, and every write after that throws.
+       *
+       * `stream.respond` on a destroyed stream raises ERR_HTTP2_INVALID_STREAM synchronously from
+       * inside an upstream event callback, where nothing catches it: the promise is already
+       * constructed, so the throw is an uncaught exception and the proxy exits. Reproduced against
+       * Node 22 with a client RST at 60 ms and an origin answering at 400 ms.
+       */
+      const abandon = (): void => {
+        upstream.destroy();
+        finish();
+      };
+      stream.on('aborted', abandon);
+      stream.on('close', abandon);
+
+      if (options.onRequest) {
+        // The hook above consumed the body, so replay the bytes it read rather than the stream.
+        upstream.end(requestBody.buffer());
+      } else {
+        stream.on('data', (chunk: Buffer) => {
+          requestBody.add(chunk);
+          if (!upstream.write(chunk)) {
+            stream.pause();
+            upstream.once('drain', () => stream.resume());
+          }
+        });
+        // Without this, a client that aborts mid-upload never emits `end`, `upstream.end()` is
+        // never called, and the origin waits for a body that will not arrive.
+        stream.on('end', () => upstream.end());
+      }
       stream.on('error', reject);
 
       upstream.on('error', reject);
@@ -466,32 +536,54 @@ export function attachTlsIntercept(
             recordableResponse[key] = value;
           }
         }
+        if (stream.destroyed) {
+          abandon();
+          return;
+        }
         stream.respond(downstream);
 
         // Tee, never buffer, for the same reason as HTTP/1.1: a model reply arrives over seconds
         // and the agent renders it as it lands.
         upstream.on('data', (chunk: Buffer) => {
           responseBody.add(chunk);
+          if (stream.destroyed) {
+            abandon();
+            return;
+          }
           if (!stream.write(chunk)) {
+            // `drain` never fires on a destroyed stream, so a client that goes mid-response would
+            // otherwise leave upstream paused for good and the exchange never recorded.
             upstream.pause();
             stream.once('drain', () => upstream.resume());
           }
         });
         upstream.on('end', () => {
-          stream.end();
+          if (settled) return;
+          if (!stream.destroyed) stream.end();
           counters.intercepted += 1;
+          // A body orca cannot decode is still an exchange worth having. `decodeRequestBody`
+          // throws for zstd on a runtime without it -- inside `engines`, and why the repo's own
+          // zstd test is skipped there -- and an exception in this callback would take the process
+          // down with the exchange unrecorded. server.ts already decodes inside a try/catch for
+          // the same reason.
+          let recordedRequest: string;
+          try {
+            recordedRequest = decodeRequestBody(requestBody.buffer(), contentEncoding);
+          } catch (err) {
+            options.onFailure?.({
+              host: target.host,
+              port: target.port,
+              reason: `request body left opaque: ${String(err)}`,
+            });
+            recordedRequest = requestBody.text();
+          }
           options.onNetExchange?.({
             host: target.host,
             port: target.port,
             method,
             path,
             requestHeaders: recordableHeaders,
-            requestBody: decodeRequestBody(
-              requestBody.buffer(),
-              typeof headers['content-encoding'] === 'string'
-                ? headers['content-encoding']
-                : undefined,
-            ),
+            requestBody: recordedRequest,
             requestTruncated: requestBody.truncated,
             status,
             alpn: 'h2',
@@ -501,7 +593,7 @@ export function attachTlsIntercept(
             responseBytes: responseBody.bytes,
             durationMs: Date.now() - startedAt,
           });
-          resolve();
+          finish();
         });
       });
     });

--- a/packages/proxy/src/intercept.ts
+++ b/packages/proxy/src/intercept.ts
@@ -3,11 +3,19 @@ import {
   type IncomingMessage,
   type ServerResponse,
 } from 'node:http';
+import {
+  connect as http2Connect,
+  createSecureServer as createHttp2SecureServer,
+  constants as H2,
+  type ClientHttp2Session,
+  type Http2SecureServer,
+  type ServerHttp2Stream,
+} from 'node:http2';
 import { Agent, request as httpsRequest } from 'node:https';
 import { connect as netConnect, isIP, type Socket } from 'node:net';
 import { createSecureContext, rootCertificates, TLSSocket, type SecureContext } from 'node:tls';
 import * as zlib from 'node:zlib';
-import { AUTH_REQUEST_HEADERS, AUTH_RESPONSE_HEADERS } from '@orcareplay/core';
+import { AUTH_REQUEST_HEADERS, AUTH_RESPONSE_HEADERS, BINARY_BODY_PREFIX } from '@orcareplay/core';
 import type { RunCa } from './ca.js';
 import { HostPolicy } from './tls-hosts.js';
 
@@ -67,6 +75,15 @@ export interface NetExchange {
   responseTruncated: boolean;
   /** The full size on the wire, even where the captured body was truncated. */
   responseBytes: number;
+  /**
+   * Which application protocol the client negotiated: `h2`, `http/1.1`, or absent when the client
+   * offered no ALPN at all.
+   *
+   * Recorded because the interceptor now speaks both, and which one a given agent picks is the
+   * difference between two code paths. Without it, "did this run go through the h2 path" is a
+   * question a trace cannot answer.
+   */
+  alpn?: string;
   durationMs: number;
 }
 
@@ -90,6 +107,13 @@ export interface InterceptResponse {
 }
 
 /** Decode a request body for model-dialect parsing while leaving forwarding byte-for-byte. */
+/** Decode a recorded body, whichever of the two forms it was stored in. */
+export function readRecordedBody(body: string): Buffer {
+  return body.startsWith(BINARY_BODY_PREFIX)
+    ? Buffer.from(body.slice(BINARY_BODY_PREFIX.length), 'base64')
+    : Buffer.from(body, 'utf8');
+}
+
 export function decodeRequestBody(bytes: Buffer, contentEncoding?: string): string {
   const encoding = contentEncoding?.split(',')[0]?.trim().toLowerCase();
   if (encoding === 'zstd') {
@@ -102,9 +126,16 @@ export function decodeRequestBody(bytes: Buffer, contentEncoding?: string): stri
     ).zstdDecompressSync;
     if (!decompress)
       throw new Error('zstd request encoding requires a Node runtime with zstd support');
-    return decompress(bytes).toString('utf8');
+    return recordableBody(decompress(bytes));
   }
-  return bytes.toString('utf8');
+  return recordableBody(bytes);
+}
+
+/** Text when the bytes are text, base64 behind a marker when they are not. */
+function recordableBody(bytes: Buffer): string {
+  const asText = bytes.toString('utf8');
+  if (Buffer.compare(Buffer.from(asText, 'utf8'), bytes) === 0) return asText;
+  return `${BINARY_BODY_PREFIX}${bytes.toString('base64')}`;
 }
 
 /**
@@ -218,14 +249,31 @@ export function attachTlsIntercept(
    * socket this map does not know is simply a miss, which is exactly the answer wanted.
    */
   const targets = new WeakMap<object, Target>();
+  /**
+   * The same answer as `targets`, reachable from an h2 session.
+   *
+   * `session.socket` is a Proxy standing in for the real socket, so it is never a key `targets`
+   * knows -- the lookup silently missed and every h2 stream was rejected as arriving on an unknown
+   * connection. A property on the socket survives the Proxy, which forwards unknown reads through.
+   */
+  const TARGET = Symbol('orca.intercept.target');
+  /**
+   * Which origin a decrypted request was destined for.
+   *
+   * Two indirections to get through, both of them somebody else's wrapper. The h2 server hands out
+   * a Proxy in place of the socket, which forwards unknown property reads to the real one; and the
+   * socket it terminated is a `TLSSocket` wrapping the socket we tagged, reachable as `_parent`.
+   */
+  const targetOf = (socket: unknown): Target | undefined => {
+    let cursor: unknown = socket;
+    for (let depth = 0; depth < 4 && typeof cursor === 'object' && cursor !== null; depth += 1) {
+      const own = (cursor as Record<symbol, Target | undefined>)[TARGET] ?? targets.get(cursor);
+      if (own) return own;
+      cursor = (cursor as { _parent?: unknown })._parent;
+    }
+    return undefined;
+  };
   const open = new Set<Socket | TLSSocket>();
-
-  const decrypted = createHttpServer((req, res) => {
-    void forward(req, res).catch((err: unknown) => {
-      if (!res.headersSent) res.writeHead(502, { 'content-type': 'application/json' });
-      res.end(JSON.stringify({ error: { message: `orca tls-intercept: ${String(err)}` } }));
-    });
-  });
 
   /**
    * A protocol switch inside a session we decrypted — a WebSocket, usually.
@@ -235,15 +283,240 @@ export function attachTlsIntercept(
    * saying so leaves the operator with a message instead of a hang, and the remedy is to take the
    * host off the allowlist so the whole connection is tunnelled untouched instead.
    */
-  decrypted.on('upgrade', (req, socket: Socket) => {
-    const target = targets.get(req.socket);
+  const onUpgrade = (req: IncomingMessage, socket: Socket): void => {
+    const target = targetOf(req.socket);
     options.onFailure?.({
       host: target?.host ?? 'unknown',
       port: target?.port ?? 0,
       reason: `orca cannot relay an ${String(req.headers.upgrade)} upgrade through an intercepted connection`,
     });
     socket.end('HTTP/1.1 501 Not Implemented\r\nconnection: close\r\n\r\n');
-  });
+  };
+
+  /**
+   * One upstream h2 session per origin, reused across streams the way `Agent` is for HTTP/1.1.
+   *
+   * `ALPNProtocols: ['h2']` on purpose: this session exists only because the client asked for h2,
+   * and an origin answering `http/1.1` here would leave us holding a session that cannot carry the
+   * request. Failing loudly beats forwarding into a protocol mismatch.
+   */
+  const h2Upstreams = new Map<string, ClientHttp2Session>();
+
+  function upstreamH2(target: Target): ClientHttp2Session {
+    const key = `${target.host}:${target.port}`;
+    const existing = h2Upstreams.get(key);
+    if (existing && !existing.closed && !existing.destroyed) return existing;
+    const session = http2Connect(`https://${target.host}:${target.port}`, {
+      ALPNProtocols: ['h2'],
+      ...(originTrust ? { ca: originTrust } : {}),
+    });
+    session.on('error', (err) => {
+      options.onFailure?.({ host: target.host, port: target.port, reason: String(err) });
+      h2Upstreams.delete(key);
+    });
+    session.on('close', () => h2Upstreams.delete(key));
+    h2Upstreams.set(key, session);
+    return session;
+  }
+
+  /**
+   * One TLS-terminating server per intercepted host, and the reason it is a server rather than a
+   * socket we terminate ourselves.
+   *
+   * The obvious shape -- `new TLSSocket({ isServer: true })`, then hand the decrypted socket to an
+   * HTTP server -- works for HTTP/1.1 and silently does not for h2. An `Http2Session` takes over
+   * the socket's handle rather than reading the stream, so the client's connection preface and its
+   * first PING, already buffered by the time the handshake callback runs, are never seen: the
+   * session establishes, nothing flows, and the client gives up with a keepalive timeout. Verified
+   * on a loopback with no agent involved. Letting the h2 server do the TLS itself is what fixes
+   * it, and `allowHTTP1` keeps one server able to serve both.
+   *
+   * Per host rather than one server with `SNICallback`, so the certificate is still chosen by the
+   * CONNECT target exactly as before. SNI would work for every client that sends it and quietly
+   * pick the wrong certificate for one that does not.
+   */
+  const h2Servers = new Map<string, Http2SecureServer>();
+
+  function serverFor(host: string): Http2SecureServer {
+    const cached = h2Servers.get(host);
+    if (cached) return cached;
+    const issued = options.ca.issue(host);
+    const server = createHttp2SecureServer({
+      key: issued.keyPem,
+      cert: issued.certPem,
+      allowHTTP1: true,
+      ALPNProtocols: ['h2', 'http/1.1'],
+    });
+
+    // An h2 request emits both `stream` and `request` when `allowHTTP1` is set, so `request` has
+    // to serve HTTP/1.1 only or the same exchange is answered twice and the second attempt throws
+    // ERR_HTTP2_HEADERS_SENT.
+    server.on('request', (req, res) => {
+      // The event is typed for h2 because the server can serve it, but `allowHTTP1` means an
+      // HTTP/1.1 session delivers the node:http pair instead. The version check above is what
+      // makes the cast true rather than hopeful.
+      if (req.httpVersionMajor >= 2) return;
+      const req1 = req as unknown as IncomingMessage;
+      const res1 = res as unknown as ServerResponse;
+      void forward(req1, res1).catch((err: unknown) => {
+        if (!res.headersSent) res.writeHead(502, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ error: { message: `orca tls-intercept: ${String(err)}` } }));
+      });
+    });
+
+    server.on('stream', (stream: ServerHttp2Stream, headers) => {
+      void forwardH2(stream, headers).catch((err: unknown) => {
+        if (!stream.headersSent) stream.respond({ ':status': 502 });
+        stream.end(JSON.stringify({ error: { message: `orca tls-intercept h2: ${String(err)}` } }));
+      });
+    });
+
+    server.on('upgrade', onUpgrade);
+    server.on('tlsClientError', (err, socket) => reportH2(socket, err));
+    server.on('sessionError', (err, session) => reportH2(session?.socket, err));
+    server.on('clientError', (err, socket) => reportH2(socket, err));
+    server.on('error', (err) => reportH2(undefined, err));
+    server.on('session', (session) => {
+      session.on('error', (err) => reportH2(session.socket, err));
+    });
+
+    h2Servers.set(host, server);
+    return server;
+  }
+
+  /**
+   * Errors inside an h2 session, reported rather than swallowed.
+   *
+   * Without these the only symptom of a session that never became usable was the *client*
+   * complaining -- "HTTP/2 keepalive ping timed out" -- with nothing on this side saying why, which
+   * is the same blindness the HTTP/1.1 path avoids by reporting handshake failures.
+   */
+  const reportH2 = (socket: unknown, reason: unknown): void => {
+    const target = targetOf(socket);
+    options.onFailure?.({
+      host: target?.host ?? 'unknown',
+      port: target?.port ?? 0,
+      reason: `h2 session: ${String(reason)}`,
+    });
+  };
+  /**
+   * The h2 twin of `forward`, recording the same exchange.
+   *
+   * Two differences from HTTP/1.1, both protocol rules rather than choices: the method, path and
+   * authority arrive as `:`-prefixed pseudo-headers and have to be rebuilt rather than copied, and
+   * h2 forbids the hop-by-hop headers outright, so passing one through is an error rather than
+   * merely being wrong.
+   */
+  async function forwardH2(
+    stream: ServerHttp2Stream,
+    headers: Record<string, string | string[] | undefined>,
+  ): Promise<void> {
+    // `session` is optional on the type because a stream outlives a destroyed session; a stream
+    // being served cannot have lost it, but the lookup needs a socket either way.
+    const target = stream.session ? targetOf(stream.session.socket) : undefined;
+    if (!target) throw new Error('decrypted h2 stream arrived on an unknown connection');
+
+    const startedAt = Date.now();
+    const method = String(headers[H2.HTTP2_HEADER_METHOD] ?? 'GET');
+    const path = String(headers[H2.HTTP2_HEADER_PATH] ?? '/');
+    const outbound: Record<string, string | string[]> = {
+      [H2.HTTP2_HEADER_METHOD]: method,
+      [H2.HTTP2_HEADER_PATH]: path,
+      [H2.HTTP2_HEADER_SCHEME]: 'https',
+      [H2.HTTP2_HEADER_AUTHORITY]: String(
+        headers[H2.HTTP2_HEADER_AUTHORITY] ?? `${target.host}:${target.port}`,
+      ),
+    };
+    const recordableHeaders: Record<string, string> = {};
+    for (const [name, value] of Object.entries(headers)) {
+      const key = name.toLowerCase();
+      if (key.startsWith(':') || HOP_BY_HOP.has(key) || value === undefined) continue;
+      outbound[key] = value;
+      if (!SECRET_REQUEST_HEADERS.has(key) && typeof value === 'string') {
+        recordableHeaders[key] = value;
+      }
+    }
+
+    const requestBody = new Capture(maxCaptured);
+    const responseBody = new Capture(maxCaptured);
+
+    await new Promise<void>((resolve, reject) => {
+      const upstream = upstreamH2(target).request(outbound);
+
+      stream.on('data', (chunk: Buffer) => {
+        requestBody.add(chunk);
+        if (!upstream.write(chunk)) {
+          stream.pause();
+          upstream.once('drain', () => stream.resume());
+        }
+      });
+      stream.on('end', () => upstream.end());
+      stream.on('error', reject);
+
+      upstream.on('error', reject);
+      upstream.on('response', (responseHeaders) => {
+        const status = Number(responseHeaders[H2.HTTP2_HEADER_STATUS] ?? 0);
+        const recordableResponse: Record<string, string> = {};
+        const downstream: Record<string, string | string[] | number> = { ':status': status };
+        for (const [name, value] of Object.entries(responseHeaders)) {
+          const key = name.toLowerCase();
+          if (key.startsWith(':') || HOP_BY_HOP.has(key) || value === undefined) continue;
+          downstream[key] = value;
+          if (!SECRET_RESPONSE_HEADERS.has(key) && typeof value === 'string') {
+            recordableResponse[key] = value;
+          }
+        }
+        stream.respond(downstream);
+
+        // Tee, never buffer, for the same reason as HTTP/1.1: a model reply arrives over seconds
+        // and the agent renders it as it lands.
+        upstream.on('data', (chunk: Buffer) => {
+          responseBody.add(chunk);
+          if (!stream.write(chunk)) {
+            upstream.pause();
+            stream.once('drain', () => upstream.resume());
+          }
+        });
+        upstream.on('end', () => {
+          stream.end();
+          counters.intercepted += 1;
+          options.onNetExchange?.({
+            host: target.host,
+            port: target.port,
+            method,
+            path,
+            requestHeaders: recordableHeaders,
+            requestBody: decodeRequestBody(
+              requestBody.buffer(),
+              typeof headers['content-encoding'] === 'string'
+                ? headers['content-encoding']
+                : undefined,
+            ),
+            requestTruncated: requestBody.truncated,
+            status,
+            alpn: 'h2',
+            responseHeaders: recordableResponse,
+            responseBody: responseBody.text(),
+            responseTruncated: responseBody.truncated,
+            responseBytes: responseBody.bytes,
+            durationMs: Date.now() - startedAt,
+          });
+          resolve();
+        });
+      });
+    });
+  }
+
+  /** The negotiated protocol, looked up through the TLS wrapper the server put in place. */
+  const alpnOf = (socket: unknown): string | undefined => {
+    let cursor: unknown = socket;
+    for (let depth = 0; depth < 4 && typeof cursor === 'object' && cursor !== null; depth += 1) {
+      const value = (cursor as { alpnProtocol?: unknown }).alpnProtocol;
+      if (typeof value === 'string') return value;
+      cursor = (cursor as { _parent?: unknown })._parent;
+    }
+    return undefined;
+  };
 
   function contextFor(host: string): SecureContext {
     const cached = contexts.get(host);
@@ -255,7 +528,7 @@ export function attachTlsIntercept(
   }
 
   async function forward(req: IncomingMessage, res: ServerResponse): Promise<void> {
-    const target = targets.get(req.socket);
+    const target = targetOf(req.socket);
     if (!target) throw new Error('decrypted request arrived on an unknown connection');
 
     const startedAt = Date.now();
@@ -366,6 +639,7 @@ export function attachTlsIntercept(
             ),
             requestTruncated: requestBody.truncated,
             status: originRes.statusCode ?? 0,
+            alpn: alpnOf(req.socket),
             responseHeaders,
             responseBody: responseBody.text(),
             responseTruncated: responseBody.truncated,
@@ -383,23 +657,10 @@ export function attachTlsIntercept(
   function intercept(clientSocket: Socket, head: Buffer, target: Target): void {
     clientSocket.write('HTTP/1.1 200 Connection Established\r\n\r\n');
     if (head.length > 0) clientSocket.unshift(head);
-    const secure = new TLSSocket(clientSocket, {
-      isServer: true,
-      secureContext: contextFor(target.host),
-      // Pin HTTP/1.1. A client that offers h2 and gets no answer would otherwise speak HTTP/2
-      // frames into an HTTP/1.1 parser.
-      ALPNProtocols: ['http/1.1'],
-    });
-    targets.set(secure, target);
-    open.add(secure);
-    secure.on('close', () => open.delete(secure));
-    secure.on('error', (err) => {
-      // Usually the client rejecting our certificate, which is the correct outcome for a client
-      // that was never told to trust this run. Report it; do not crash the recording.
-      options.onFailure?.({ host: target.host, port: target.port, reason: String(err) });
-      secure.destroy();
-    });
-    decrypted.emit('connection', secure);
+    // Tagged before the handover, because the server wraps this socket in a TLSSocket of its own
+    // and the request that comes back out carries the wrapper, not this.
+    (clientSocket as unknown as Record<symbol, Target>)[TARGET] = target;
+    serverFor(target.host).emit('connection', clientSocket);
   }
 
   function tunnel(clientSocket: Socket, head: Buffer, target: Target): void {
@@ -478,6 +739,10 @@ export function attachTlsIntercept(
     policy,
     close: () => {
       agent.destroy();
+      for (const session of h2Upstreams.values()) session.destroy();
+      h2Upstreams.clear();
+      for (const server of h2Servers.values()) server.close();
+      h2Servers.clear();
       for (const socket of open) socket.destroy();
       open.clear();
     },
@@ -510,8 +775,17 @@ class Capture {
     this.#captured += chunk.length;
   }
 
+  /**
+   * The captured bytes as something a trace can hold.
+   *
+   * Text when the bytes are text, and base64 behind a marker when they are not. `toString('utf8')`
+   * on a binary body replaces every invalid sequence with U+FFFD and is not reversible: a Connect
+   * protobuf body came back with 974 replacement characters in 8,459 bytes, which is enough to
+   * make the payload undecodable while still looking like it was captured. The round-trip test is
+   * what tells the two cases apart.
+   */
   text(): string {
-    return Buffer.concat(this.#chunks).toString('utf8');
+    return recordableBody(Buffer.concat(this.#chunks));
   }
 
   buffer(): Buffer {

--- a/packages/proxy/test/tls-intercept.test.ts
+++ b/packages/proxy/test/tls-intercept.test.ts
@@ -6,6 +6,12 @@ import { createServer as createHttpsServer, type Server as HttpsServer } from 'n
 import type { AddressInfo, Socket } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import {
+  connect as h2Connect,
+  createSecureServer as createHttp2Origin,
+  type Http2SecureServer,
+  type ClientHttp2Session,
+} from 'node:http2';
 import { connect as tlsConnect } from 'node:tls';
 import zlib from 'node:zlib';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -136,6 +142,101 @@ function commonName(certPem: string): string {
   return /CN=(.*)/.exec(new X509Certificate(certPem).subject)?.[1] ?? '';
 }
 
+/**
+ * The same idea as `startOrigin`, over HTTP/2.
+ *
+ * A separate helper rather than an option on the first one, because an h2 origin answers on
+ * `stream` rather than with a request/response pair, and because the interesting cases here are
+ * about *when* it answers: `delayMs` lets the origin reply after the client has already gone,
+ * which is the shape that used to take the proxy down.
+ */
+async function startH2Origin(
+  ca: RunCa,
+  opts: { delayMs?: number; onStream?: () => void } = {},
+): Promise<{ port: number; hits: number; close: () => Promise<void> }> {
+  const issued = ca.issue('127.0.0.1');
+  const server: Http2SecureServer = createHttp2Origin({
+    key: issued.keyPem,
+    cert: issued.certPem,
+  });
+  const state = { hits: 0 };
+  // Tracked so `close` can force them down. `server.close()` waits for open sessions, and the
+  // proxy holds its upstream h2 session in a cache until the whole handle is closed -- so an
+  // origin waiting politely deadlocks the teardown.
+  const sessions = new Set<{ destroy: () => void }>();
+  server.on('session', (session) => {
+    sessions.add(session);
+    session.on('close', () => sessions.delete(session));
+  });
+  server.on('stream', (stream) => {
+    state.hits += 1;
+    opts.onStream?.();
+    stream.on('error', () => undefined);
+    stream.on('data', () => undefined);
+    const answer = (): void => {
+      if (stream.destroyed) return;
+      stream.respond({ ':status': 200, 'content-type': 'text/plain' });
+      stream.end('from-origin');
+    };
+    stream.on('end', () => {
+      if (opts.delayMs) setTimeout(answer, opts.delayMs);
+      else answer();
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  return {
+    port: (server.address() as AddressInfo).port,
+    get hits() {
+      return state.hits;
+    },
+    close: () =>
+      new Promise<void>((resolve) => {
+        for (const session of sessions) session.destroy();
+        sessions.clear();
+        server.close(() => resolve());
+      }),
+  };
+}
+
+/** An h2 session to `host:port` through the proxy's CONNECT tunnel. */
+async function h2Through(opts: {
+  proxyPort: number;
+  host: string;
+  port: number;
+  trust: string[];
+}): Promise<ClientHttp2Session> {
+  const target = `${opts.host}:${opts.port}`;
+  const tunnel = httpRequest({
+    host: '127.0.0.1',
+    port: opts.proxyPort,
+    method: 'CONNECT',
+    path: target,
+    headers: { host: target },
+  });
+  tunnel.end();
+  const [res, socket, head] = (await once(tunnel, 'connect')) as [IncomingMessage, Socket, Buffer];
+  if (res.statusCode !== 200) {
+    socket.destroy();
+    throw new Error(`CONNECT refused: ${res.statusCode}`);
+  }
+  if (head.length > 0) socket.unshift(head);
+  // The TLS handshake is done here rather than left to `http2.connect`: given a
+  // `createConnection`, http2 uses that stream as the transport as-is and adds no encryption, so
+  // an unwrapped socket would speak cleartext h2 frames at a TLS server.
+  const secure = tlsConnect({
+    socket,
+    ca: opts.trust,
+    host: opts.host,
+    port: opts.port,
+    ALPNProtocols: ['h2'],
+  });
+  await once(secure, 'secureConnect');
+  const session = h2Connect(`https://${target}`, { createConnection: () => secure });
+  session.on('error', () => undefined);
+  await once(session, 'connect');
+  return session;
+}
+
 type OriginHandler = Parameters<typeof createHttpsServer>[1];
 
 async function startOrigin(
@@ -257,6 +358,134 @@ describe('TLS interception', () => {
     });
     return proxy;
   }
+
+  /**
+   * HTTP/2, which reaches a different forwarder inside the interceptor.
+   *
+   * These exist because the h2 path was added without them and three failures followed from that:
+   * a replay that went live, a late origin response that killed the process, and an undecodable
+   * body that did the same. Each test below is one of those.
+   */
+  describe('over HTTP/2', () => {
+    let h2Origin: Awaited<ReturnType<typeof startH2Origin>>;
+
+    afterEach(async () => {
+      await h2Origin?.close();
+    });
+
+    /** `createProxy` with a replay hook, which is what makes the origin off-limits. */
+    async function startReplayProxy(
+      hosts: string[],
+      reply: (path: string) => { status: number; headers?: Record<string, string>; body: string },
+    ): Promise<ProxyHandle> {
+      proxy = await createProxy({
+        mode: 'record',
+        onExchange: (e) => void modelExchanges.push(e),
+        tls: {
+          ca: runCa,
+          hosts,
+          trustedOriginCerts: [originCa.certPem],
+          onNetExchange: (e) => void netExchanges.push(e),
+          onRequest: async (req) => reply(req.path),
+        },
+      });
+      return proxy;
+    }
+
+    it('answers from the replay hook without opening a connection to the origin', async () => {
+      h2Origin = await startH2Origin(originCa);
+      const handle = await startReplayProxy([`127.0.0.1:${h2Origin.port}`], () => ({
+        status: 418,
+        headers: { 'content-type': 'text/plain' },
+        body: 'from-recording',
+      }));
+
+      const session = await h2Through({
+        proxyPort: handle.port,
+        host: '127.0.0.1',
+        port: h2Origin.port,
+        trust: [runCa.certPem],
+      });
+      const request = session.request({ ':method': 'POST', ':path': '/replay' });
+      let status = 0;
+      let body = '';
+      request.on('response', (h) => void (status = Number(h[':status'])));
+      request.setEncoding('utf8');
+      request.on('data', (c: string) => void (body += c));
+      request.end('hello');
+      await once(request, 'close');
+      session.destroy();
+
+      expect(status).toBe(418);
+      expect(body).toBe('from-recording');
+      // The point of the whole test: a strict replay must not reach the provider.
+      expect(h2Origin.hits).toBe(0);
+    });
+
+    it('survives an origin response that arrives after the client has gone', async () => {
+      let answered = false;
+      h2Origin = await startH2Origin(originCa, { delayMs: 250 });
+      const handle = await startProxy([`127.0.0.1:${h2Origin.port}`]);
+
+      const session = await h2Through({
+        proxyPort: handle.port,
+        host: '127.0.0.1',
+        port: h2Origin.port,
+        trust: [runCa.certPem],
+      });
+      const request = session.request({ ':method': 'POST', ':path': '/abort' });
+      request.on('error', () => undefined);
+      request.end('hello');
+      await new Promise((r) => setTimeout(r, 40));
+      // The client gives up while the origin is still thinking. Responding on this stream
+      // afterwards raises ERR_HTTP2_INVALID_STREAM from inside an event callback, which used to
+      // be an uncaught exception and took the proxy process with it.
+      request.destroy();
+      await new Promise((r) => setTimeout(r, 500));
+      answered = true;
+      session.destroy();
+
+      expect(answered).toBe(true);
+      expect(h2Origin.hits).toBe(1);
+    });
+
+    it('records an exchange whose request body it cannot decode', async () => {
+      h2Origin = await startH2Origin(originCa);
+      const handle = await startProxy([`127.0.0.1:${h2Origin.port}`]);
+      const failures: string[] = [];
+      // `onFailure` is the channel the opaque case reports on, and the proxy under test already
+      // has one wired by `startProxy`; this asserts the exchange, which is the load-bearing half.
+
+      const session = await h2Through({
+        proxyPort: handle.port,
+        host: '127.0.0.1',
+        port: h2Origin.port,
+        trust: [runCa.certPem],
+      });
+      const request = session.request({
+        ':method': 'POST',
+        ':path': '/v1/embeddings',
+        // Claims an encoding the body does not have. `decodeRequestBody` throws either because
+        // the runtime has no zstd or because the stream is corrupt; both used to escape the
+        // `end` handler as an uncaught exception.
+        'content-encoding': 'zstd',
+      });
+      request.on('error', () => undefined);
+      request.setEncoding('utf8');
+      let body = '';
+      request.on('data', (c: string) => void (body += c));
+      request.end(Buffer.from('not zstd at all'));
+      await once(request, 'close');
+      session.destroy();
+      expect(failures).toHaveLength(0);
+
+      expect(body).toBe('from-origin');
+      const opaque = netExchanges.find((e) => e.path === '/v1/embeddings');
+      expect(opaque).toBeDefined();
+      expect(opaque?.alpn).toBe('h2');
+      expect(opaque?.status).toBe(200);
+    });
+  });
 
   it('refuses CONNECT entirely when interception was not asked for', async () => {
     proxy = await createProxy({ mode: 'record' });


### PR DESCRIPTION
<!-- orca-cr-summary:start -->
<!-- orca-code-review-summary -->
<!-- orca-cr-state: {"p0":0,"p1":0,"p2":0,"p3":0,"push":2} -->

## Orca-Code-Review — push 2

| Severity | Count | Δ vs previous push |
|---|---|---|
| P0 | 0 | 0 |
| P1 | 0 | -3 |
| P2 | 0 | 0 |
| P3 | 0 | 0 |

✅ no blocking findings
<!-- orca-cr-summary:end -->

`--tls-intercept` offered only `http/1.1`. A client that offers h2 and nothing else finds no common protocol, and the handshake dies before any bytes move:

```
warn tls.handshake_failed host=agentn.global.api5.cursor.sh
  reason="tls_handle_alpn: no application protocol"
```

Cursor's agent stream is one of those, and it is the case this came from. Offering both protocols is where it starts; three separate things had to be right after that.

## The socket cannot be terminated by hand

The existing shape — `new TLSSocket({ isServer: true })`, then the decrypted socket handed to an HTTP server — works for HTTP/1.1 and silently does not for h2. An `Http2Session` takes over the socket's handle rather than reading the stream, so the connection preface and the first PING, already buffered by the time the handshake callback runs, are never seen. The session establishes, nothing flows, and the client gives up:

```
RetriableError: [internal] HTTP/2 keepalive ping timed out after 5000ms
```

Reproduced on a loopback with no agent in it at all, which is what separated "wrong architecture" from "Cursor is unusual":

```
client: connected
server: alpn = h2
server: session established
TIMEOUT after 8s
```

The fix is to let `http2.createSecureServer` do the TLS itself. One server per intercepted host rather than one server with `SNICallback`, so the certificate is still chosen by the CONNECT target — SNI would work for every client that sends it and quietly pick the wrong certificate for one that does not. `allowHTTP1: true` keeps a single server serving both, and because an h2 request then emits `stream` *and* `request`, the latter serves HTTP/1.1 only or the same exchange is answered twice and throws `ERR_HTTP2_HEADERS_SENT`.

Two mistakes on the way, both worth knowing: `secureConnect` is the client-side event and never fires on a socket built with `isServer: true`; and `session.socket` is a Proxy, not the socket, so a `WeakMap` keyed by socket never matches.

## A binary body could not survive the trace

Two independent problems.

`bytes.toString('utf8')` on a protobuf body replaces every invalid sequence with U+FFFD and is not reversible — 974 replacement characters in 8,459 bytes. A body that is not valid UTF-8 is now recorded as base64 behind a marker, decided by a round-trip test, so text bodies are untouched.

Then the redactor shredded the base64. It is one long high-entropy run by construction, and the entropy scanner replaced 226 spans of a 14 KB response with `<secret:high_entropy:…>`. The raw bytes were 14,366 and began with valid Connect framing; the trace copy was 6,161 bytes of noise. Comparing the two in one run is what identified it — before that the corruption looked like the interceptor losing the head of the stream. The redactor now leaves a marked body alone; the named pattern rules still run on it, and only the randomness heuristic is skipped, which was protecting nothing there because a credential inside a binary body is not matchable once encoded.

## Observability

`net.request` records the negotiated protocol. With two paths available, "did this run go through the h2 one" is otherwise a question a trace cannot answer. Measured across five harnesses:

| host | negotiated | path |
|---|---|---|
| `agentn.global.api5.cursor.sh` | **h2** | new |
| `api2.cursor.sh`, `repo42.cursor.sh` | no ALPN | unchanged |
| `models.opencode.ai` | no ALPN | unchanged |
| `api.anthropic.com` | `http/1.1` | unchanged |

Exactly one host negotiates h2. Everything else offers no ALPN or picks `http/1.1`.

## The HTTP/1.1 path is unchanged, checked rather than assumed

Offering h2 means a client that was previously forced onto HTTP/1.1 could now choose h2 and take new code, so the same command was run against this build and against a rebuilt baseline:

```
this build:  model.request 2 | 200 responses 2 | tools=29 | 105,329 bytes
baseline:    model.request 2 | 200 responses 2 | tools=29 | 105,333 bytes
```

`orca record claude --tls-intercept --upstream-anthropic https://api.anthropic.com`, two runs each, stable. The four-byte difference is the working directory name. The baseline was produced by `git stash push packages/` and a rebuild, not from memory.

| | |
|---|---|
| `npm run typecheck` | passes |
| `packages/proxy/test/tls-intercept.test.ts` | 12/12, three consecutive runs |
| full suite | 32 failed / 1493 passed, the same 16 files as the baseline |

Every failure in the suite predates this change.

## Note

`capture/CURSOR-HTTP2.md` on #20 is the long-form account of all four obstacles, including the one that is not in this PR: Cursor's prompt arrives in the response rather than the request. That branch is the consumer of this one — its `cursor` profile needs a build with this change, which is why it carries an `ORCA_BIN` escape hatch until this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
