### PR TITLE
git was rewriting the bytes a trace is hashed over

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,19 @@
+# A trace is evidence, and its integrity is a byte hash over the file. Git's newline conversion
+# rewrites those bytes on a Windows checkout, so a freshly cloned example fails its own integrity
+# check for a reason that has nothing to do with the reader. Before this file existed, every trace
+# under examples/ arrived with CRLF on Windows and `verify_integrity()` returned False on a run
+# that was intact in the repository — the failure mode this project exists to rule out.
+
+# Normalise to LF in the index and check out LF everywhere. The tooling, the tests and the trace
+# format all assume LF; nothing here wants CRLF.
+* text=auto eol=lf
+
+# Content-addressed. Never rewritten, in either direction.
+examples/traces/** -text
+packages/*/fixtures/** -text
+packages/*/test/fixtures/** -text
+
+*.png binary
+*.jpg binary
+*.gz binary
+*.zip binary

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -52,7 +52,10 @@ def write_trace(
     directory.mkdir(parents=True, exist_ok=True)
     body = "".join(json.dumps(e, separators=(",", ":")) + "\n" for e in events) + trailing
     events_path = directory / "events.jsonl"
-    events_path.write_text(body, encoding="utf-8")
+    # newline="" or Windows rewrites every LF as CRLF on the way out, while the digest below is
+    # taken over the LF form. The file then fails its own integrity check for a reason that has
+    # nothing to do with the reader, which hashes bytes.
+    events_path.write_text(body, encoding="utf-8", newline="")
 
     for digest, payload in (blobs or {}).items():
         shard = directory / "blobs" / digest[:2]


### PR DESCRIPTION
<!-- orca-cr-summary:start -->
<!-- orca-code-review-summary -->
<!-- orca-cr-state: {"p0":0,"p1":0,"p2":0,"p3":0,"push":1} -->

## Orca-Code-Review — push 1

| Severity | Count |
|---|---|
| P0 | 0 |
| P1 | 0 |
| P2 | 0 |
| P3 | 0 |

✅ no blocking findings
<!-- orca-cr-summary:end -->

Cloning this repository on Windows produces example traces that fail their own integrity check.

## What happens

There is no `.gitattributes`, so git applies its default newline conversion on checkout. Every LF in `examples/traces/**` becomes CRLF on disk. `verify_integrity()` hashes bytes — correctly — so it reports a mismatch on a run that is byte-perfect in the repository.

```
examples/traces/run_9f2c14a03b71/manifest.json: CRLF=46 LF=46   # before
examples/traces/run_9f2c14a03b71/manifest.json: CRLF=0  LF=46   # after
```

Three Python conformance tests fail for this reason and no other. It is invisible on Linux and in CI, which is why it survived.

**This is the failure mode the project exists to rule out.** A tool whose output is evidence must not have that evidence altered between the repository and the disk. A user who clones, runs the example, and sees `ok=False` has every reason to distrust the reader — and would be wrong, which is worse than a plain bug.

## The fix

`* text=auto eol=lf` for the default. Traces and fixtures marked `-text` so they are never rewritten in either direction, since they are addressed by content hash.

## Same bug in miniature, in the test helper

`conftest.write_trace` wrote `events.jsonl` with `write_text` (which translates newlines on Windows) and then hashed the untranslated string. Two more failures, same cause, `newline=""` fixes it.

## Result

Python suite on Windows: **180 passed, 0 failed** — was 5 failed / 175 passed. typecheck rc=0, conformance 38 events / 0 failures. The JS suite's 23 Windows-only failures are unchanged and unrelated (path separators).