### PR TITLE
proxy: relay the query the client wrote, and stop a test blaming its neighbours

### DIFF
--- a/packages/cli/test/e2e.test.ts
+++ b/packages/cli/test/e2e.test.ts
@@ -249,16 +249,30 @@ describe('end to end: record → replay → fork', () => {
     // removed — one per `orca replay`, growing with the size of your checkout, in a directory
     // `orca gc` deliberately will not sweep because it only reclaims fork worktrees. Replay owns
     // it, so replay has to clean it up.
+    //
+    // Watched in a temp directory of this test's own, not in the machine's. Diffing a listing of
+    // the whole OS temp dir before and after cannot tell a directory *this* replay created from
+    // one another test's replay created in the same window, so under the parallel suite it failed
+    // with nothing wrong. `replay.ts` calls `tmpdir()` at the moment it mkdtemps, so redirecting
+    // it here is enough, and leaves the product's own output alone.
+    const isolatedTmp = await mkdtemp(join(tmpdir(), 'orca-e2e-tmp-'));
+    const outerTmp = { TEMP: process.env.TEMP, TMP: process.env.TMP, TMPDIR: process.env.TMPDIR };
+    process.env.TEMP = isolatedTmp;
+    process.env.TMP = isolatedTmp;
+    process.env.TMPDIR = isolatedTmp;
     process.env.FAKE_AGENT_READ = 'auth.ts';
     try {
-      const before = await readdir(tmpdir());
       await record();
       await replayCommand(parseArgs(['replay', 'last']), out, workspace);
-      const after = await readdir(tmpdir());
-      const leaked = after.filter((e) => e.startsWith('orca-safety-') && !before.includes(e));
+      const leaked = (await readdir(isolatedTmp)).filter((e) => e.startsWith('orca-safety-'));
       expect(leaked, 'the pre-replay snapshot store must not outlive the replay').toEqual([]);
     } finally {
       delete process.env.FAKE_AGENT_READ;
+      for (const [key, value] of Object.entries(outerTmp)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+      await rm(isolatedTmp, { recursive: true, force: true });
     }
   });
 

--- a/packages/proxy/src/server.ts
+++ b/packages/proxy/src/server.ts
@@ -633,7 +633,17 @@ export async function createProxy(options: ProxyOptions): Promise<ProxyHandle> {
     // dialect's own path — and the incoming path cannot be trusted to be it: a bare base url
     // (no `/v1`) reaches this proxy as `/chat/completions`, and a gateway handed that without the
     // version segment answers 404.
-    const upstreamPath = relaying && forwardBase !== undefined ? path : target.requestPath;
+    //
+    // The query survives the substitution either way, because it is not part of the endpoint's
+    // shape. A path says which endpoint; a query says how to call it, and the client set it —
+    // `?api-version=` is required on every Azure OpenAI call, and dropping it turns a working
+    // configuration into `404 Resource not found` with nothing in the run explaining why.
+    // Replacing a path is orca normalising an address it chose; replacing the parameters would
+    // be orca editing the request.
+    const queryAt = path.indexOf('?');
+    const query = queryAt === -1 ? '' : path.slice(queryAt);
+    const upstreamPath =
+      relaying && forwardBase !== undefined ? path : `${target.requestPath}${query}`;
 
     // Spec §2: "a gateway chose a model". Orca *is* the gateway on this path — it substitutes the
     // model, picks the wire format that serves it, and picks the origin — and it was making all
@@ -932,7 +942,17 @@ export async function createProxy(options: ProxyOptions): Promise<ProxyHandle> {
 
   async function handle(req: IncomingMessage, res: ServerResponse): Promise<void> {
     const startedAt = Date.now();
-    const path = (req.url ?? '/').split('?')[0] ?? '/';
+    // Split, not discarded. Two different questions are asked of a request line here and they
+    // want different halves of it: *which endpoint is this* is answered by the path alone —
+    // `selectDialect` matches an endpoint and a query is not part of one — while *what do I
+    // send upstream* wants the line as the client wrote it. Dropping the query at the top answered
+    // the first question and silently lost the second: a client calling
+    // `<base>/chat/completions?api-version=2026-02-01` reached its origin as
+    // `/v1/chat/completions`, which is `404 Resource not found` on Azure OpenAI, where that
+    // parameter is required on every call. The trace lost it too, so nothing in the run said why.
+    const rawPath = req.url ?? '/';
+    const path = rawPath.split('?')[0] ?? '/';
+    const query = rawPath.slice(path.length);
 
     if (path === '/__orca/health') {
       json(res, 200, { ok: true, ...stats });
@@ -945,6 +965,8 @@ export async function createProxy(options: ProxyOptions): Promise<ProxyHandle> {
     // envelope orca wrapped it in.
     const forward: ForwardPath | undefined = decodeForwardPath(path);
     const dialectPath = forward?.path ?? path;
+    /** What goes upstream and into the trace: the endpoint orca resolved, called the way it was. */
+    const requestedPath = `${dialectPath}${query}`;
 
     const dialect = selectDialect(dialects, dialectPath);
     // Only a POST is ever a model call. Relaxing this to `!dialect && …` let a PUT or a DELETE on
@@ -971,7 +993,7 @@ export async function createProxy(options: ProxyOptions): Promise<ProxyHandle> {
 
     if (!dialect) {
       await passThrough(
-        dialectPath,
+        requestedPath,
         rawBody,
         headers,
         recordableHeaders,
@@ -1000,7 +1022,7 @@ export async function createProxy(options: ProxyOptions): Promise<ProxyHandle> {
     if (options.mode === 'record') {
       await goLive(
         dialect,
-        dialectPath,
+        requestedPath,
         rawBody,
         headers,
         recordableHeaders,
@@ -1091,7 +1113,7 @@ export async function createProxy(options: ProxyOptions): Promise<ProxyHandle> {
 
     await goLive(
       dialect,
-      dialectPath,
+      requestedPath,
       rawBody,
       headers,
       recordableHeaders,

--- a/packages/proxy/test/server.test.ts
+++ b/packages/proxy/test/server.test.ts
@@ -82,6 +82,38 @@ describe('proxy — record mode', () => {
     expect(ex.usage?.input_tokens).toBe(12);
   });
 
+  it('sends the query the client wrote, on the endpoint orca resolved', async () => {
+    const up = stubUpstream(ANTHROPIC_REPLY);
+    const proxy = await createProxy({
+      mode: 'record',
+      fetchImpl: up.fetchImpl,
+      upstream: { anthropic: 'https://res.openai.azure.com/openai/deployments/dep' },
+    });
+    closers.push(proxy.close);
+
+    const res = await post(`${proxy.url}/v1/messages?api-version=2026-02-01`, ANTHROPIC_BODY);
+
+    // The path is orca's to normalise -- it chose this origin, and the incoming path cannot be
+    // trusted to carry the version segment. The query is not: the client set it, and Azure OpenAI
+    // requires `api-version` on every call, so losing it is `404 Resource not found` with nothing
+    // in the run to explain it.
+    expect(res.status).toBe(200);
+    expect(up.calls).toHaveLength(1);
+    expect(up.calls[0]!.url).toBe(
+      'https://res.openai.azure.com/openai/deployments/dep/v1/messages?api-version=2026-02-01',
+    );
+  });
+
+  it('adds no query to a request that had none', async () => {
+    const up = stubUpstream(ANTHROPIC_REPLY);
+    const proxy = await createProxy({ mode: 'record', fetchImpl: up.fetchImpl });
+    closers.push(proxy.close);
+
+    await post(`${proxy.url}/v1/messages`, ANTHROPIC_BODY);
+
+    expect(up.calls[0]!.url).not.toContain('?');
+  });
+
   it('forwards the caller auth header upstream but never records it', async () => {
     // Both halves matter. Claude Code under a subscription login authenticates with its own
     // `authorization: Bearer` header and ignores any injected key, so a proxy that drops it


### PR DESCRIPTION
<!-- orca-cr-summary:start -->
<!-- orca-code-review-summary -->
<!-- orca-cr-state: {"p0":0,"p1":0,"p2":0,"p3":0,"push":1} -->

## Orca-Code-Review — push 1

| Severity | Count |
|---|---|
| P0 | 0 |
| P1 | 0 |
| P2 | 0 |
| P3 | 0 |

✅ no blocking findings
<!-- orca-cr-summary:end -->

Two small, unrelated things found while verifying #33's neighbourhood. One would stop an Azure user
connecting; the other fails CI when nothing is wrong.

## The query never left `handle()`

`handle()` split the query off the request line and dropped it, so nothing downstream saw it —
not the upstream call, not the trace. Measured against a logging origin:

| client posted to | upstream received |
|---|---|
| `<base>/chat/completions?api-version=2026-02-01` | `POST /openai/deployments/mydep/v1/chat/completions` |

**Azure OpenAI requires `api-version` on every call**, so that is `404 Resource not found`, and the
recording shows a path the client never asked for, so nothing in the run explains it.

Two questions get asked of a request line here and they want different halves. *Which endpoint is
this* is the path alone — `selectDialect` matches an endpoint and a query is not part of one, which
is what #39 established. *What do I send upstream* wants the line as written. Splitting instead of
discarding answers both, and the query now reaches all three forwarding sites: both `goLive` calls
and `passThrough`, which relays a request no dialect claimed and should relay it as written.

Replacing the path stays as it was, reason intact — orca chose that origin, and a bare base URL
arrives here without the version segment, which a gateway answers 404. Normalising an address orca
picked is not the same as editing parameters the client set.

Seven rounds against a controlled upstream:

| | |
|---|---|
| `?a=1&b=my%20dep&c=a%2Bb` | survives byte for byte, encoding included |
| no query | unchanged, nothing appended |
| `/forward/<base>/chat/completions?api-version=…` | upstream gets `<base>/chat/completions?api-version=…` |
| replay of a query-bearing recording | `reused=1/1 exact=1 divergences=0`, upstream never touched |
| fork of one | `exit=0` |
| unclaimed path with a query | 404, identical to `main` — pre-existing, not this change |

The `/forward/` row is the whole Azure shape, because that route keeps the client's path instead of
substituting the dialect's. An Azure call routed through it is now correct upstream where before it
lost the parameter. On the substituting route the `/v1` segment remains: that is the existing
design, and a separate question from throwing the parameters away.

## A test that blamed its neighbours

`does not leave a copy of the working tree in the temp directory` diffed a listing of the **whole
OS temp directory** before and after a replay and called any new `orca-safety-*` its own. Under the
parallel suite another file's replay creates one inside that window. Green 3/3 alone,
intermittently red under `vitest run`, on two different branches — I met it as noise across a dozen
suite runs before looking at why.

It now watches a temp directory of its own. `replay.ts` calls `tmpdir()` when it mkdtemps rather
than caching it, so redirecting `TEMP`/`TMP`/`TMPDIR` for the duration is enough — the alternative,
having replay report an internal scratch path so a test could read it, would widen the product's
surface for a test's benefit.

Scoping an assertion risks it quietly stopping asserting, which is worse than the flake. So that
was checked rather than assumed: `os.tmpdir()` honours the override here and `mkdtemp` lands inside
it, and with replay's own cleanup removed the test fails as it should —
`expected [ 'orca-safety-LgJNQb' ] to deeply equal []`.

## Verification

Full suite compared per-test against `main`: **23 failures each, the same 23** — all pre-existing
Windows ones (`0o600` modes, symlinks, `SHELL` in a fixture). `conformance.mjs`: 0 failures. Three
consecutive runs of the e2e file: 27 passed, and the single failure is
`forks from a checkpoint and continues live`, red on `main` too.

Both changes mutation-checked: reverting `requestedPath` to `dialectPath`, or removing replay's
cleanup, turns exactly the matching test red and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
