### PR TITLE
ship the MCP server image to ghcr.io

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -1,0 +1,90 @@
+# Publishes the MCP server image to GitHub Container Registry.
+#
+# ghcr.io needs no credential beyond the workflow's own GITHUB_TOKEN, so this costs nothing to
+# operate and nothing to rotate. It also gives Docker's MCP catalog and any OCI client a real
+# image to pull instead of a Dockerfile they have to build themselves.
+#
+# Separate from release.yml on purpose: the npm publish must not wait on a container build, and a
+# Dockerfile fix must not force a version bump across twelve npm packages. It runs after a release
+# tag because the Dockerfile pins an exact npm version — building before that version exists would
+# fail, and building `latest` would make the image silently change what it runs.
+name: Release (image)
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Build without pushing'
+        type: boolean
+        default: true
+
+env:
+  IMAGE: ghcr.io/${{ github.repository_owner }}/orcareplay
+
+jobs:
+  image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write # provenance attestation, same reasoning as npm
+    steps:
+      - uses: actions/checkout@v4
+
+      # The Dockerfile pins the npm version. If it disagrees with the tag we would ship an image
+      # whose name says one thing and whose contents say another — the exact failure the
+      # ORCA_VERSION fix was about.
+      - name: Dockerfile pin matches the tag
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF#refs/tags/v}"
+          pin=$(grep -oE 'orcareplay@[0-9]+\.[0-9]+\.[0-9]+' Dockerfile | head -1 | cut -d@ -f2)
+          [ "$tag" = "$pin" ] || { echo "tag v$tag but Dockerfile pins $pin"; exit 1; }
+
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to ghcr.io
+        if: ${{ github.event.inputs.dry-run != 'true' }}
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Version
+        id: v
+        run: |
+          case "${GITHUB_REF}" in
+            refs/tags/v*) echo "value=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT" ;;
+            *) echo "value=$(node -p "require('./packages/cli/package.json').version")" >> "$GITHUB_OUTPUT" ;;
+          esac
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event.inputs.dry-run != 'true' }}
+          tags: |
+            ${{ env.IMAGE }}:${{ steps.v.outputs.value }}
+            ${{ env.IMAGE }}:latest
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.description=Read recorded coding-agent runs over MCP
+            org.opencontainers.image.licenses=Apache-2.0
+          provenance: true
+          sbom: true
+
+      # Same guarantee npm provenance gives: this image came from this workflow, from this commit.
+      - name: Attest
+        if: ${{ github.event.inputs.dry-run != 'true' }}
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.IMAGE }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true


### PR DESCRIPTION
<!-- orca-cr-summary:start -->
<!-- orca-code-review-summary -->
<!-- orca-cr-state: {"p0":0,"p1":0,"p2":0,"p3":0,"push":1} -->

## Orca-Code-Review — push 1

| Severity | Count |
|---|---|
| P0 | 0 |
| P1 | 0 |
| P2 | 0 |
| P3 | 0 |

✅ no blocking findings
<!-- orca-cr-summary:end -->

Publishes the MCP server image to GitHub Container Registry on a release tag.

**Why.** Docker's MCP catalog submission ([docker/mcp-registry#4947](https://github.com/docker/mcp-registry/pull/4947)) and any OCI client currently have a Dockerfile they must build themselves. `ghcr.io` needs no credential beyond the workflow's own `GITHUB_TOKEN`, so this costs nothing to operate and nothing to rotate — unlike Docker Hub, which would need an account and a stored token.

**Separate workflow, same reasoning as the Python one.** The npm publish must not wait on a container build, and a Dockerfile fix must not force a version bump across twelve npm packages.

**It runs on a release tag, not on push.** The Dockerfile pins an exact npm version: building before that version exists fails, and pinning `latest` would let the image silently change what it runs — which is the opposite of the point for a tool whose output is evidence.

**A guard checks the tag against the Dockerfile pin.** Shipping an image whose name says one version and whose contents say another is the `ORCA_VERSION` failure from 0.2.1, one layer down. Better to fail the release than to publish a mislabelled image.

**Also attests.** `provenance: true`, `sbom: true`, plus a build-provenance attestation pushed to the registry — the same guarantee npm provenance gives: this image came from this workflow, from this commit.

Multi-arch: `linux/amd64` and `linux/arm64`.

**Not verified yet:** `workflow_dispatch` only works once the file is on the default branch, so the dry run has not run. I will trigger it immediately after merge and report — that build is also what settles the open question in the Docker catalog PR, where I said plainly I could not build the image locally.