### PR TITLE
Fix the two silent capture failures in `orca record opencode`

### DIFF
--- a/packages/adapters/fixtures/harness/opencode.json
+++ b/packages/adapters/fixtures/harness/opencode.json
@@ -1,10 +1,17 @@
 {
   "adapter": "opencode",
   "harness_versions": null,
-  "verified_at": "2026-08-29",
+  "verified_at": "2026-09-06",
   "command": "opencode",
-  "env_vars": ["ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL", "OPENAI_API_KEY", "OPENAI_BASE_URL"],
+  "env_vars": [
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_BASE_URL",
+    "OPENAI_API_KEY",
+    "OPENAI_BASE_URL",
+    "OPENCODE_CONFIG_CONTENT",
+    "SHELL"
+  ],
   "base_urls": { "OPENAI_BASE_URL": "/v1", "ANTHROPIC_BASE_URL": "" },
   "optional_env_vars": [],
-  "note": "Both origins are redirected because OpenCode picks its provider per model. Credentials pass through when the user has either one; the placeholders recorded here appear only when the user has neither, so recording never makes a provider look configured that is not."
+  "note": "Both origins are redirected because OpenCode picks its provider per model. The config overlay adds OPENCODE_CONFIG_CONTENT, pointing OpenCode's first-party providers (opencode, opencode-go) at the proxy with their real base encoded into the path — no environment variable names those origins. SHELL points at a run shim so the shell tool, which execs $SHELL by absolute path, is captured; the shim stands in for a shell OpenCode would resolve anyway. Credentials pass through when the user has either one; the placeholders recorded here appear only when the user has neither, so recording never makes a provider look configured that is not."
 }

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -18,6 +18,8 @@
   ],
   "dependencies": {
     "@orcareplay/node-instrument": "0.1.2",
-    "@orcareplay/plugin-api": "0.1.2"
+    "@orcareplay/plugin-api": "0.1.2",
+    "@orcareplay/proxy": "0.1.2",
+    "@orcareplay/shell-shim": "0.1.2"
   }
 }

--- a/packages/adapters/src/opencode-config.ts
+++ b/packages/adapters/src/opencode-config.ts
@@ -1,0 +1,209 @@
+import { readFile, stat } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+/**
+ * What OpenCode's own configuration says about a provider's base URL.
+ *
+ * The adapter redirects OpenCode's first-party providers through the proxy by writing a
+ * `provider.<id>.options.baseURL` override, and OpenCode merges config sources in an order that
+ * puts that override last — over a base URL the user configured for the same provider. Overriding
+ * someone's deliberate routing would make the recorded run talk to a host they never named, which
+ * is the one capture bug worse than an empty trace. So the adapter reads the same files OpenCode
+ * reads and carries the configured base URL *through* the redirect instead of replacing it.
+ *
+ * The files are JSONC — comments and trailing commas are allowed and the user's own config uses
+ * both — so a small stripper runs before `JSON.parse`. A file that still will not parse marks the
+ * whole scan untrusted: without knowing what the user intended, the adapter must not touch their
+ * routing at all, and the run degrades to the pre-override behaviour (uncaptured, with the
+ * end-of-run warning saying so) rather than to a captured run aimed at the wrong origin.
+ */
+
+export interface OpenCodeConfigScan {
+  /** Provider id → the `options.baseURL` the user configured, when they configured one. */
+  overrides: Map<string, string>;
+  /** False when a config file existed but could not be parsed, so no override can be trusted. */
+  trusted: boolean;
+}
+
+/**
+ * Strip what JSONC allows and JSON does not: comments and trailing commas.
+ *
+ * Strings are copied verbatim with their escapes, because a config comment is prose that may
+ * contain `//` — a URL, say — and stripping inside a string would corrupt the value while the
+ * file still parsed. Trailing commas are removed only when the next significant character closes
+ * a value, which a comma inside a string never is.
+ */
+export function stripJsonc(text: string): string {
+  let out = '';
+  let i = 0;
+  while (i < text.length) {
+    const ch = text[i]!;
+    if (ch === '"') {
+      const end = stringEnd(text, i);
+      out += text.slice(i, end);
+      i = end;
+      continue;
+    }
+    if (ch === '/' && text[i + 1] === '/') {
+      while (i < text.length && text[i] !== '\n') i += 1;
+      continue;
+    }
+    if (ch === '/' && text[i + 1] === '*') {
+      const end = text.indexOf('*/', i + 2);
+      i = end === -1 ? text.length : end + 2;
+      out += ' ';
+      continue;
+    }
+    out += ch;
+    i += 1;
+  }
+  return stripTrailingCommas(out);
+}
+
+/** Index just past the closing quote of the string starting at `start`, or end of input. */
+function stringEnd(text: string, start: number): number {
+  let i = start + 1;
+  while (i < text.length) {
+    const ch = text[i]!;
+    if (ch === '\\') {
+      i += 2;
+      continue;
+    }
+    if (ch === '"') return i + 1;
+    i += 1;
+  }
+  return text.length;
+}
+
+function stripTrailingCommas(text: string): string {
+  let out = '';
+  let i = 0;
+  while (i < text.length) {
+    const ch = text[i]!;
+    if (ch === '"') {
+      const end = stringEnd(text, i);
+      out += text.slice(i, end);
+      i = end;
+      continue;
+    }
+    if (ch === ',') {
+      let look = i + 1;
+      while (look < text.length && /\s/.test(text[look]!)) look += 1;
+      const next = text[look];
+      if (next === '}' || next === ']') {
+        i += 1;
+        continue;
+      }
+    }
+    out += ch;
+    i += 1;
+  }
+  return out;
+}
+
+/** Every `provider.<id>.options.baseURL` in one parsed config. */
+function providerBaseURLs(config: unknown): Map<string, string> {
+  const out = new Map<string, string>();
+  if (config === null || typeof config !== 'object' || Array.isArray(config)) return out;
+  const provider = (config as Record<string, unknown>)['provider'];
+  if (provider === null || typeof provider !== 'object' || Array.isArray(provider)) return out;
+  for (const [id, entry] of Object.entries(provider as Record<string, unknown>)) {
+    if (entry === null || typeof entry !== 'object' || Array.isArray(entry)) continue;
+    const options = (entry as Record<string, unknown>)['options'];
+    if (options === null || typeof options !== 'object' || Array.isArray(options)) continue;
+    const baseURL = (options as Record<string, unknown>)['baseURL'];
+    if (typeof baseURL === 'string' && baseURL.trim() !== '') out.set(id, baseURL.trim());
+  }
+  return out;
+}
+
+/**
+ * The config files OpenCode reads that could set a provider base URL.
+ *
+ * Global, then `OPENCODE_CONFIG`, then project-level `.opencode` directories walking up the way
+ * OpenCode's own loader walks — bounded at the git root or the home directory, because above
+ * those, neither OpenCode nor anyone else looks. Order does not matter here: the scan collects
+ * every override it can see, and a later source winning the merge is the same override either way.
+ */
+async function openCodeConfigFiles(
+  env: Record<string, string | undefined>,
+  cwd: string,
+): Promise<string[]> {
+  const files: string[] = [];
+  const globalDir =
+    readEnvValue(env, 'OPENCODE_CONFIG_DIR') ??
+    (readEnvValue(env, 'XDG_CONFIG_HOME') !== undefined
+      ? join(readEnvValue(env, 'XDG_CONFIG_HOME')!, 'opencode')
+      : join(homeOf(env), '.config', 'opencode'));
+  for (const file of ['config.json', 'opencode.json', 'opencode.jsonc']) {
+    files.push(join(globalDir, file));
+  }
+
+  const custom = readEnvValue(env, 'OPENCODE_CONFIG');
+  if (custom !== undefined) files.push(custom);
+
+  const stop = new Set([homeOf(env)]);
+  let at = cwd;
+  for (let depth = 0; depth < 64; depth += 1) {
+    for (const file of ['opencode.json', 'opencode.jsonc']) {
+      files.push(join(at, '.opencode', file));
+    }
+    if (stop.has(at)) break;
+    if (await isDirectory(join(at, '.git'))) break;
+    const parent = at.slice(0, at.lastIndexOf('/'));
+    if (parent === '' || parent === at) break;
+    at = parent;
+  }
+  return files;
+}
+
+function homeOf(env: Record<string, string | undefined>): string {
+  return readEnvValue(env, 'HOME') ?? homedir();
+}
+
+function readEnvValue(env: Record<string, string | undefined>, name: string): string | undefined {
+  const value = env[name];
+  return value !== undefined && value !== '' ? value : undefined;
+}
+
+async function isDirectory(path: string): Promise<boolean> {
+  try {
+    return (await stat(path)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Read the base URLs the user's OpenCode configuration sets per provider.
+ *
+ * A missing file is not a failure — most of these do not exist. A file that exists and will not
+ * parse is: the adapter then knows less than it must to rewrite routing safely, and reports that
+ * by clearing `trusted`.
+ */
+export async function openCodeConfiguredBaseURLs(
+  env: Record<string, string | undefined>,
+  cwd: string,
+): Promise<OpenCodeConfigScan> {
+  const overrides = new Map<string, string>();
+  let trusted = true;
+  for (const file of await openCodeConfigFiles(env, cwd)) {
+    let text: string;
+    try {
+      text = await readFile(file, 'utf8');
+    } catch {
+      continue;
+    }
+    if (text.trim() === '') continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(stripJsonc(text));
+    } catch {
+      trusted = false;
+      continue;
+    }
+    for (const [id, url] of providerBaseURLs(parsed)) overrides.set(id, url);
+  }
+  return { overrides, trusted };
+}

--- a/packages/adapters/src/opencode.ts
+++ b/packages/adapters/src/opencode.ts
@@ -1,5 +1,9 @@
+import { basename, join } from 'node:path';
 import type { Adapter, Launch, RecordContext } from '@orcareplay/plugin-api';
+import { forwardBasePath } from '@orcareplay/proxy';
+import { resolveRealBinary } from '@orcareplay/shell-shim';
 import { detectAgent, homeDirHas } from './detect.js';
+import { openCodeConfiguredBaseURLs } from './opencode-config.js';
 import { passKey, passThrough, proxyBase, readEnv } from './env.js';
 
 /**
@@ -16,8 +20,107 @@ export function opencodeHasOwnAuth(): boolean {
 }
 
 /**
+ * OpenCode's first-party providers, and the base URL the models.dev catalog gives each.
+ *
+ * OpenCode resolves its API origin per model, and only the OpenAI and Anthropic origins can be
+ * named with an environment variable — so a run on one of these talked straight to its provider
+ * while the proxy saw nothing, and the trace came out empty while the agent answered happily.
+ * A config overlay (see `prepare`) points each at the proxy carrying its own destination, which
+ * is one mechanism for both and for any later first-party provider, at the cost of this table
+ * going stale: a provider added after it was written keeps bypassing capture the way it did
+ * before, which the end-of-run `capture.empty` warning is what says out loud.
+ */
+const OPENCODE_FIRST_PARTY_BASE: Record<string, string> = {
+  opencode: 'https://opencode.ai/zen/v1',
+  'opencode-go': 'https://opencode.ai/zen/go/v1',
+};
+
+/** The environment variable the overlay rides in on, and the one it must never clobber. */
+const CONFIG_CONTENT_VAR = 'OPENCODE_CONFIG_CONTENT';
+
+/**
+ * Shells whose real binary a shim can find again, from OpenCode's own acceptable set — the
+ * POSIX shells it runs commands with, minus the ones it refuses outright.
+ */
+const SHIMMABLE_SHELLS = ['zsh', 'bash', 'sh', 'ksh', 'dash'] as const;
+
+/**
+ * The shell OpenCode falls back to when `SHELL` is unset or one it denies, which is what a
+ * recorded run should resolve through the shim so that it behaves like the unrecorded one.
+ */
+function fallbackShells(): string[] {
+  return process.platform === 'darwin' ? ['zsh', 'bash', 'sh'] : ['bash', 'sh'];
+}
+
+/**
+ * Route OpenCode's shell tool through the shim, by pointing `SHELL` at one.
+ *
+ * OpenCode resolves its shell from this variable and then execs it *by absolute path*, so the
+ * PATH shim in front of `bash` and `sh` never engaged: on macOS every command ran under
+ * `/bin/zsh` and the frames file stayed empty while the trace showed shell tool calls. The shim
+ * named after the real shell keeps every flag OpenCode passes (`-c`, and the login wrappers)
+ * byte-identical — it is argv-transparent — so the run behaves the same and the shim sees it.
+ *
+ * The name is resolved before the run starts, because a shim whose real binary cannot be found
+ * on PATH would answer every command 127 and break the run instead of under-recording it.
+ * `installShellShim` writes one shim per name in its default set; a name that is not there
+ * simply never gets picked, and the end-of-run `shell.ineffective` warning is what reports the
+ * layer as unused.
+ */
+async function shellThroughShim(
+  env: Record<string, string | undefined>,
+  runDir: string,
+): Promise<string | undefined> {
+  if (process.platform === 'win32') return undefined;
+  const shimDir = join(runDir, 'shims');
+  const current = basename(readEnv(env, 'SHELL') ?? '').toLowerCase();
+  const candidates = SHIMMABLE_SHELLS.includes(current as (typeof SHIMMABLE_SHELLS)[number])
+    ? [current, ...fallbackShells()]
+    : fallbackShells();
+  for (const name of new Set(candidates)) {
+    if ((await resolveRealBinary(name, env['PATH'] ?? '', shimDir)) !== undefined) {
+      return join(shimDir, name);
+    }
+  }
+  return undefined;
+}
+
+/**
+ * The config overlay that rewrites OpenCode's per-provider origins through the proxy.
+ *
+ * `provider.<id>.options.baseURL` is the one lever OpenCode honours over its catalog's origin,
+ * and `OPENCODE_CONFIG_CONTENT` is the config source merged last, so the overlay decides the
+ * final URL without touching the user's files. Each base URL is rewritten to
+ * `<proxy>/forward/<encoded base>`: the request arrives at the proxy naming where it was headed,
+ * the proxy records the exchange and forwards to that base — so an OpenAI-compatible provider
+ * whose origin is neither api.openai.com nor api.anthropic.com is captured, not bypassed.
+ *
+ * The user's own `options.baseURL` for the same provider is carried through rather than replaced.
+ * A config that could not be parsed clears the whole overlay: an unreadable intent is not a
+ * licence to reroute someone's provider. And an `OPENCODE_CONFIG_CONTENT` the user already set is
+ * relayed untouched — there is no way to merge two sources of one variable, and clobbering theirs
+ * to add capture would change more than the capture.
+ */
+async function baseURLsThroughProxy(ctx: RecordContext): Promise<Record<string, string>> {
+  // There is no way to merge two sources of one variable, and clobbering theirs to add capture
+  // would change more than the capture — so it is relayed exactly as it arrived.
+  const theirs = readEnv(ctx.env, CONFIG_CONTENT_VAR);
+  if (theirs !== undefined) return { [CONFIG_CONTENT_VAR]: theirs };
+  const scan = await openCodeConfiguredBaseURLs(ctx.env, ctx.cwd);
+  if (!scan.trusted) return {};
+  const provider: Record<string, { options: { baseURL: string } }> = {};
+  for (const [id, catalogBase] of Object.entries(OPENCODE_FIRST_PARTY_BASE)) {
+    const base = scan.overrides.get(id) ?? catalogBase;
+    provider[id] = { options: { baseURL: `${proxyBase(ctx.proxyUrl)}${forwardBasePath(base)}` } };
+  }
+  return { [CONFIG_CONTENT_VAR]: JSON.stringify({ provider }) };
+}
+
+/**
  * OpenCode picks its provider per model, so both origins are redirected: whichever protocol the
- * chosen model speaks, the traffic lands on the proxy.
+ * chosen model speaks, the traffic lands on the proxy. Providers whose origin is neither of the
+ * two — OpenCode's own first-party ones, most visibly — are redirected by the config overlay
+ * below, because no environment variable can name their origin for them.
  */
 export const openCodeAdapter: Adapter = {
   id: 'opencode',
@@ -52,6 +155,15 @@ export const openCodeAdapter: Adapter = {
       passKey(env, ctx.env, 'OPENAI_API_KEY');
       passKey(env, ctx.env, 'ANTHROPIC_API_KEY');
     }
+    Object.assign(env, await baseURLsThroughProxy(ctx));
+
+    // `SHELL` overrides the user's own only to a shim standing in for a shell OpenCode would have
+    // picked anyway. With `--no-shell` there is no shim directory, OpenCode's own resolution
+    // finds nothing there and falls back exactly as it would unrecorded — so the wrong variable
+    // costs nothing, and the right one is what makes the frames file non-empty.
+    const shell = await shellThroughShim(ctx.env, ctx.runDir);
+    if (shell !== undefined) env['SHELL'] = shell;
+
     return { command: 'opencode', args: [...ctx.userArgs], env };
   },
 };

--- a/packages/adapters/test/adapters.test.ts
+++ b/packages/adapters/test/adapters.test.ts
@@ -332,9 +332,119 @@ describe('openCodeAdapter', () => {
 
   it('falls back to placeholders only when the user has no credential at all', async () => {
     // Nothing to flip here, and an SDK client that refuses to start without a key helps nobody.
+    // The branch reads the credential file `opencode auth login` writes in the real home as well
+    // as the environment, so HOME is isolated: on a machine that has signed in to OpenCode the
+    // placeholder branch is unreachable, which is not what this test is about.
+    isolate();
     const none = await openCodeAdapter.prepare(ctx());
     expect(none.env.OPENAI_API_KEY).toBe('orca-recorded');
     expect(none.env.ANTHROPIC_API_KEY).toBe('orca-recorded');
+  });
+
+  it('rewrites the first-party providers through the proxy in a config overlay', async () => {
+    // OpenCode resolves its API origin per model out of its catalog, and no environment variable
+    // names those origins — so a run on `opencode-go` streamed straight to the provider while the
+    // proxy saw nothing and the trace stayed empty. The overlay points each provider at the proxy
+    // with its real base encoded into the path, which is what makes the request carry its own
+    // destination.
+    const launch = await openCodeAdapter.prepare(ctx());
+    const content = JSON.parse(launch.env.OPENCODE_CONFIG_CONTENT!);
+    expect(content.provider['opencode-go'].options.baseURL).toBe(
+      'http://127.0.0.1:51733/forward/' + encodeURIComponent('https://opencode.ai/zen/go/v1'),
+    );
+    expect(content.provider['opencode'].options.baseURL).toBe(
+      'http://127.0.0.1:51733/forward/' + encodeURIComponent('https://opencode.ai/zen/v1'),
+    );
+    // The base-url variables stay, for the providers the overlay does not name.
+    expect(launch.env.OPENAI_BASE_URL).toBe('http://127.0.0.1:51733/v1');
+  });
+
+  it('carries a user-configured base url through the redirect instead of replacing it', async () => {
+    // Someone who set `options.baseURL` for a first-party provider routed those models somewhere
+    // deliberately. The overlay merges last in OpenCode's config order, so clobbering it would
+    // send the recorded run to a host the user never named.
+    const home = isolate();
+    const configDir = join(home, '.config', 'opencode');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(
+      join(configDir, 'opencode.jsonc'),
+      [
+        '{',
+        '  // the corporate gateway fronts the zen models too',
+        '  "provider": {',
+        '    "opencode-go": {',
+        '      "options": {',
+        '        "baseURL": "https://corpo.example/v1",',
+        '      },',
+        '    },',
+        '  },',
+        '}',
+      ].join('\n'),
+    );
+    const launch = await openCodeAdapter.prepare(ctx({ env: { HOME: home, PATH: BARE_PATH } }));
+    const content = JSON.parse(launch.env.OPENCODE_CONFIG_CONTENT!);
+    expect(content.provider['opencode-go'].options.baseURL).toBe(
+      'http://127.0.0.1:51733/forward/' + encodeURIComponent('https://corpo.example/v1'),
+    );
+    // A provider the user left alone still gets the catalog base.
+    expect(content.provider['opencode'].options.baseURL).toBe(
+      'http://127.0.0.1:51733/forward/' + encodeURIComponent('https://opencode.ai/zen/v1'),
+    );
+  });
+
+  it('skips the overlay entirely when the user config cannot be parsed', async () => {
+    // A config orca cannot read is an intent orca cannot honour. Rewriting routing on top of an
+    // unreadable config risks sending the run somewhere the user never named; capturing nothing
+    // is the recoverable failure, and the end-of-run warning says so.
+    const home = isolate();
+    const configDir = join(home, '.config', 'opencode');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, 'opencode.jsonc'), '{ "provider": { "opencode-go": ');
+    const launch = await openCodeAdapter.prepare(ctx({ env: { HOME: home, PATH: BARE_PATH } }));
+    expect('OPENCODE_CONFIG_CONTENT' in launch.env).toBe(false);
+  });
+
+  it('leaves an OPENCODE_CONFIG_CONTENT the user already set standing', async () => {
+    // There is no way to merge two sources of one variable, and clobbering theirs to add capture
+    // would change more than the capture.
+    const theirs = '{"model":"opencode-go/glm-5.3-flash"}';
+    const launch = await openCodeAdapter.prepare(ctx({ env: { OPENCODE_CONFIG_CONTENT: theirs } }));
+    expect(launch.env.OPENCODE_CONFIG_CONTENT).toBe(theirs);
+  });
+
+  it('points SHELL at the shim for a shell OpenCode would have picked anyway', async () => {
+    // OpenCode execs `$SHELL` by absolute path, so a PATH shim never engaged and macOS runs
+    // captured no shell frames at all. The shim must be named after the real shell — OpenCode
+    // accepts it by basename — and the real binary must be on PATH, or every command would 127.
+    if (process.platform === 'win32') return;
+    const runDir = join(scratch, 'run');
+    const launch = await openCodeAdapter.prepare(
+      ctx({
+        runDir,
+        env: { HOME: isolate(), PATH: BARE_PATH, SHELL: '/bin/zsh' },
+      }),
+    );
+    if (process.platform === 'darwin') {
+      expect(launch.env.SHELL).toBe(join(runDir, 'shims', 'zsh'));
+    } else {
+      // The shim name is whichever shell the fallback would use and PATH can resolve again.
+      expect(launch.env.SHELL).toMatch(new RegExp(`.*${join('shims', '(zsh|bash|sh)')}$`));
+    }
+  });
+
+  it('shims the shell OpenCode itself would fall back to', async () => {
+    if (process.platform === 'win32') return;
+    // `fish` is on OpenCode's deny list: unrecorded, it falls back to the platform default, and
+    // the recorded run must fall back to the shim for that same default.
+    const runDir = join(scratch, 'run');
+    const launch = await openCodeAdapter.prepare(
+      ctx({
+        runDir,
+        env: { HOME: isolate(), PATH: BARE_PATH, SHELL: '/usr/local/bin/fish' },
+      }),
+    );
+    const expected = process.platform === 'darwin' ? 'zsh' : 'bash';
+    expect(launch.env.SHELL).toBe(join(runDir, 'shims', expected));
   });
 
   it('detects by ~/.config/opencode, and not at all in a bare environment', async () => {

--- a/packages/adapters/test/harness-versions.test.ts
+++ b/packages/adapters/test/harness-versions.test.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync } from 'node
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { afterAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { Adapter, Launch, RecordContext } from '@orcareplay/plugin-api';
 import { defaultAdapters } from '../src/index.js';
 
@@ -51,6 +51,25 @@ interface HarnessFixture {
 const SCRATCH = mkdtempSync(join(tmpdir(), 'orca-harness-fixture-'));
 afterAll(() => rmSync(SCRATCH, { recursive: true, force: true }));
 
+/**
+ * An empty home, saved and restored. An adapter's `prepare` may consult the real home — OpenCode's
+ * does, because `opencode auth login` writes a credential file there and that file decides the
+ * credential branch — so a fixture recorded on a machine that has signed in reads a different
+ * contract from one that has not. The fixtures describe the adapter, not the machine running the
+ * tests.
+ */
+const SAVED_HOME = { HOME: process.env['HOME'], USERPROFILE: process.env['USERPROFILE'] };
+beforeAll(() => {
+  process.env['HOME'] = SCRATCH;
+  process.env['USERPROFILE'] = SCRATCH;
+});
+afterAll(() => {
+  for (const [name, value] of Object.entries(SAVED_HOME)) {
+    if (value === undefined) delete process.env[name];
+    else process.env[name] = value;
+  }
+});
+
 function ctx(over: Partial<RecordContext> = {}): RecordContext {
   return {
     runId: 'run_fixture',
@@ -58,7 +77,9 @@ function ctx(over: Partial<RecordContext> = {}): RecordContext {
     proxyUrl: PROXY,
     runDir: join(SCRATCH, 'work', '.orca', 'runs', 'run_fixture'),
     userArgs: [...USER_ARGS],
-    env: {},
+    // PATH, because a real run carries one and an adapter may resolve against it — OpenCode's
+    // now points SHELL at a shim, and only when the real shell is findable again.
+    env: { PATH: process.env['PATH'] ?? '' },
     ...over,
   };
 }

--- a/packages/adapters/test/opencode-config.test.ts
+++ b/packages/adapters/test/opencode-config.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { stripJsonc } from '../src/opencode-config.js';
+
+/**
+ * The stripper stands between the user's JSONC config and `JSON.parse`, so every way a comment or
+ * a trailing comma can hide inside a value matters: a URL in prose, a comma inside a string, a
+ * block comment spanning lines. Breaking any of them corrupts a config that would have parsed,
+ * and the adapter then either captures nothing or reroutes on a guess.
+ */
+describe('stripJsonc', () => {
+  it('parses plain JSON unchanged', () => {
+    const text = '{"a":1,"b":[2,3]}';
+    expect(JSON.parse(stripJsonc(text))).toEqual({ a: 1, b: [2, 3] });
+  });
+
+  it('strips line comments, including ones holding urls', () => {
+    const text = [
+      '{',
+      '  // see https://example.com/docs for why',
+      '  "provider": {}, // trailing prose',
+      '}',
+    ].join('\n');
+    expect(JSON.parse(stripJsonc(text))).toEqual({ provider: {} });
+  });
+
+  it('strips block comments and keeps the tokens either side apart', () => {
+    const text = '{"a"/* the key */:/* the value */1}';
+    expect(JSON.parse(stripJsonc(text))).toEqual({ a: 1 });
+  });
+
+  it('leaves comment and comma syntax inside strings alone', () => {
+    const text = '{"url":"https://example.com/a,//b","note":"keep , this } one"}';
+    expect(JSON.parse(stripJsonc(text))).toEqual({
+      url: 'https://example.com/a,//b',
+      note: 'keep , this } one',
+    });
+  });
+
+  it('honours escaped quotes inside strings', () => {
+    const text = '{"say":"a \\"comment\\" // here"}';
+    expect(JSON.parse(stripJsonc(text))).toEqual({ say: 'a "comment" // here' });
+  });
+
+  it('removes trailing commas in objects and arrays', () => {
+    const text = '{"a":[1,2,3,],"b":{"c":1,},}';
+    expect(JSON.parse(stripJsonc(text))).toEqual({ a: [1, 2, 3], b: { c: 1 } });
+  });
+
+  it('keeps the comma a value legitimately ends with from being read as trailing', () => {
+    const text = '{"a":[1,2] ,"b":3}';
+    expect(JSON.parse(stripJsonc(text))).toEqual({ a: [1, 2], b: 3 });
+  });
+
+  it('survives an unterminated string by stopping at the end of input', () => {
+    // The caller treats a failed parse as an untrusted config; the stripper's job is only to
+    // never throw on the way there.
+    expect(() => JSON.parse(stripJsonc('{"a":"unterminated'))).toThrow();
+  });
+
+  it('survives an unterminated block comment', () => {
+    expect(() => JSON.parse(stripJsonc('{"a":1 /* never closed'))).toThrow();
+  });
+});

--- a/packages/cli/src/commands/attach.ts
+++ b/packages/cli/src/commands/attach.ts
@@ -183,6 +183,7 @@ async function runAttached(
     port: requestedPort,
     upstream: plan.upstream,
     upstreamHeaders: plan.headers,
+    upstreamHeadersOrigin: plan.headersOrigin,
     ...tls.proxyOptions,
     onUnmatched: () => {
       unmatched += 1;

--- a/packages/cli/src/commands/record.ts
+++ b/packages/cli/src/commands/record.ts
@@ -500,9 +500,9 @@ async function runRecording(
   /**
    * Shell capture that was on and recorded nothing.
    *
-   * `installShellShim` succeeding means a `bash` and an `sh` were written into the run directory
-   * and put at the front of PATH. It does not mean the harness went through them, and on Windows
-   * Claude Code does not: it finds its shell without consulting PATH, so the shim sits there
+   * `installShellShim` succeeding means a `sh`, a `bash` and a `zsh` were written into the run
+   * directory and put at the front of PATH. It does not mean the harness went through them, and
+   * on Windows Claude Code does not: it finds its shell without consulting PATH, so the shim sits
    * unused while `shell=on` is printed and the frames file stays empty. What is lost is precisely
    * what only the shim can see — the real exit code, the real duration, and which stream each byte
    * came from — while the commands still appear as tool calls, so nothing looks wrong.

--- a/packages/cli/src/commands/record.ts
+++ b/packages/cli/src/commands/record.ts
@@ -213,6 +213,7 @@ async function runRecording(
     mode: 'record',
     upstream: plan.upstream,
     upstreamHeaders: plan.headers,
+    upstreamHeadersOrigin: plan.headersOrigin,
     onExchange: (exchange: RecordedExchange) => {
       modelExchanges += 1;
       writes.push(() => persist(exchange));

--- a/packages/cli/src/commands/replay.ts
+++ b/packages/cli/src/commands/replay.ts
@@ -327,6 +327,7 @@ async function replayExact(args: ParsedArgs, out: Output, ctx: Ctx): Promise<Rep
     loose: args.bool('loose'),
     upstream: plan.upstream,
     upstreamHeaders: plan.headers,
+    upstreamHeadersOrigin: plan.headersOrigin,
     ...tls.proxyOptions,
     onDivergence: (d) => {
       divergences.push(d);
@@ -713,6 +714,7 @@ async function replayFork(
     exchanges: ctx.exchanges,
     upstream: plan.upstream,
     upstreamHeaders: plan.headers,
+    upstreamHeadersOrigin: plan.headersOrigin,
     ...tls.proxyOptions,
     onExchange: (exchange) => {
       writes.push(async () => {

--- a/packages/cli/src/upstream.ts
+++ b/packages/cli/src/upstream.ts
@@ -17,6 +17,15 @@ import { gatewayHeaders, readConfig, resolveUpstream } from './config.js';
 export interface UpstreamPlan {
   upstream: Record<string, string> | undefined;
   headers: Record<string, string> | undefined;
+  /**
+   * The origin the headers belong to, when they belong to one.
+   *
+   * The gateway key is attached per request rather than to every outbound call, because a
+   * forwarded request can legitimately go somewhere the gateway is not — a `/forward/` path names
+   * its own destination, and sending the gateway's credential there hands a third party a key
+   * they were never meant to see, which is the one outcome this plan exists to make impossible.
+   */
+  headersOrigin: string | undefined;
 }
 
 export async function upstreamPlan(
@@ -42,6 +51,7 @@ export async function upstreamPlan(
   return {
     upstream,
     headers: goingToGateway && Object.keys(headers).length > 0 ? headers : undefined,
+    headersOrigin: goingToGateway ? config.gateway!.url : undefined,
   };
 }
 

--- a/packages/proxy/src/forward.ts
+++ b/packages/proxy/src/forward.ts
@@ -1,0 +1,64 @@
+/**
+ * The origin-prefixed path an adapter can hand a client whose base URL orca rewrites.
+ *
+ * Base-URL variables cover the harnesses that read one, and `--tls-intercept` covers the ones
+ * that read none. Between them sits a third shape: a harness that resolves each *provider's*
+ * origin itself — OpenCode picks a base URL per model out of its catalog — so no single
+ * environment variable can name where the traffic was headed. The adapter rewrites that base URL
+ * to `<proxy>/forward/<encoded base>`, and the request arrives carrying its own destination.
+ *
+ * Encoding is `encodeURIComponent` of the whole base URL, so a base with a path in it
+ * (`https://opencode.ai/zen/go/v1`) survives as one opaque first segment and the path the SDK
+ * appends (`/chat/completions`) stays readable after it.
+ */
+export interface ForwardPath {
+  /** The base URL the request was actually addressed to, without a trailing slash. */
+  base: string;
+  /** What follows the prefix: the path the client appended to the base it was given. */
+  path: string;
+}
+
+export const FORWARD_PREFIX = '/forward/';
+
+/**
+ * Decode a `/forward/` path, or undefined when it is not one.
+ *
+ * Every failure decodes to `undefined` rather than throwing, because the prefix sits in a
+ * namespace any client can write to: a POST to `/forward/plain` from a harness that happens to
+ * use that path must fall through to the ordinary handling — passthrough or dialect — and not
+ * become a 500 from a bad `new URL`. The bar for "is one of ours" is deliberately high: the
+ * segment must percent-decode to an absolute http(s) origin-or-base with no credentials, query
+ * or fragment, which no ordinary API path collides with.
+ */
+export function decodeForwardPath(path: string): ForwardPath | undefined {
+  if (!path.startsWith(FORWARD_PREFIX)) return undefined;
+  const rest = path.slice(FORWARD_PREFIX.length);
+  const separator = rest.indexOf('/');
+  const encoded = separator === -1 ? rest : rest.slice(0, separator);
+  const tail = separator === -1 ? '' : rest.slice(separator);
+
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(encoded);
+  } catch {
+    return undefined;
+  }
+
+  let url: URL;
+  try {
+    url = new URL(decoded);
+  } catch {
+    return undefined;
+  }
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') return undefined;
+  if (url.username !== '' || url.password !== '' || url.search !== '' || url.hash !== '') {
+    return undefined;
+  }
+
+  return { base: decoded.replace(/\/+$/, ''), path: tail === '' ? '/' : tail };
+}
+
+/** The path an adapter writes into a rewritten base URL: `<proxy>/forward/<encoded base>`. */
+export function forwardBasePath(base: string): string {
+  return `${FORWARD_PREFIX}${encodeURIComponent(base.replace(/\/+$/, ''))}`;
+}

--- a/packages/proxy/src/index.ts
+++ b/packages/proxy/src/index.ts
@@ -1,4 +1,5 @@
 export * from './matching.js';
+export * from './forward.js';
 export * from './dialects.js';
 export * from './ca.js';
 export * from './intercept.js';

--- a/packages/proxy/src/server.ts
+++ b/packages/proxy/src/server.ts
@@ -30,6 +30,7 @@ import {
   selectDialect,
   type Dialect,
 } from './dialects.js';
+import { decodeForwardPath, type ForwardPath } from './forward.js';
 import {
   attachTlsIntercept,
   decodeRequestBody,
@@ -144,8 +145,17 @@ export interface ProxyOptions {
   fetchImpl?: typeof fetch;
   host?: string;
   port?: number;
-  /** Extra headers to attach to live upstream calls (an API key the agent never saw). */
+  /** Extra headers attached to live upstream calls, and the origin they belong to. */
   upstreamHeaders?: Record<string, string>;
+  /**
+   * The origin {@link upstreamHeaders} are meant for, when they belong to one.
+   *
+   * The gateway's key goes on requests to the gateway and on nothing else: a forwarded request
+   * can name a destination the gateway is not, and attaching the credential anyway would hand a
+   * third party a key they were never meant to see. Unset keeps the old behaviour — headers on
+   * every live call — for callers that attach them per purpose rather than per origin.
+   */
+  upstreamHeadersOrigin?: string;
   /**
    * Where to send a POST whose path no dialect claims.
    *
@@ -317,6 +327,19 @@ function json(res: ServerResponse, status: number, body: unknown): void {
   const text = JSON.stringify(body);
   res.writeHead(status, { 'content-type': 'application/json' });
   res.end(text);
+}
+
+/**
+ * Whether two origin strings name the same scheme, host and port — the test a credential must
+ * pass before travelling with a request. Same shape as the copy in the CLI's upstream plan,
+ * which cannot be imported from here: the proxy is a leaf, and the comparison is two lines.
+ */
+function sameOrigin(a: string, b: string): boolean {
+  try {
+    return new URL(a).origin === new URL(b).origin;
+  } catch {
+    return a.replace(/\/+$/, '') === b.replace(/\/+$/, '');
+  }
 }
 
 export async function createProxy(options: ProxyOptions): Promise<ProxyHandle> {
@@ -509,6 +532,23 @@ export async function createProxy(options: ProxyOptions): Promise<ProxyHandle> {
       )
     : undefined;
 
+  /**
+   * The configured extra headers for one outbound call — only when the call is going where they
+   * belong.
+   *
+   * `upstreamHeaders` exist to put a gateway's credential on calls to that gateway. With a
+   * forwarded request naming its own destination, "every live call" would put the credential on
+   * someone else's origin, so the origin the headers name is attached to them and compared here.
+   * Callers that set headers without an origin get the old behaviour: on every call, their
+   * responsibility.
+   */
+  function headersForOrigin(origin: string): Record<string, string> {
+    const extra = options.upstreamHeaders;
+    if (extra === undefined) return {};
+    if (options.upstreamHeadersOrigin === undefined) return extra;
+    return sameOrigin(origin, options.upstreamHeadersOrigin) ? extra : {};
+  }
+
   async function goLive(
     dialect: Dialect,
     path: string,
@@ -519,6 +559,13 @@ export async function createProxy(options: ProxyOptions): Promise<ProxyHandle> {
     recordableHeaders: Record<string, string>,
     res: ServerResponse,
     startedAt: number,
+    /**
+     * The base URL the request itself names, from a `/forward/` path. It restores the destination
+     * orca took the call away from, so it outranks only the dialect's vendor default — an upstream
+     * the operator configured is an instruction and wins. Dropped on a cross-provider fork, where
+     * the model asked for is being served by a different origin on purpose.
+     */
+    forwardBase?: string,
   ): Promise<void> {
     stats.liveCalls += 1;
 
@@ -551,9 +598,27 @@ export async function createProxy(options: ProxyOptions): Promise<ProxyHandle> {
     // is the common one: someone who passed --upstream-anthropic pointed *this run* at a specific
     // origin, and a gateway serves both dialects from it. Going to api.openai.com instead because
     // the fork changed model would ignore an instruction the user gave explicitly.
+    // Where this call goes, in strict order of who decided it. A `/forward/` path names its own
+    // destination — that is the whole point of the encoding — so on a live call that orca is
+    // merely relaying (record, or a loose replay continuing past its recording) the request's own
+    // base outranks every configured origin: a gateway picked up from `orca setup` is a default
+    // for calls orca would otherwise have to guess at, not a licence to readdress one that
+    // announces where it was headed. A fork is different: substituting the model is the operator
+    // choosing where answers come from, so the fork target's explicit upstream — or the gateway —
+    // decides, and the forwarded base is dropped as incoherent for the substitution.
+    const relaying = options.forkModel === undefined && !crossProvider;
     const origin =
-      options.upstream?.[target.id] ?? options.upstream?.[dialect.id] ?? target.defaultUpstream;
-    const upstreamPath = crossProvider ? target.requestPath : path;
+      relaying && forwardBase !== undefined
+        ? forwardBase
+        : (options.upstream?.[target.id] ??
+          options.upstream?.[dialect.id] ??
+          target.defaultUpstream);
+    // A relayed call keeps the path the client appended, because the base it names expects
+    // exactly that. Everything else is answered by an origin orca chose, which expects the
+    // dialect's own path — and the incoming path cannot be trusted to be it: a bare base url
+    // (no `/v1`) reaches this proxy as `/chat/completions`, and a gateway handed that without the
+    // version segment answers 404.
+    const upstreamPath = relaying && forwardBase !== undefined ? path : target.requestPath;
 
     // Spec §2: "a gateway chose a model". Orca *is* the gateway on this path — it substitutes the
     // model, picks the wire format that serves it, and picks the origin — and it was making all
@@ -582,7 +647,7 @@ export async function createProxy(options: ProxyOptions): Promise<ProxyHandle> {
       headers: {
         'content-type': 'application/json',
         ...headersForModel(headers, options.forkModel),
-        ...(options.upstreamHeaders ?? {}),
+        ...headersForOrigin(origin),
       },
       body: outboundBody,
     });
@@ -664,8 +729,13 @@ export async function createProxy(options: ProxyOptions): Promise<ProxyHandle> {
    * a base URL; the client's own headers say which provider that was, and its own credential is
    * already on the request addressed to them.
    */
-  function passthroughOrigin(headers: Record<string, string>): string {
+  function passthroughOrigin(headers: Record<string, string>, forwardBase?: string): string {
     if (options.passthroughUpstream !== undefined) return options.passthroughUpstream;
+    // A relayed request's own destination, before anything configured: on a live call with no
+    // model substitution, the request says where it was headed, and a gateway picked up from
+    // setup is a default for calls orca would otherwise guess at — not a readdressing of one that
+    // announces its own. A fork is a substitution, and its configured origins decide instead.
+    if (options.forkModel === undefined && forwardBase !== undefined) return forwardBase;
     const configured = [...new Set(Object.values(options.upstream ?? {}))];
     if (configured.length === 1) return configured[0]!;
     const names = new Set(Object.keys(headers).map((h) => h.toLowerCase()));
@@ -692,6 +762,7 @@ export async function createProxy(options: ProxyOptions): Promise<ProxyHandle> {
     recordableHeaders: Record<string, string>,
     res: ServerResponse,
     startedAt: number,
+    forwardBase?: string,
   ): Promise<void> {
     // `hybrid` is a fork, and a fork runs a live agent — so it forwards, exactly as `record` does.
     // Refusing here killed the fork on the first call orca could not read, which is the failure
@@ -710,7 +781,7 @@ export async function createProxy(options: ProxyOptions): Promise<ProxyHandle> {
     }
 
     stats.passedThrough += 1;
-    const origin = passthroughOrigin(headers);
+    const origin = passthroughOrigin(headers, forwardBase);
     const upstreamRes = await doFetch(`${origin}${path}`, {
       method: 'POST',
       // `upstreamHeaders` too, as `goLive` does. Omitting them sent a gateway the agent's own
@@ -719,7 +790,7 @@ export async function createProxy(options: ProxyOptions): Promise<ProxyHandle> {
       headers: {
         'content-type': 'application/json',
         ...headers,
-        ...(options.upstreamHeaders ?? {}),
+        ...headersForOrigin(origin),
       },
       body: rawBody,
     });
@@ -853,14 +924,21 @@ export async function createProxy(options: ProxyOptions): Promise<ProxyHandle> {
       return;
     }
 
-    const dialect = selectDialect(dialects, path);
+    // A `/forward/` path carries the base URL the client was actually given — see
+    // `decodeForwardPath`. The dialect reads the real path behind the prefix, and everything
+    // recorded below does too, so the trace shows the conversation the agent had, not the
+    // envelope orca wrapped it in.
+    const forward: ForwardPath | undefined = decodeForwardPath(path);
+    const dialectPath = forward?.path ?? path;
+
+    const dialect = selectDialect(dialects, dialectPath);
     // Only a POST is ever a model call. Relaxing this to `!dialect && …` let a PUT or a DELETE on
     // a dialect path through to `goLive`, which forwarded it upstream and recorded it as a model
     // exchange; and it turned `GET /v1/messages` into a 400 about unreadable JSON rather than the
     // honest answer. Method first, then passthrough decides what to do with a POST orca cannot read.
     if (req.method !== 'POST') {
       json(res, 404, {
-        error: { message: `orca proxy does not handle ${req.method ?? 'GET'} ${path}` },
+        error: { message: `orca proxy does not handle ${req.method ?? 'GET'} ${dialectPath}` },
       });
       return;
     }
@@ -877,7 +955,15 @@ export async function createProxy(options: ProxyOptions): Promise<ProxyHandle> {
     }
 
     if (!dialect) {
-      await passThrough(path, rawBody, headers, recordableHeaders, res, startedAt);
+      await passThrough(
+        dialectPath,
+        rawBody,
+        headers,
+        recordableHeaders,
+        res,
+        startedAt,
+        forward?.base,
+      );
       return;
     }
 
@@ -889,7 +975,7 @@ export async function createProxy(options: ProxyOptions): Promise<ProxyHandle> {
       json(res, 400, {
         error: {
           message:
-            `orca proxy could not read the body of POST ${path}: expected JSON, got ` +
+            `orca proxy could not read the body of POST ${dialectPath}: expected JSON, got ` +
             `${rawBody === '' ? 'an empty body' : `${rawBody.length} bytes that do not parse`}`,
         },
       });
@@ -897,7 +983,16 @@ export async function createProxy(options: ProxyOptions): Promise<ProxyHandle> {
     }
 
     if (options.mode === 'record') {
-      await goLive(dialect, path, rawBody, headers, recordableHeaders, res, startedAt);
+      await goLive(
+        dialect,
+        dialectPath,
+        rawBody,
+        headers,
+        recordableHeaders,
+        res,
+        startedAt,
+        forward?.base,
+      );
       return;
     }
 
@@ -979,7 +1074,16 @@ export async function createProxy(options: ProxyOptions): Promise<ProxyHandle> {
       }
     }
 
-    await goLive(dialect, path, rawBody, headers, recordableHeaders, res, startedAt);
+    await goLive(
+      dialect,
+      dialectPath,
+      rawBody,
+      headers,
+      recordableHeaders,
+      res,
+      startedAt,
+      forward?.base,
+    );
   }
 
   const host = options.host ?? '127.0.0.1';

--- a/packages/proxy/test/forward.test.ts
+++ b/packages/proxy/test/forward.test.ts
@@ -1,0 +1,300 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import type { NetExchange } from '../src/intercept.js';
+import { createProxy } from '../src/server.js';
+import { decodeForwardPath, forwardBasePath } from '../src/forward.js';
+
+const closers: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  while (closers.length) await closers.pop()!();
+});
+
+/**
+ * A `/forward/` path is how an adapter hands the proxy a request whose real destination orca
+ * rewrote away: the harness's base URL was pointed here with the true base encoded into the path,
+ * so every request arrives naming where it was headed. The assertions are about restoring that
+ * faithfully — same bytes, same path, same wire shape — and about the prefix never firing on a
+ * path that merely looks like one.
+ */
+
+const ZEN_GO = 'https://opencode.ai/zen/go/v1';
+
+describe('decodeForwardPath', () => {
+  it('decodes an encoded base and keeps the appended path', () => {
+    const decoded = decodeForwardPath(`${forwardBasePath(ZEN_GO)}/chat/completions`);
+    expect(decoded).toEqual({ base: ZEN_GO, path: '/chat/completions' });
+  });
+
+  it('decodes a base with no appended path to the root', () => {
+    expect(decodeForwardPath(forwardBasePath('https://api.example.com'))).toEqual({
+      base: 'https://api.example.com',
+      path: '/',
+    });
+  });
+
+  it('strips a trailing slash from the base', () => {
+    const decoded = decodeForwardPath(`${forwardBasePath(`${ZEN_GO}/`)}/chat/completions`);
+    expect(decoded?.base).toBe(ZEN_GO);
+  });
+
+  it('refuses a path that only begins with the prefix', () => {
+    expect(decodeForwardPath('/forward/plain')).toBeUndefined();
+    expect(decodeForwardPath('/forward/https%3A%2F%2F')).toBeUndefined();
+    expect(decodeForwardPath('/forward/%E0%A4%A')).toBeUndefined();
+    expect(decodeForwardPath('/forward/a%2Fb/v1/embeddings')).toBeUndefined();
+  });
+
+  it('refuses anything that is not a bare http(s) base', () => {
+    expect(decodeForwardPath(forwardBasePath('ftp://opencode.ai/x'))).toBeUndefined();
+    expect(
+      decodeForwardPath(forwardBasePath('https://user:pw@opencode.ai/zen/go/v1')),
+    ).toBeUndefined();
+    expect(decodeForwardPath(forwardBasePath('https://opencode.ai/x?key=1'))).toBeUndefined();
+    expect(decodeForwardPath(forwardBasePath('https://opencode.ai/x#frag'))).toBeUndefined();
+  });
+});
+
+function stubUpstream(reply: unknown, status = 200) {
+  const calls: { url: string; body: string; headers: Record<string, string> }[] = [];
+  const fetchImpl = (async (url: string | URL | Request, init: RequestInit = {}) => {
+    calls.push({
+      url: String(url),
+      body: String(init.body ?? ''),
+      headers: (init.headers ?? {}) as Record<string, string>,
+    });
+    return new Response(JSON.stringify(reply), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as unknown as typeof fetch;
+  return { calls, fetchImpl };
+}
+
+async function post(url: string, body: unknown, headers: Record<string, string> = {}) {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', ...headers },
+    body: JSON.stringify(body),
+  });
+  return { status: res.status, text: await res.text() };
+}
+
+const TURN = {
+  model: 'glm-5.3-flash',
+  messages: [{ role: 'user', content: 'hello' }],
+};
+
+describe('record mode — a forwarded origin', () => {
+  it('forwards to the base the request named and records the real path', async () => {
+    const up = stubUpstream({
+      id: 'c1',
+      choices: [{ message: { role: 'assistant', content: 'hi' } }],
+    });
+    const proxy = await createProxy({ mode: 'record', fetchImpl: up.fetchImpl });
+    closers.push(proxy.close);
+
+    const res = await post(`${proxy.url}${forwardBasePath(ZEN_GO)}/chat/completions`, TURN);
+
+    expect(res.status).toBe(200);
+    expect(up.calls[0]!.url).toBe(`${ZEN_GO}/chat/completions`);
+    const exchange = proxy.exchanges()[0]!;
+    expect(exchange.dialect).toBe('openai');
+    expect(exchange.path).toBe('/chat/completions');
+    expect(exchange.canonicalRequest.model).toBe('glm-5.3-flash');
+  });
+
+  it('keeps the caller auth header upstream and out of the trace', async () => {
+    const up = stubUpstream({ id: 'c1', choices: [] });
+    const proxy = await createProxy({ mode: 'record', fetchImpl: up.fetchImpl });
+    closers.push(proxy.close);
+
+    await post(`${proxy.url}${forwardBasePath(ZEN_GO)}/chat/completions`, TURN, {
+      authorization: 'Bearer sk-live-9',
+    });
+
+    expect(up.calls[0]!.headers['authorization']).toBe('Bearer sk-live-9');
+    expect(JSON.stringify(proxy.exchanges()[0])).not.toContain('sk-live-9');
+  });
+
+  it('outranks a configured gateway on a live call, because the request names its own destination', async () => {
+    // A gateway picked up from `orca setup` is a default for calls orca would otherwise have to
+    // guess at. A forwarded request announces where it was headed — and the recorded run that
+    // exposed this answered every turn with the gateway's website 404 page, because
+    // `https://gateway/chat/completions` is not an API path anything serves.
+    const up = stubUpstream({ id: 'c1', choices: [] });
+    const proxy = await createProxy({
+      mode: 'record',
+      fetchImpl: up.fetchImpl,
+      upstream: { openai: 'https://api.orcarouter.ai' },
+    });
+    closers.push(proxy.close);
+
+    const res = await post(`${proxy.url}${forwardBasePath(ZEN_GO)}/chat/completions`, TURN);
+
+    expect(res.status).toBe(200);
+    expect(up.calls[0]!.url).toBe(`${ZEN_GO}/chat/completions`);
+  });
+
+  it('does not carry a gateway key to the destination the request named', async () => {
+    // `upstreamHeaders` are the gateway's credential. Attaching them to every outbound call used
+    // to be harmless because every outbound call went to the gateway; with forwarded requests
+    // going to their own origin, it would hand a third party a key they were never meant to see.
+    const up = stubUpstream({ id: 'c1', choices: [] });
+    const proxy = await createProxy({
+      mode: 'record',
+      fetchImpl: up.fetchImpl,
+      upstream: { openai: 'https://api.orcarouter.ai' },
+      upstreamHeaders: { authorization: 'Bearer sk-gateway-key' },
+      upstreamHeadersOrigin: 'https://api.orcarouter.ai',
+    });
+    closers.push(proxy.close);
+
+    await post(`${proxy.url}${forwardBasePath(ZEN_GO)}/chat/completions`, TURN);
+
+    expect(up.calls[0]!.url).toBe(`${ZEN_GO}/chat/completions`);
+    expect(up.calls[0]!.headers['authorization']).toBeUndefined();
+  });
+
+  it('normalizes the path for an origin orca chose, so a gateway sees its version segment', async () => {
+    // A bare base url (no `/v1`) reaches this proxy as `/chat/completions`; a gateway handed that
+    // without the version segment answers 404. The dialect's own path is what an origin orca
+    // picked expects — which is also what an env-redirected request already carries.
+    const up = stubUpstream({ id: 'c1', choices: [] });
+    const proxy = await createProxy({
+      mode: 'hybrid',
+      exchanges: [],
+      forkAt: 0,
+      forkModel: 'gpt-5.6-luna',
+      fetchImpl: up.fetchImpl,
+      upstream: { openai: 'https://api.orcarouter.ai' },
+      upstreamHeaders: { authorization: 'Bearer sk-gateway-key' },
+      upstreamHeadersOrigin: 'https://api.orcarouter.ai',
+    });
+    closers.push(proxy.close);
+
+    await post(`${proxy.url}${forwardBasePath(ZEN_GO)}/chat/completions`, {
+      ...TURN,
+      model: 'glm-5.3-flash',
+    });
+
+    expect(up.calls[0]!.url).toBe('https://api.orcarouter.ai/v1/chat/completions');
+    expect(up.calls[0]!.headers['authorization']).toBe('Bearer sk-gateway-key');
+  });
+
+  it('sends an unclaimed tail through passthrough to the forwarded base, past a configured gateway', async () => {
+    const up = stubUpstream({ object: 'list', data: [] });
+    const seen: NetExchange[] = [];
+    const proxy = await createProxy({
+      mode: 'record',
+      fetchImpl: up.fetchImpl,
+      onNetExchange: (e) => void seen.push(e),
+    });
+    closers.push(proxy.close);
+
+    const res = await post(`${proxy.url}${forwardBasePath(ZEN_GO)}/v1/embeddings`, {
+      input: 'hello',
+    });
+
+    expect(res.status).toBe(200);
+    expect(up.calls[0]!.url).toBe(`${ZEN_GO}/v1/embeddings`);
+    expect(seen[0]).toMatchObject({ host: 'opencode.ai', path: '/v1/embeddings', status: 200 });
+    expect(proxy.stats().passedThrough).toBe(1);
+  });
+
+  it('lets a configured gateway have an unclaimed tail on a fork, where the fork decides', async () => {
+    // Substituting the model is the operator choosing where answers come from, so the fork's
+    // configured origin decides for an unclaimed tail too.
+    const up = stubUpstream({ object: 'list', data: [] });
+    const proxy = await createProxy({
+      mode: 'hybrid',
+      exchanges: [],
+      forkAt: 0,
+      forkModel: 'gpt-5.6-luna',
+      fetchImpl: up.fetchImpl,
+      upstream: { openai: 'https://api.orcarouter.ai' },
+    });
+    closers.push(proxy.close);
+
+    await post(`${proxy.url}${forwardBasePath(ZEN_GO)}/v1/embeddings`, { input: 'hello' });
+
+    expect(up.calls[0]!.url).toBe('https://api.orcarouter.ai/v1/embeddings');
+  });
+
+  it('treats an undecodable /forward/ path as an ordinary unclaimed path', async () => {
+    const up = stubUpstream({ ok: true });
+    const proxy = await createProxy({
+      mode: 'record',
+      fetchImpl: up.fetchImpl,
+      passthroughUpstream: 'https://api.openai.com',
+    });
+    closers.push(proxy.close);
+
+    const res = await post(`${proxy.url}/forward/plain`, { input: 'x' });
+
+    expect(res.status).toBe(200);
+    expect(up.calls[0]!.url).toBe('https://api.openai.com/forward/plain');
+  });
+
+  it('answers 404 to a GET on a forwarded path, as to any other', async () => {
+    const up = stubUpstream({ ok: true });
+    const proxy = await createProxy({ mode: 'record', fetchImpl: up.fetchImpl });
+    closers.push(proxy.close);
+
+    const res = await fetch(`${proxy.url}${forwardBasePath(ZEN_GO)}/chat/completions`);
+    expect(res.status).toBe(404);
+    expect(await res.text()).toContain('GET');
+    expect(up.calls).toHaveLength(0);
+  });
+});
+
+describe('a cross-provider fork drops the forwarded base', () => {
+  it('serves the fork target from its own origin, not the recorded one', async () => {
+    // Forking an OpenAI-compatible recording onto a Claude model means the answer comes from
+    // api.anthropic.com; the forwarded base pointed at the recorded provider and is incoherent
+    // for the translation. The explicit upstream or the target default decides instead.
+    const up = stubUpstream({
+      id: 'm1',
+      content: [],
+      usage: { input_tokens: 1, output_tokens: 1 },
+    });
+    const proxy = await createProxy({
+      mode: 'hybrid',
+      exchanges: [],
+      forkAt: 0,
+      forkModel: 'claude-opus-5',
+      fetchImpl: up.fetchImpl,
+    });
+    closers.push(proxy.close);
+
+    await post(`${proxy.url}${forwardBasePath(ZEN_GO)}/chat/completions`, TURN);
+
+    expect(up.calls[0]!.url).toBe('https://api.anthropic.com/v1/messages');
+  });
+});
+
+describe('replay — a forwarded path is matched, not forwarded', () => {
+  it('serves a matching exchange from the recording', async () => {
+    // Recorded through the same forward path, so the fixture is an exchange the proxy itself
+    // built — the matcher compares canonical forms, and a hand-written one is a test of the
+    // author's memory of the translator.
+    const reply = { id: 'c1', choices: [{ message: { role: 'assistant', content: 'recorded' } }] };
+    const recorder = stubUpstream(reply);
+    const record = await createProxy({ mode: 'record', fetchImpl: recorder.fetchImpl });
+    closers.push(record.close);
+    await post(`${record.url}${forwardBasePath(ZEN_GO)}/chat/completions`, TURN);
+
+    const up = stubUpstream({ id: 'live', choices: [] });
+    const proxy = await createProxy({
+      mode: 'replay',
+      exchanges: record.exchanges(),
+      fetchImpl: up.fetchImpl,
+    });
+    closers.push(proxy.close);
+
+    const res = await post(`${proxy.url}${forwardBasePath(ZEN_GO)}/chat/completions`, TURN);
+
+    expect(res.status).toBe(200);
+    expect(JSON.parse(res.text).choices[0].message.content).toBe('recorded');
+    expect(up.calls).toHaveLength(0);
+    expect(proxy.stats().matchedExact).toBe(1);
+  });
+});

--- a/packages/shell-shim/src/install.ts
+++ b/packages/shell-shim/src/install.ts
@@ -3,8 +3,15 @@ import { fileURLToPath } from 'node:url';
 import { join } from 'node:path';
 import type { ShellFrame } from './runner.js';
 
-/** Shells an agent actually reaches for. Shimming more binaries buys detail and costs blast radius. */
-export const DEFAULT_SHIMS = ['sh', 'bash'] as const;
+/**
+ * Shells an agent actually reaches for. Shimming more binaries buys detail and costs blast radius.
+ *
+ * `zsh` is here because of how harnesses resolve their shell rather than despite it: OpenCode
+ * reads `$SHELL` and execs that binary by absolute path, so a PATH shim in front of `bash` and
+ * `sh` alone sat unused on every macOS run while the shell tool happily used `/bin/zsh`. The
+ * adapter points `$SHELL` at the shim instead, which requires a shim named `zsh` to exist.
+ */
+export const DEFAULT_SHIMS = ['sh', 'bash', 'zsh'] as const;
 
 export interface InstallOptions {
   runDir: string;

--- a/packages/shell-shim/src/resolve.ts
+++ b/packages/shell-shim/src/resolve.ts
@@ -1,4 +1,4 @@
-import { access, constants, realpath, stat } from 'node:fs/promises';
+import { access, constants, open, realpath, stat } from 'node:fs/promises';
 import { delimiter, extname, join, resolve } from 'node:path';
 
 /**
@@ -8,7 +8,16 @@ import { delimiter, extname, join, resolve } from 'node:path';
  * shim itself: that is an exec loop, and it would happen inside the user's agent run rather than
  * anywhere convenient. Comparison is by resolved real path, because PATH routinely contains the
  * same directory spelled several ways (`/x`, `/x/.`, a symlink) and a string compare misses those.
+ *
+ * One directory is not enough to exclude, though. A run inside a run — or an agent that records
+ * things for a living and is now being recorded — has *another* run's shim directory on PATH, and
+ * a `sh` found there is a shim script, not a binary: spawning it re-runs the runner, which
+ * resolves again, and the command hangs in a hundred-deep exec loop until something kills it. The
+ * shim scripts carry a marker comment, so anything carrying it is refused no matter which
+ * directory it sits in.
  */
+const SHIM_MARKER = 'orca record';
+
 export async function resolveRealBinary(
   name: string,
   pathVar: string,
@@ -23,12 +32,37 @@ export async function resolveRealBinary(
 
     for (const candidateName of candidateNames(name)) {
       const candidate = join(entry, candidateName);
-      if (await isExecutableFile(candidate)) return candidate;
+      if (await isExecutableFile(candidate)) {
+        if (await isOrcaShim(candidate)) continue;
+        return candidate;
+      }
     }
   }
   // Deliberately undefined rather than a guess: exec'ing the wrong binary is worse than a clear
   // error the caller can report.
   return undefined;
+}
+
+/**
+ * Whether the file is one of orca's own shim scripts, identified by its marker comment.
+ *
+ * Read from the head of the file: a script's shebang-and-comment block sits in the first few
+ * hundred bytes, and anything else on PATH is a binary whose first bytes are safe to read and
+ * discard. A file that cannot be read is not a shim — the exec attempt will say what is wrong
+ * with it.
+ */
+async function isOrcaShim(path: string): Promise<boolean> {
+  const handle = await open(path, 'r').catch(() => undefined);
+  if (handle === undefined) return false;
+  try {
+    const buffer = Buffer.alloc(256);
+    const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);
+    return buffer.subarray(0, bytesRead).includes(SHIM_MARKER);
+  } catch {
+    return false;
+  } finally {
+    await handle.close();
+  }
 }
 
 async function safeRealpath(path: string): Promise<string | undefined> {

--- a/packages/shell-shim/test/resolve.test.ts
+++ b/packages/shell-shim/test/resolve.test.ts
@@ -84,6 +84,32 @@ describe('resolveRealBinary', () => {
     );
     expect(found).toBe(join(realDir, executable));
   });
+
+  it.skipIf(process.platform === 'win32')(
+    'refuses a shim another run left on PATH, not only its own',
+    async () => {
+      // A run inside a run — or an agent that records things and is now being recorded — has a
+      // *different* run's shim directory on PATH. A `bash` found there is a shim script, and
+      // spawning it re-runs the runner, which resolves again: the hundred-deep exec loop the
+      // first nested recording turned into. The marker comment is what makes one recognisable.
+      const otherRun = join(root, 'other-run-shims');
+      await mkdir(otherRun);
+      const shimScript = [
+        '#!/bin/sh',
+        '# Written by orca record. Runs the real binary and notes what happened.',
+        `exec node runner-bin.js bash ${otherRun} frames -- "$@"`,
+        '',
+      ].join('\n');
+      await writeFile(join(otherRun, executable), shimScript);
+      await chmod(join(otherRun, executable), 0o755);
+      const found = await resolveRealBinary(
+        'bash',
+        `${otherRun}${delimiter}${shimDir}${delimiter}${realDir}`,
+        shimDir,
+      );
+      expect(found).toBe(join(realDir, executable));
+    },
+  );
 });
 
 describe('resolveRunnerBin', () => {

--- a/packages/shell-shim/test/shim.test.ts
+++ b/packages/shell-shim/test/shim.test.ts
@@ -1,4 +1,5 @@
 import { execFile } from 'node:child_process';
+import { existsSync } from 'node:fs';
 import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -159,7 +160,24 @@ describe('shell shim', () => {
     expect(contents).not.toBe('');
     expect(shim.shimmed).toContain('sh');
     expect(shim.shimmed).toContain('bash');
+    // zsh is the shell OpenCode's tool resolves to on macOS, where it execs `$SHELL` by absolute
+    // path — the shim only captures anything there because a `zsh` shim exists to point at.
+    expect(shim.shimmed).toContain('zsh');
+    expect(await readFile(join(shim.dir, 'zsh'), 'utf8').catch(() => '')).not.toBe('');
   });
+
+  // Where zsh exists at all, its shim must pass a command through and record it. macOS has one
+  // at /bin/zsh; a minimal Linux image may not, and that is a fact about the image, not the shim.
+  const zshOnPath = ['/bin/zsh', '/usr/bin/zsh', '/usr/local/bin/zsh'].some((p) => existsSync(p));
+  it.skipIf(process.platform === 'win32' || !zshOnPath)(
+    'passes a zsh command through byte for byte and records it',
+    async () => {
+      const result = await through('zsh', ['-c', 'printf zsh-out']);
+      expect(result.stdout).toBe('zsh-out');
+      const [frame] = await readShellFrames(shim.framesPath);
+      expect(frame).toMatchObject({ name: 'zsh', argv: ['-c', 'printf zsh-out'] });
+    },
+  );
 
   it.skipIf(process.platform !== 'win32')(
     'writes command shims Windows can launch from PATH',
@@ -168,7 +186,7 @@ describe('shell shim', () => {
       expect(contents).toContain('@echo off');
       expect(contents).toContain('%*');
       expect(await readFile(join(shim.dir, 'bash.cmd'), 'utf8')).not.toBe('');
-      expect(shim.shimmed).toEqual(['sh', 'bash']);
+      expect(shim.shimmed).toEqual(['sh', 'bash', 'zsh']);
     },
   );
 });


### PR DESCRIPTION
<!-- orca-cr-summary:start -->
<!-- orca-code-review-summary -->
<!-- orca-cr-state: {"p0":0,"p1":0,"p2":0,"p3":0,"push":1} -->

## Orca-Code-Review — push 1

| Severity | Count |
|---|---|
| P0 | 0 |
| P1 | 0 |
| P2 | 0 |
| P3 | 0 |

✅ no blocking findings
<!-- orca-cr-summary:end -->

## The failure, met on a real recording

`orca record opencode` on an `opencode-go` model: the agent answered happily, exited zero, and the trace held two events (`run.start`, `fs.snapshot`). No `model.request`, no `model.response`, and an empty `shell-frames.jsonl` — while `lsof` showed the agent's one established connection going to `172.65.90.21:443`, the provider, and nothing to the proxy. Two capture layers were silently absent:

1. **OpenCode resolves its API origin per model, and only two origins can be named with an environment variable.** `OPENAI_BASE_URL` and `ANTHROPIC_BASE_URL` cover `api.openai.com` and `api.anthropic.com`; OpenCode's own first-party providers (`opencode`, `opencode-go`) resolve their base from the catalog (`https://opencode.ai/zen/go/v1`) and no variable names it, so the traffic never reached the proxy. The adapter's own comment claimed "whichever protocol the chosen model speaks, the traffic lands on the proxy" — the assumption behind that is false for any third origin.
2. **OpenCode's shell tool resolves its interpreter from `$SHELL` and execs it by absolute path.** The PATH shim in front of `bash`/`sh` never engaged; the log said `shell tool using shell /bin/zsh` and the frames file stayed empty while every command ran.

## The fix

**Origin-prefixed forwarding** (`proxy`): an adapter rewrites a provider base to `<proxy>/forward/<encodeURIComponent(base)>`, so every request arrives naming its own destination. The decoder is strict (http(s), no credentials/query/fragment, `undefined` on anything else, so the prefix never fires on a path that merely looks like one). Dialect selection and the recorded trace use the real path behind the prefix.

Routing, by who decided it:

- a live relay (record, or `--loose` continuation) goes to the base the request named — a gateway from `orca setup` is a *default*, not a readdressing of a request that announces its own destination. This ordering is not theoretical: the first version let the configured gateway win, and every turn came back `404` — the gateway's website HTML, recorded faithfully in the trace;
- a fork substitutes the model, which is the operator choosing where answers come from: the fork's explicit upstream decides, the forwarded base is dropped, and the path is normalized to the dialect's own (`/chat/completions` → `/v1/chat/completions`), because a gateway handed a version-less path answers 404;
- the gateway's credential goes only where the gateway is: `upstreamHeaders` now name their origin and are attached only on matching calls, so a forwarded request to a third origin never carries the gateway's key.

**The opencode adapter**: writes a config overlay in `OPENCODE_CONFIG_CONTENT` (merged last by OpenCode) pointing the first-party providers at the proxy through the mechanism above. It honours routing the user configured — their own `options.baseURL` for the same provider is carried *through* the redirect rather than replaced, read from the same JSONC files OpenCode reads; an unparseable config disables the overlay entirely; a user-set `OPENCODE_CONFIG_CONTENT` is relayed untouched. And `SHELL` points at a run shim named after a shell OpenCode would resolve anyway, guarded by resolvability — a shim whose real binary is missing would 127 every command instead of under-recording.

**shell-shim**: `zsh` joins the default shims, and `resolveRealBinary` now refuses *any* run's shim found on PATH, not only its own — found because the test suite hung: a run inside a run has another run's shim directory on PATH, and resolving a shim script as a binary is a hundred-deep exec loop inside the user's agent run.

## Verified against the running harness

`opencode run --agent glm53-flash -m opencode-go/glm-5.3-flash` under the fixed proxy: 3/3 model exchanges at status 200 (title generator → `tool_use` → `end_turn`), the shell command captured in a zsh frame (argv, exit code, duration, byte counts), exit 0 — where the same command without the fix recorded one 404 HTML page per turn and never reached the model. The harness fixture is updated in the same change with `verified_at` set to that day, per the fixture's own rule.

## Tests

- proxy 200/200, adapters 274/274 (new: forward decoding/routing/credential-gating suite, JSONC stripper suite, opencode overlay + SHELL tests, nested-shim refusal).
- Full suite compared per test against `main`: **11 failures on both, identical lists** — pre-existing and environment-dependent (network/toolchain), none in the proxy, adapters or shell-shim.