### PR TITLE
Say what replay proves, in the tool description and in the skill

### DIFF
--- a/packages/cli/src/mcp-server.ts
+++ b/packages/cli/src/mcp-server.ts
@@ -93,7 +93,9 @@ export const MCP_TOOLS: McpTool[] = [
     description:
       'Re-run a recording exactly, with the network blocked and no tokens spent, and report what ' +
       'could not be reproduced: divergences, and requests the recording could not serve. Free ' +
-      'and repeatable. Use it to confirm a failure is deterministic before trying to explain it.',
+      'and repeatable. It shows the recorded decisions still reproduce; it cannot show a fresh ' +
+      'run would fail the same way, because the model is not asked again — its recorded ' +
+      'responses are served back.',
     inputSchema: {
       type: 'object',
       properties: {

--- a/skills/orca-replay/SKILL.md
+++ b/skills/orca-replay/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: orca-replay
-description: Answer questions about a past agent run from its recording instead of from memory, and re-run or fork that run. Use when someone asks why an earlier run did something ("why did you delete my migration", "what touched this config", "which tool call broke the build"), wants a past failure reproduced, wants to know whether a failure is deterministic or a one-off, or asks whether a different model would have got it right. Requires the orcareplay MCP server and at least one recording under .orca/runs.
+description: Answers questions about a past agent run from its recording rather than from memory, and replays or forks that run. Use when asked why an earlier run did something, or to reproduce a failure.
 license: Apache-2.0
 compatibility: Requires the `orcareplay` npm package (Node 20+) with its MCP server registered as `orca`, and at least one recorded run in the project's .orca/runs directory.
 metadata:
@@ -19,12 +19,13 @@ anyone mentioning it.
 answer.** Do not reconstruct it. If a recording exists, guessing is the wrong move even when the
 guess would have been right.
 
-## When this applies
+## When to Use This Skill
 
 - "Why did you delete/overwrite/move X?"
 - "What changed this file?" / "Which step broke the build?"
 - "Can you reproduce yesterday's failure?"
-- "Is this flaky or does it fail every time?"
+- "Does this still reproduce?" (see the limit on that in step 4 — replay cannot tell you
+  whether a *fresh* run would fail again)
 - "Would a different model have got this right?"
 
 ## Workflow
@@ -56,11 +57,36 @@ looks like the `rm` at step 14, going by timing" are different claims, and flatt
 confident sentence is the specific failure this tool exists to prevent. Name the rule when you lean
 on an inferred edge.
 
-### 4. Confirm it is deterministic before explaining it
+### 4. Reproduce it before explaining it
 
-`orca_replay` re-runs the recording with the network blocked and no tokens spent, then reports what
-could not be reproduced — divergences, and requests the recording could not serve. It is free and
-repeatable, so there is no reason to skip it before committing to an explanation.
+`orca_replay` re-runs the recording and reports what could not be reproduced — divergences, and
+requests the recording could not serve.
+
+**What "offline" covers, and what it does not.** Every model response comes from the trace and the
+proxy forwards nothing upstream, so no provider is contacted and no tokens are spent. An unmatched
+request halts the replay rather than falling through to the network, unless `--loose` was asked for.
+
+That covers the model traffic. It does not cover the agent's own subprocesses: unless the recording
+used `--tls-intercept` — in which case replay re-establishes interception for the hosts it recorded
+— a `curl`, `npm install`, `git push` or database call inside a recorded shell command goes
+straight out. Replay is not a sandbox; only a network-isolated container makes it one.
+
+**What a matching replay proves, and what it does not.** It shows the recorded decisions reproduce
+against today's environment. It cannot show the failure is deterministic, because the model is not
+being asked again — the same recorded responses are served back. If the user wants to know whether a
+fresh run would fail the same way, say that replay cannot answer it; that needs real runs.
+
+**Replay re-executes the agent, not just its model traffic.** The recorded model responses are
+served from the trace, but the agent process runs again for real — so every shell command it issued
+runs again too. `worktree: true` isolates repository files and nothing else. Anything the run
+touched outside the tree — `/tmp`, Docker, a local database, a package manager, another host — is
+mutated a second time.
+
+**So check before the first replay of a run, not after.** Read its shell commands with
+`orca_show_run` and tell the user what will re-execute. If any of it reached outside the working
+tree, get approval for that specifically or replay inside a container; do not treat the earlier
+`worktree` answer as covering it. A run that only read files and edited the repository is free and
+repeatable, and worth replaying before committing to any explanation.
 
 **Pass `worktree: true`.** It replays into a scratch copy and leaves the working tree alone.
 
@@ -76,30 +102,56 @@ calls for themselves — a quota probe, a session-naming request — and a repla
 ### 5. Only then consider comparing models
 
 `orca_compare` forks one run onto several models from the same checkpoint: same files, same
-conversation prefix, so the model is the only variable. Grade with `verify` — a shell command whose
-exit code is the verdict, e.g. `"npm test"` or `"npx tsc --noEmit"`. Pick the fork point with
-`orca_checkpoints` and pass it as `from`.
+conversation prefix, so the model is the only variable. Pick the fork point with `orca_checkpoints`
+and pass it as `from`.
+
+Grade with `verify` — a shell command whose exit code is the verdict. Use something the repository
+already declares (`"npm test"`, `"npm run typecheck"`) or an explicitly local binary
+(`"./node_modules/.bin/tsc --noEmit"`), not `npx <tool>`: with no local install, npx runs whatever
+the registry has under that name, and `npx tsc` resolves a package deprecated in 2016 that is not
+TypeScript.
 
 **`orca_compare` uploads the recording to other people's models, and spends real money doing it.**
 Each model named receives the same files and conversation prefix the original run had — so whatever
 that run touched (source, prompts, configuration, anything a credential was pasted into) is sent to
 every provider behind those model ids.
 
-Before calling it, tell the user *what* will be sent and *to whom*, not only how many models and
-roughly what it costs. Approving a bill is not approving a disclosure, and the two need separate
-answers when the recording is from a private codebase. `orca scrub` exists for the cases where the
-comparison is worth running but the trace is not safe to send as-is. Never run it to satisfy
-curiosity the user did not express.
+**And each fork is a live agent, not a replay.** From the fork point onward the model is really
+being asked, and whatever it decides to do, it does — its shell commands execute for real, and so
+does the `verify` command you pass. Each fork gets its own worktree, so repository files are
+isolated per model; nothing outside the tree is. A fork can also take actions the original run never
+took, because it is a different model making fresh decisions.
+
+So the approval has three parts, and they are not the same question:
+
+1. **Disclosure** — what context is uploaded, and to which providers. Approving a bill is not
+   approving a disclosure, and the two need separate answers when the recording is from a private
+   codebase. `orca scrub` is for when the comparison is worth running but the trace is not safe to
+   send as-is.
+2. **Side effects** — what the recorded run did outside its worktree, since each fork may repeat it
+   and may go further. Same check as step 4, `orca_show_run`, and the same answer if it reached
+   Docker, a database, a deployment or another host: get approval for that specifically, or run the
+   comparison in an isolated environment.
+3. **Cost** — how many models times how many forks.
+
+Never run it to satisfy curiosity the user did not express.
 
 ## If there is no recording yet
 
-Say so plainly rather than falling back to guessing, and offer to start one. If `orca` is missing,
-ask before installing it and install a pinned version rather than whatever `latest` points at
-today — a global install is a change to the user's machine, not a detail of your task:
+Say so plainly rather than falling back to guessing, and offer to start one.
+
+If `orca` is already installed:
 
 ```console
-npm i -g orcareplay@0.1.2    # ask first; pinned, not `latest`
 orca record claude           # or codex, opencode, openclaw, grok
+```
+
+If it is not, ask before installing it — a global install changes the user's machine, and that is
+their call, not a detail of your task. Install a pinned version rather than whatever `latest`
+resolves to today:
+
+```console
+npm i -g orcareplay@0.1.2     # ask first
 ```
 
 `orca record <agent>` runs the agent unmodified behind a local proxy. Nothing about the agent
@@ -113,8 +165,13 @@ papering over it.
 
 ## Sharing a run with someone else
 
-`orca export last -o run.html` writes one self-contained file. `orca scrub` removes anything
-sensitive first. Traces hold whatever the run held, so scrub before sending a recording anywhere.
+`orca export last -o run.html` writes one self-contained file. A trace holds whatever the run held,
+so run `orca scrub` before sending one anywhere.
+
+Scrubbing is best-effort, not a guarantee. It matches known key shapes and high-entropy strings; it
+cannot know that a particular internal hostname, customer name, or unreleased feature is
+confidential to this user. So scrub, then have the user look at what is actually going out, and get
+their agreement — do not describe a scrubbed trace as safe on the strength of the scrubber alone.
 
 ## Limitations
 
@@ -133,9 +190,12 @@ sensitive first. Traces hold whatever the run held, so scrub before sending a re
 - **Not every harness is recordable.** Agents that read no base-URL variable and pin their own
   origin need `--tls-intercept`, and some cannot be reached at all. A recording that came back
   empty means the harness was not captured, not that nothing happened.
-- **Replay is not a time machine for the world.** It reproduces the agent's side of the run.
-  External state the run depended on — a database row, a remote branch, the clock — is whatever it
-  is now.
+- **Replay is not a time machine, and not a sandbox.** It reproduces the agent's side of the run
+  against today's world. External state the run depended on — a database row, a remote branch, the
+  clock — is whatever it is now, and the run's own shell commands reach it for real.
+- **A matching replay is not a determinism result.** The model is not re-asked; its recorded
+  responses are served back. Whether a fresh run would fail the same way is a different question
+  that replay cannot answer.
 
 ## Tools
 


### PR DESCRIPTION
<!-- orca-cr-summary:start -->
<!-- orca-code-review-summary -->
<!-- orca-cr-state: {"p0":0,"p1":0,"p2":0,"p3":0,"push":1} -->

## Orca-Code-Review — push 1

| Severity | Count |
|---|---|
| P0 | 0 |
| P1 | 0 |
| P2 | 0 |
| P3 | 0 |

✅ no blocking findings
<!-- orca-cr-summary:end -->

Two files. The one-line change to the tool description is the reason this exists; the skill picks up the same correction.

## The tool description told the model something replay cannot do

```diff
-      'and repeatable. Use it to confirm a failure is deterministic before trying to explain it.',
+      'and repeatable. It shows the recorded decisions still reproduce; it cannot show a fresh ' +
+      'run would fail the same way, because the model is not asked again — its recorded ' +
+      'responses are served back.',
```

A replay does not ask the model again. `packages/proxy/test/server.test.ts:552` asserts exactly that — the recorded response is served and `fetchImpl` is never called. So a matching replay shows the recorded decisions still reproduce against today's environment, and says nothing about whether a fresh run would fail the same way.

This already contradicted our own documentation. `docs/architecture.md` opens its divergence section with **"Agent harnesses are not deterministic"** — timestamps, UUIDs, context compaction firing at a different point.

It matters more than a doc typo because of where it lives. A tool description is what the model reads before choosing the tool and what it echoes back afterwards, so the practical outcome is an agent running a replay and reporting a determinism result nobody measured, with the user then deciding the bug is not flaky and can be fixed directly. It is in the published 0.1.2 — `npm pack orcareplay@0.1.2` and grep `dist/mcp-server.js`.

**Left alone:** `with the network blocked and no tokens spent`. That one holds. The proxy forwards nothing upstream, and an unmatched request halts the replay rather than falling through, unless `--loose` was asked for (`packages/proxy/src/server.ts:952`).

## The skill

Same correction, plus what writing and defending it turned up:

- **Replay re-executes the agent.** `runChild` spawns it; the shell shim is a byte-faithful passthrough that records and never blocks. So a recorded run's shell commands run again. `worktree: true` isolates repository files and nothing else, and a subprocess's own network is untouched — unless the recording used `--tls-intercept`, where replay re-establishes interception for the hosts it recorded.
- **`orca_compare` uploads the run.** Every model named receives the same files and conversation prefix, and each fork is a live agent (`compare.ts:89`, "each fork spawns a real agent against a real worktree") which can act where the recording never did. Disclosure, side effects and cost are three separate approvals, not one.
- **`orca scrub` is best-effort.** It matches known key shapes and high-entropy strings, as the README says; it cannot know that a particular hostname or customer name is confidential. The skill no longer describes a scrubbed trace as safe on the scrubber's word alone.
- **A `## Limitations` section**, which it should have had from the start.

Most of these came out of an adversarial review on a downstream submission of the same skill. I kept the corrections and left out the ceremony that review also pushed for — a multi-step package-inspection ritual before you can record anything makes the skill worse even where each step is defensible.

## Verification

| check | result |
|---|---|
| `npm run typecheck` | passes |
| `vitest packages/cli/test/mcp-server.test.ts` | 17/17 |
| built server, `tools/list` over stdio | serves the new string |
| `skills-ref validate` (agentskills reference impl) | valid skill |
| `npm test` | 23 failed — **the same 23 that fail on an unmodified `main`**, all Windows platform (`0o600` mode assertions and similar) |

No README changes. I drafted some and then took them back out: "no network" and "no variance" are accurate for the common case and for `--tls-intercept` recordings, and four hedged sentences would have been worse than one precise tool description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
