### PR TITLE
mcp registry: publish the server where clients look for it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,3 +68,21 @@ jobs:
               ( cd "$dir" && npm publish --provenance --access public )
             fi
           done
+
+      # The npm packages are the artefact; this makes them findable. Ownership is proved twice at
+      # once: `mcpName` in packages/cli/package.json must equal the name in server.json, and GitHub
+      # OIDC proves the workflow really runs in this repository. No token is stored, and there is no
+      # interactive login — which is why this could not be done by hand.
+      #
+      # A dry run must not reach the registry either, so the whole step is skipped for it.
+      - name: Publish to the MCP Registry
+        if: ${{ github.event.inputs.dry-run != 'true' }}
+        run: |
+          set -euo pipefail
+          os=$(uname -s | tr '[:upper:]' '[:lower:]')
+          arch=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_${os}_${arch}.tar.gz" | tar xz mcp-publisher
+          node scripts/sync-server-json.mjs "${GITHUB_REF#refs/tags/v}"
+          ./mcp-publisher validate
+          ./mcp-publisher login github-oidc
+          ./mcp-publisher publish

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# Ships only the MCP server, not the recorder.
+#
+# Recording works by wrapping a process on the host — a local proxy, a PATH shim, a shadow git
+# index. None of that survives a container boundary, so `orca record` inside here would watch an
+# empty namespace. What does travel is the read side: the six MCP tools serve runs that already
+# exist on disk, so a client mounts its `.orca` directory and reads it.
+#
+#   docker run -i --rm -v "$PWD/.orca:/work/.orca:ro" orcareplay
+#
+# Read-only is deliberate. `orca_replay` and `orca_compare` execute a real agent and can spend
+# money, so a container that only ever reads is the honest default; drop `:ro` if you mean to
+# fork from in here.
+FROM node:22-alpine
+
+ENV NODE_ENV=production
+WORKDIR /work
+
+# Pinned, not `latest`: an image that silently changes what it runs is the opposite of the point.
+RUN npm install -g --omit=dev orcareplay@0.2.2
+
+# stdio transport — the client owns stdin/stdout, so no port is exposed.
+ENTRYPOINT ["orca", "mcp"]

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,7 @@
 {
   "name": "orcareplay",
   "version": "0.2.1",
+  "mcpName": "io.github.Continuum-AI-Corp/orcareplay",
   "type": "module",
   "license": "Apache-2.0",
   "description": "Record, replay and fork debugger for AI agents",

--- a/scripts/sync-server-json.mjs
+++ b/scripts/sync-server-json.mjs
@@ -1,0 +1,13 @@
+// `server.json` carries its own version, and the MCP Registry rejects a publish whose version it
+// has already seen. Deriving it from the tag keeps one number in one place: forget to edit this
+// file and the release fails, which is the wrong failure to have at publish time.
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const version = process.argv[2];
+if (!version) throw new Error('usage: sync-server-json.mjs <version>');
+
+const manifest = JSON.parse(readFileSync('server.json', 'utf8'));
+manifest.version = version;
+for (const pkg of manifest.packages ?? []) pkg.version = version;
+writeFileSync('server.json', `${JSON.stringify(manifest, null, 2)}\n`);
+console.log(`server.json -> ${version}`);

--- a/server.json
+++ b/server.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.Continuum-AI-Corp/orcareplay",
+  "description": "Read, replay and fork recorded coding-agent runs. Capture happens below the harness, so model traffic, shell exit codes, per-turn file changes and MCP calls share one timeline.",
+  "repository": {
+    "url": "https://github.com/Continuum-AI-Corp/OrcaReplay",
+    "source": "github"
+  },
+  "version": "0.2.2",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "orcareplay",
+      "version": "0.2.2",
+      "transport": {
+        "type": "stdio"
+      },
+      "runtimeArguments": [
+        {
+          "type": "positional",
+          "value": "mcp",
+          "isRequired": true,
+          "description": "Serves the six read-and-replay tools over stdio."
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
<!-- orca-cr-summary:start -->
<!-- orca-code-review-summary -->
<!-- orca-cr-state: {"p0":0,"p1":0,"p2":0,"p3":0,"push":1} -->

## Orca-Code-Review — push 1

| Severity | Count |
|---|---|
| P0 | 0 |
| P1 | 0 |
| P2 | 0 |
| P3 | 0 |

✅ no blocking findings
<!-- orca-cr-summary:end -->

Adds `server.json`, `mcpName`, an OIDC publish step in the release workflow, and a Dockerfile for the MCP server.

**Why now.** Three directories were blocked on exactly this: the official MCP Registry needs `server.json` + `mcpName`; PulseMCP has paused manual submissions and says it will auto-ingest from the official registry when it reopens; Docker's MCP catalog requires a Dockerfile in the source repo.

**The three pieces must agree.** `server.json` names the server and its npm package; `mcpName` in `packages/cli/package.json` must equal that name; the registry reads both and refuses a publish when they disagree — that is how it verifies ownership. GitHub OIDC supplies the identity, so no token is stored, and `mcp-publisher login github-oidc` only works from inside Actions.

**Version drift is designed out.** `scripts/sync-server-json.mjs` derives the version from the tag. The registry rejects a version it has already seen, so a forgotten manual edit would fail *after* npm had published — the worst moment. Same reasoning as the `ORCA_VERSION` fix in 0.2.1.

**The Dockerfile is deliberately read-only in spirit.** Recording wraps a host process; a local proxy, a PATH shim and a shadow git index do not cross a container boundary, so `orca record` inside would watch an empty namespace. What travels is the read side — mount `.orca` and the six MCP tools serve runs that already exist. The documented invocation mounts it `:ro`, because `orca_replay` and `orca_compare` run a real agent and can spend money.

**Not verified locally:** no Docker on this machine, so the image has not been built here. It also pins `orcareplay@0.2.2`, which does not exist until this ships — the image is buildable only after the release.

Gate: typecheck rc=0, conformance 38 events / 0 failures, version test passes.