### PR TITLE
proxy: match a dialect on the path, not on the path plus its query string

### DIFF
--- a/packages/proxy/src/server.ts
+++ b/packages/proxy/src/server.ts
@@ -389,7 +389,12 @@ export async function createProxy(options: ProxyOptions): Promise<ProxyHandle> {
    * falls through to `net.request` / `net.response`, where it is described but not interpreted.
    */
   function onDecrypted(exchange: NetExchange): void {
-    const dialect = selectDialect(dialects, exchange.path);
+    // On the path alone. A dialect matches an endpoint, and a query string is not part of the
+    // endpoint -- Azure OpenAI's are all `?api-version=...`, so matching the raw path recorded
+    // those runs as opaque network traffic that cannot be replayed or forked, while telling the
+    // operator no dialect claimed the path. `onInterceptedRequest` below has always split it off
+    // for exactly this reason; the recording side had not.
+    const dialect = selectDialect(dialects, exchange.path.split('?')[0] ?? exchange.path);
     if (dialect && exchange.method === 'POST' && !exchange.requestTruncated) {
       try {
         // Codex's HTTPS fallback currently labels this SSE body as application/json. The wire

--- a/packages/proxy/test/tls-intercept.test.ts
+++ b/packages/proxy/test/tls-intercept.test.ts
@@ -664,6 +664,30 @@ describe('TLS interception', () => {
     expect(netExchanges).toHaveLength(0);
   });
 
+  it('recognises a model API call whose endpoint carries a query string', async () => {
+    const handle = await startProxy([`127.0.0.1:${model.port}`]);
+
+    await through({
+      proxyPort: handle.port,
+      host: '127.0.0.1',
+      port: model.port,
+      trust: [runCa.certPem],
+      method: 'POST',
+      // What Azure OpenAI's endpoints look like, and they are not optional there.
+      path: '/v1/chat/completions?api-version=2026-02-01',
+      body: JSON.stringify({ model: 'gpt-5.2', messages: [{ role: 'user', content: 'hello' }] }),
+      headers: { 'content-type': 'application/json' },
+    });
+
+    // Matching the raw path recorded this as net traffic: unreplayable, unforkable, and reported
+    // as a path no dialect claims.
+    expect(modelExchanges).toHaveLength(1);
+    expect(modelExchanges[0]!.dialect).toBe('openai');
+    expect(netExchanges).toHaveLength(0);
+    // The query stays in the trace -- it is what the agent asked for; only the match ignores it.
+    expect(modelExchanges[0]!.path).toBe('/v1/chat/completions?api-version=2026-02-01');
+  });
+
   it.skipIf(zstdCompressSync === undefined)(
     'replays a zstd-compressed Codex request inside intercepted TLS',
     async () => {


### PR DESCRIPTION
<!-- orca-cr-summary:start -->
<!-- orca-code-review-summary -->
<!-- orca-cr-state: {"p0":0,"p1":0,"p2":0,"p3":0,"push":1} -->

## Orca-Code-Review — push 1

| Severity | Count |
|---|---|
| P0 | 0 |
| P1 | 0 |
| P2 | 0 |
| P3 | 0 |

✅ no blocking findings
<!-- orca-cr-summary:end -->

One line, and the same file already does it forty-five lines below.

`onDecrypted` — the recording side — passed the raw request path to `selectDialect`.
`onInterceptedRequest` — the replay side — has always done `request.path.split('?')[0]` first. So
the same proxy matched a dialect when replaying a request and missed it when recording one.

## What it costs

Measured against one controlled origin, same body, only the query differing:

| path | recorded as |
|---|---|
| `/v1/chat/completions` | `model.request` + `model.response` |
| `/v1/chat/completions?api-version=2026-02-01` | `net.request` + `net.response` |

The second is not a corner case: **Azure OpenAI's endpoints carry `?api-version=` and it is not
optional there.** A run against one records traffic that cannot be replayed and cannot be forked,
and the only thing the run says about it is

```
warn tls.unclaimed_path path=/v1/chat/completions?api-version=2026-02-01
  detail="decrypted and recorded, but no wire dialect claims this path"
  next="docs/plugins.md to add a dialect for it"
```

— pointing the operator at the docs to write a dialect that already exists and already matches.

## The change

A dialect matches an endpoint, and a query string is not part of the endpoint. The path stays in
the trace in full, because that is what the agent asked for; only the match ignores the query. The
test asserts both halves.

## How it was found

By driving oversized responses at a controlled origin for an unrelated check, and noticing that
even the small control case came back as `net.*`. The test is written the way that would have
caught it: the same request as the neighbouring `records an intercepted model API call as a model
exchange` test, with a query string on the endpoint.

Mutation-checked: restoring the raw path turns exactly that test red and nothing else. Full suite
compared per-test against `main` — same failures either way; the one difference,
`e2e.test.ts > does not leave a copy of the working tree in the temp directory`, is a temp-dir race
under parallel load that passes 3/3 in isolation with this change and 2/2 without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
