### PR TITLE
proxy: the response body a compressed reply left unreadable, and the two facts promotion dropped

### DIFF
--- a/packages/cli/src/exchange-events.ts
+++ b/packages/cli/src/exchange-events.ts
@@ -106,6 +106,9 @@ export class ExchangeEventDeriver {
         path: exchange.path,
         messages: exchange.canonicalRequest.messages.length,
         tools: exchange.canonicalRequest.tools?.length ?? 0,
+        // Only where orca established the connection and therefore knows. Absent reads as "not
+        // recorded" rather than as HTTP/1.1, which is why it is left off instead of defaulted.
+        ...(exchange.alpn === undefined ? {} : { alpn: exchange.alpn }),
       },
       payload: exchange.rawRequest,
       // Absent rather than empty when nothing came back: an edge list naming nothing is noise a
@@ -132,6 +135,11 @@ export class ExchangeEventDeriver {
         status: exchange.status,
         duration_ms: exchange.durationMs ?? 0,
         streamed: exchange.streamed,
+        // The payload below is the decoded body, so the encoding it arrived in is recorded here or
+        // nowhere: a promoted exchange keeps no response headers.
+        ...(exchange.responseDecodedFrom === undefined
+          ? {}
+          : { decoded_from: exchange.responseDecodedFrom }),
       },
       payload: exchange.rawResponse,
     });

--- a/packages/cli/src/tls-capture.ts
+++ b/packages/cli/src/tls-capture.ts
@@ -329,6 +329,11 @@ export async function persistNetExchange(
       intercepted: true,
       headers: exchange.responseHeaders,
       bytes: exchange.responseBytes,
+      // What orca decompressed, next to the header set that no longer describes it. `bytes` is
+      // still the wire count, so the two together say how much the encoding was worth.
+      ...(exchange.responseDecodedFrom === undefined
+        ? {}
+        : { decoded_from: exchange.responseDecodedFrom }),
       truncated: exchange.responseTruncated,
       // Only when it happened, so a normal exchange carries no field saying it was normal. It
       // reads differently from `truncated`: the agent stopped reading, orca did not stop keeping.

--- a/packages/proxy/src/intercept.ts
+++ b/packages/proxy/src/intercept.ts
@@ -173,9 +173,12 @@ export function decodeBody(bytes: Buffer, contentEncoding?: string): string {
  * The response body as the client saw it, plus the encoding orca took off to get there.
  *
  * Not attempted on a capture that is a prefix rather than the whole stream: half a deflate member
- * cannot be inflated, and `truncated` / `abandoned` already say the record is incomplete. Failing
- * to decode is not fatal either -- the wire bytes are kept and the reason is reported, the same
- * way an undecodable request body is.
+ * cannot be inflated, and `truncated` / `abandoned` already say the record is incomplete. Nor on a
+ * response that carried no body -- RFC 7232 asks a 304 to send the header fields a 200 would have
+ * sent, `content-encoding` among them, and 204 and HEAD arrive the same way; every decoder throws
+ * "unexpected end of file" on an empty buffer, which would have reported an opaque body where
+ * there was no body at all. Failing to decode a body that *is* there is not fatal either -- the
+ * wire bytes are kept and the reason is reported, the same way an undecodable request body is.
  */
 function recordableResponseBody(
   captured: Capture,
@@ -183,7 +186,13 @@ function recordableResponseBody(
   whole: boolean,
 ): { body: string; decodedFrom?: string; error?: string } {
   const encoding = contentEncoding?.split(',')[0]?.trim().toLowerCase();
-  if (encoding === undefined || encoding === '' || encoding === 'identity' || !whole) {
+  if (
+    encoding === undefined ||
+    encoding === '' ||
+    encoding === 'identity' ||
+    captured.bytes === 0 ||
+    !whole
+  ) {
     return { body: captured.text() };
   }
   try {

--- a/packages/proxy/src/intercept.ts
+++ b/packages/proxy/src/intercept.ts
@@ -76,8 +76,18 @@ export interface NetExchange {
   requestBody: string;
   requestTruncated: boolean;
   status: number;
+  /**
+   * Auth headers removed, and -- when orca decoded the body -- the two headers that described the
+   * encoding it removed. See {@link headersWithoutEncoding}.
+   */
   responseHeaders: Record<string, string>;
   responseBody: string;
+  /**
+   * The `content-encoding` orca decoded away, when there was one. Absent when the recorded body is
+   * exactly the bytes that arrived, which is the ordinary case: `accept-encoding` is stripped from
+   * every intercepted request so an origin that honours it answers in plaintext.
+   */
+  responseDecodedFrom?: string;
   responseTruncated: boolean;
   /** The full size on the wire, even where the captured body was truncated. */
   responseBytes: number;
@@ -122,7 +132,6 @@ export interface InterceptResponse {
   body: string;
 }
 
-/** Decode a request body for model-dialect parsing while leaving forwarding byte-for-byte. */
 /** Decode a recorded body, whichever of the two forms it was stored in. */
 export function readRecordedBody(body: string): Buffer {
   return body.startsWith(BINARY_BODY_PREFIX)
@@ -130,7 +139,13 @@ export function readRecordedBody(body: string): Buffer {
     : Buffer.from(body, 'utf8');
 }
 
-export function decodeRequestBody(bytes: Buffer, contentEncoding?: string): string {
+/**
+ * Decode a body for reading while forwarding stays byte-for-byte.
+ *
+ * Named for the body, not for the half of the exchange: responses arrive compressed too, and a
+ * function called `decodeRequestBody` decoding one would be a name that has to be read past.
+ */
+export function decodeBody(bytes: Buffer, contentEncoding?: string): string {
   const encoding = contentEncoding?.split(',')[0]?.trim().toLowerCase();
   // The three Node has always been able to decode. Without them a gzipped model request was
   // recorded as base64 of its compressed bytes, so no dialect could read it, the exchange was
@@ -152,6 +167,48 @@ export function decodeRequestBody(bytes: Buffer, contentEncoding?: string): stri
     return recordableBody(decompress(bytes));
   }
   return recordableBody(bytes);
+}
+
+/**
+ * The response body as the client saw it, plus the encoding orca took off to get there.
+ *
+ * Not attempted on a capture that is a prefix rather than the whole stream: half a deflate member
+ * cannot be inflated, and `truncated` / `abandoned` already say the record is incomplete. Failing
+ * to decode is not fatal either -- the wire bytes are kept and the reason is reported, the same
+ * way an undecodable request body is.
+ */
+function recordableResponseBody(
+  captured: Capture,
+  contentEncoding: string | undefined,
+  whole: boolean,
+): { body: string; decodedFrom?: string; error?: string } {
+  const encoding = contentEncoding?.split(',')[0]?.trim().toLowerCase();
+  if (encoding === undefined || encoding === '' || encoding === 'identity' || !whole) {
+    return { body: captured.text() };
+  }
+  try {
+    return { body: decodeBody(captured.buffer(), contentEncoding), decodedFrom: encoding };
+  } catch (err) {
+    return { body: captured.text(), error: String(err) };
+  }
+}
+
+/**
+ * The headers that describe the body actually recorded.
+ *
+ * `content-encoding: gzip` beside a decoded body is a claim the recording no longer supports, and
+ * a `content-length` counting compressed bytes is another. Neither fact is lost: the wire size is
+ * already on the event as `bytes`, and what orca removed is recorded as `decoded_from`. Only the
+ * recorded copy is touched -- the client is served the origin's own header set, from `outHeaders`
+ * on HTTP/1.1 and `downstream` on h2.
+ */
+function headersWithoutEncoding(headers: Record<string, string>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    if (key === 'content-encoding' || key === 'content-length') continue;
+    out[key] = value;
+  }
+  return out;
 }
 
 /** Text when the bytes are text, base64 behind a marker when they are not. */
@@ -532,13 +589,13 @@ export function attachTlsIntercept(
         if (recorded) return;
         recorded = true;
         counters.intercepted += 1;
-        // A body orca cannot decode is still an exchange worth having. `decodeRequestBody` throws
+        // A body orca cannot decode is still an exchange worth having. `decodeBody` throws
         // for zstd on a runtime without it -- inside `engines`, and why the repo's own zstd test is
         // skipped there -- and an exception in this callback would take the process down with the
         // exchange unrecorded. server.ts already decodes inside a try/catch for the same reason.
         let recordedRequest: string;
         try {
-          recordedRequest = decodeRequestBody(requestBody.buffer(), contentEncoding);
+          recordedRequest = decodeBody(requestBody.buffer(), contentEncoding);
         } catch (err) {
           options.onFailure?.({
             host: target.host,
@@ -546,6 +603,18 @@ export function attachTlsIntercept(
             reason: `request body left opaque: ${String(err)}`,
           });
           recordedRequest = requestBody.text();
+        }
+        const decoded = recordableResponseBody(
+          responseBody,
+          recordableResponse['content-encoding'],
+          !abandoned,
+        );
+        if (decoded.error !== undefined) {
+          options.onFailure?.({
+            host: target.host,
+            port: target.port,
+            reason: `response body left opaque: ${decoded.error}`,
+          });
         }
         options.onNetExchange?.({
           host: target.host,
@@ -557,8 +626,14 @@ export function attachTlsIntercept(
           requestTruncated: requestBody.truncated,
           status,
           alpn: 'h2',
-          responseHeaders: recordableResponse,
-          responseBody: responseBody.text(),
+          responseHeaders:
+            decoded.decodedFrom === undefined
+              ? recordableResponse
+              : headersWithoutEncoding(recordableResponse),
+          responseBody: decoded.body,
+          ...(decoded.decodedFrom === undefined
+            ? {}
+            : { responseDecodedFrom: decoded.decodedFrom }),
           responseTruncated: responseBody.truncated,
           responseBytes: responseBody.bytes,
           abandoned,
@@ -758,7 +833,7 @@ export function attachTlsIntercept(
         // this callback would take the process down with it. Same guard, same reason, as h2.
         let recordedRequest: string;
         try {
-          recordedRequest = decodeRequestBody(
+          recordedRequest = decodeBody(
             requestBody.buffer(),
             typeof req.headers['content-encoding'] === 'string'
               ? req.headers['content-encoding']
@@ -772,6 +847,18 @@ export function attachTlsIntercept(
           });
           recordedRequest = requestBody.text();
         }
+        const decoded = recordableResponseBody(
+          responseBody,
+          responseHeaders['content-encoding'],
+          !abandoned,
+        );
+        if (decoded.error !== undefined) {
+          options.onFailure?.({
+            host: target.host,
+            port: target.port,
+            reason: `response body left opaque: ${decoded.error}`,
+          });
+        }
         options.onNetExchange?.({
           host: target.host,
           port: target.port,
@@ -782,8 +869,14 @@ export function attachTlsIntercept(
           requestTruncated: requestBody.truncated,
           status,
           alpn: alpnOf(req.socket),
-          responseHeaders,
-          responseBody: responseBody.text(),
+          responseHeaders:
+            decoded.decodedFrom === undefined
+              ? responseHeaders
+              : headersWithoutEncoding(responseHeaders),
+          responseBody: decoded.body,
+          ...(decoded.decodedFrom === undefined
+            ? {}
+            : { responseDecodedFrom: decoded.decodedFrom }),
           responseTruncated: responseBody.truncated,
           responseBytes: responseBody.bytes,
           abandoned,

--- a/packages/proxy/src/server.ts
+++ b/packages/proxy/src/server.ts
@@ -33,7 +33,7 @@ import {
 import { decodeForwardPath, type ForwardPath } from './forward.js';
 import {
   attachTlsIntercept,
-  decodeRequestBody,
+  decodeBody,
   type InterceptResponse,
   type NetExchange,
   type NetRequest,
@@ -447,7 +447,7 @@ export async function createProxy(options: ProxyOptions): Promise<ProxyHandle> {
 
     let rawBody: string;
     try {
-      rawBody = decodeRequestBody(request.requestBytes, request.requestHeaders['content-encoding']);
+      rawBody = decodeBody(request.requestBytes, request.requestHeaders['content-encoding']);
     } catch (err) {
       if (options.mode !== 'replay' || !options.loose) {
         stats.unmatched += 1;

--- a/packages/proxy/src/server.ts
+++ b/packages/proxy/src/server.ts
@@ -117,6 +117,18 @@ export interface RecordedExchange {
   canonicalResponse?: CanonicalResponse;
   usage?: Usage;
   requestHeaders?: Record<string, string>;
+  /**
+   * Which application protocol carried it: `h2`, `http/1.1`, or absent where orca did not
+   * establish the connection itself and so cannot say. Only interception knows this -- the
+   * base-URL route hands the call to `fetch`, which chooses for itself and does not report back.
+   */
+  alpn?: string;
+  /**
+   * The `content-encoding` orca decoded away before recording the response, when there was one.
+   * Interception only, for the same reason: on the base-URL route the HTTP client decompresses
+   * before orca sees a body, so there is nothing orca could truthfully claim to have removed.
+   */
+  responseDecodedFrom?: string;
   durationMs?: number;
 }
 
@@ -423,6 +435,11 @@ export async function createProxy(options: ProxyOptions): Promise<ProxyHandle> {
           headers: exchange.requestHeaders,
           seq: captured.length,
           durationMs: exchange.durationMs,
+          // The two things only the interceptor witnessed. Without them a promoted exchange is
+          // indistinguishable from one captured over the base-URL route, which is the point --
+          // except where the difference is the thing being debugged.
+          alpn: exchange.alpn,
+          responseDecodedFrom: exchange.responseDecodedFrom,
         });
         captured.push(built);
         options.onExchange?.(built);
@@ -902,6 +919,8 @@ export async function createProxy(options: ProxyOptions): Promise<ProxyHandle> {
     headers: Record<string, string>;
     seq: number;
     durationMs: number;
+    alpn?: string;
+    responseDecodedFrom?: string;
   }): RecordedExchange {
     const canonicalRequest = input.dialect.toCanonicalRequest(JSON.parse(input.rawRequest));
     let canonicalResponse: CanonicalResponse | undefined;
@@ -926,6 +945,10 @@ export async function createProxy(options: ProxyOptions): Promise<ProxyHandle> {
       canonicalResponse,
       usage: canonicalResponse?.usage,
       requestHeaders: input.headers,
+      ...(input.alpn === undefined ? {} : { alpn: input.alpn }),
+      ...(input.responseDecodedFrom === undefined
+        ? {}
+        : { responseDecodedFrom: input.responseDecodedFrom }),
       durationMs: input.durationMs,
     };
   }

--- a/packages/proxy/test/tls-intercept.test.ts
+++ b/packages/proxy/test/tls-intercept.test.ts
@@ -610,6 +610,53 @@ describe('TLS interception', () => {
       expect(exchange.responseHeaders['content-encoding']).toBeUndefined();
     });
 
+    it('carries the protocol onto a model exchange promoted from an h2 call', async () => {
+      // `alpn` has been recorded on `net.request` since the interceptor learned h2, and the
+      // reason given was that "did this run go through the h2 path" has to be answerable from the
+      // trace. On an intercepted run it was not: every model call a dialect claims is promoted,
+      // so no `net.*` event is left to carry the field, and promotion dropped it. Asked over h2
+      // because that is the answer worth having -- and because the HTTP/1.1 test client offers no
+      // ALPN at all, where absent is the honest value.
+      h2Origin = await startH2Origin(originCa, {
+        answer: () => ({
+          contentType: 'application/json',
+          body: JSON.stringify({
+            id: 'chatcmpl-1',
+            object: 'chat.completion',
+            model: 'gpt-5.2',
+            choices: [
+              { index: 0, message: { role: 'assistant', content: 'hi' }, finish_reason: 'stop' },
+            ],
+            usage: { prompt_tokens: 3, completion_tokens: 1, total_tokens: 4 },
+          }),
+        }),
+      });
+      const handle = await startProxy([`127.0.0.1:${h2Origin.port}`]);
+
+      const session = await h2Through({
+        proxyPort: handle.port,
+        host: '127.0.0.1',
+        port: h2Origin.port,
+        trust: [runCa.certPem],
+      });
+      const request = session.request({
+        ':method': 'POST',
+        ':path': '/v1/chat/completions',
+        'content-type': 'application/json',
+      });
+      request.setEncoding('utf8');
+      request.on('data', () => undefined);
+      request.end(
+        JSON.stringify({ model: 'gpt-5.2', messages: [{ role: 'user', content: 'hi' }] }),
+      );
+      await once(request, 'close');
+      session.destroy();
+
+      expect(modelExchanges).toHaveLength(1);
+      expect(modelExchanges[0]!.alpn).toBe('h2');
+      expect(netExchanges).toHaveLength(0);
+    });
+
     /**
      * The same guarantee over h2, which is the path that actually matters here: `openrouter.ai`
      * negotiates h2, so every OpenRouter-attributed request reaches the interceptor through
@@ -960,6 +1007,7 @@ describe('TLS interception', () => {
       expect(exchange.rawResponse).not.toContain('orca-base64:');
       expect(exchange.usage?.input_tokens).toBe(3);
       expect(exchange.usage?.output_tokens).toBe(1);
+      expect(exchange.responseDecodedFrom).toBe('gzip');
     });
 
     it('stops claiming an encoding the recorded body no longer has', async () => {

--- a/packages/proxy/test/tls-intercept.test.ts
+++ b/packages/proxy/test/tls-intercept.test.ts
@@ -23,14 +23,14 @@ import { RunCa } from '../src/ca.js';
  * import was simply `undefined` and the test below died on `zstdCompressSync is not a function` —
  * a red build on every pull request, saying nothing about the change that triggered it.
  *
- * Looked up dynamically, the same way `decodeRequestBody` looks up the other half of the pair, so
+ * Looked up dynamically, the same way `decodeBody` looks up the other half of the pair, so
  * the module still loads. Skipped rather than deleted: the behaviour is real on the runtimes that
  * have zstd, and a skipped test names the runtime that is missing something where a deleted one
  * would just be gone.
  */
 const zstdCompressSync = (zlib as typeof zlib & { zstdCompressSync?: (input: Buffer) => Buffer })
   .zstdCompressSync;
-import { decodeRequestBody } from '../src/intercept.js';
+import { decodeBody } from '../src/intercept.js';
 import {
   createProxy,
   type NetExchange,
@@ -226,7 +226,12 @@ function commonName(certPem: string): string {
  */
 async function startH2Origin(
   ca: RunCa,
-  opts: { delayMs?: number; onStream?: (headers: IncomingHttpHeaders) => void } = {},
+  opts: {
+    delayMs?: number;
+    onStream?: (headers: IncomingHttpHeaders) => void;
+    /** What to answer with, for a test that needs a body a dialect can read. */
+    answer?: () => { contentType: string; body: string | Buffer; encoding?: string };
+  } = {},
 ): Promise<{ port: number; hits: number; close: () => Promise<void> }> {
   const issued = ca.issue('127.0.0.1');
   const server: Http2SecureServer = createHttp2Origin({
@@ -249,8 +254,13 @@ async function startH2Origin(
     stream.on('data', () => undefined);
     const answer = (): void => {
       if (stream.destroyed) return;
-      stream.respond({ ':status': 200, 'content-type': 'text/plain' });
-      stream.end('from-origin');
+      const chosen = opts.answer?.() ?? { contentType: 'text/plain', body: 'from-origin' };
+      stream.respond({
+        ':status': 200,
+        'content-type': chosen.contentType,
+        ...(chosen.encoding === undefined ? {} : { 'content-encoding': chosen.encoding }),
+      });
+      stream.end(chosen.body);
     };
     stream.on('end', () => {
       if (opts.delayMs) setTimeout(answer, opts.delayMs);
@@ -338,25 +348,25 @@ async function startOrigin(
  * `orca-base64:H4sIA...` and exactly that message, so these three are worth pinning: they need no
  * runtime guard, unlike zstd, and gzip is the encoding an SDK is most likely to turn on.
  */
-describe('decodeRequestBody', () => {
+describe('decodeBody', () => {
   const payload = JSON.stringify({ model: 'gpt-5.2', messages: [{ role: 'user', content: 'hi' }] });
 
   it('reads a gzipped body back as the JSON that went in', () => {
-    expect(decodeRequestBody(zlib.gzipSync(Buffer.from(payload)), 'gzip')).toBe(payload);
+    expect(decodeBody(zlib.gzipSync(Buffer.from(payload)), 'gzip')).toBe(payload);
   });
 
   it('reads deflate and brotli too', () => {
-    expect(decodeRequestBody(zlib.deflateSync(Buffer.from(payload)), 'deflate')).toBe(payload);
-    expect(decodeRequestBody(zlib.brotliCompressSync(Buffer.from(payload)), 'br')).toBe(payload);
+    expect(decodeBody(zlib.deflateSync(Buffer.from(payload)), 'deflate')).toBe(payload);
+    expect(decodeBody(zlib.brotliCompressSync(Buffer.from(payload)), 'br')).toBe(payload);
   });
 
   it("honours the first encoding of a list, and the header's case", () => {
-    expect(decodeRequestBody(zlib.gzipSync(Buffer.from(payload)), 'GZIP, identity')).toBe(payload);
+    expect(decodeBody(zlib.gzipSync(Buffer.from(payload)), 'GZIP, identity')).toBe(payload);
   });
 
   it('leaves an unencoded body alone', () => {
-    expect(decodeRequestBody(Buffer.from(payload), undefined)).toBe(payload);
-    expect(decodeRequestBody(Buffer.from(payload), 'identity')).toBe(payload);
+    expect(decodeBody(Buffer.from(payload), undefined)).toBe(payload);
+    expect(decodeBody(Buffer.from(payload), 'identity')).toBe(payload);
   });
 });
 
@@ -402,6 +412,51 @@ describe('TLS interception', () => {
           res.writeHead(200, { 'content-type': 'text/event-stream' });
           res.write('data: first\n\n');
           setTimeout(() => res.socket?.destroy(), 30);
+          return;
+        }
+        if (req.url === '/stream-gzip') {
+          // A compressed stream, handed over in two writes so a client can leave mid-member. What
+          // orca keeps is then a prefix of a deflate stream, which cannot be inflated.
+          const whole = zlib.gzipSync(Buffer.from('data: first\n\ndata: second\n\n'));
+          res.writeHead(200, {
+            'content-type': 'text/event-stream',
+            'content-encoding': 'gzip',
+          });
+          res.write(whole.subarray(0, Math.floor(whole.length / 2)));
+          void new Promise<void>((resolve) => {
+            release = resolve;
+          }).then(() => {
+            res.write(whole.subarray(Math.floor(whole.length / 2)));
+            res.end();
+          });
+          return;
+        }
+        if (req.headers['x-test-gzip'] !== undefined) {
+          // Compressed regardless of `accept-encoding`, which the interceptor strips from every
+          // request precisely so an origin that honours it answers in plaintext. This is the
+          // origin that does not: a gateway with compression forced on, or an edge handing back a
+          // pre-compressed error page.
+          const payload = JSON.stringify({
+            id: 'chatcmpl-1',
+            object: 'chat.completion',
+            model: 'gpt-5.2',
+            choices: [
+              { index: 0, message: { role: 'assistant', content: 'hi' }, finish_reason: 'stop' },
+            ],
+            usage: { prompt_tokens: 3, completion_tokens: 1, total_tokens: 4 },
+          });
+          // `lying` claims the encoding without applying it, which is what a gateway in front of
+          // an already-decompressing cache produces.
+          const out =
+            req.headers['x-test-gzip'] === 'lying'
+              ? Buffer.from(payload)
+              : zlib.gzipSync(Buffer.from(payload));
+          res.writeHead(200, {
+            'content-type': 'application/json',
+            'content-encoding': 'gzip',
+            'content-length': String(out.length),
+          });
+          res.end(out);
           return;
         }
         if (req.url === '/stream') {
@@ -521,6 +576,39 @@ describe('TLS interception', () => {
       });
       return proxy;
     }
+
+    it('decodes a compressed h2 response too, and stops claiming the encoding', async () => {
+      // The h2 forwarder builds its own header map and files its own exchange, so the property
+      // holds only where it is pinned. Asked on a path no dialect claims, because that is the
+      // exchange that keeps response headers to check.
+      h2Origin = await startH2Origin(originCa, {
+        answer: () => ({
+          contentType: 'application/json',
+          encoding: 'gzip',
+          body: zlib.gzipSync(Buffer.from('{"answer":"from the origin"}')),
+        }),
+      });
+      const handle = await startProxy([`127.0.0.1:${h2Origin.port}`]);
+
+      const session = await h2Through({
+        proxyPort: handle.port,
+        host: '127.0.0.1',
+        port: h2Origin.port,
+        trust: [runCa.certPem],
+      });
+      const request = session.request({ ':method': 'POST', ':path': '/not-a-model-endpoint' });
+      request.setEncoding('utf8');
+      request.on('data', () => undefined);
+      request.end('{}');
+      await once(request, 'close');
+      session.destroy();
+
+      expect(netExchanges).toHaveLength(1);
+      const exchange = netExchanges[0]!;
+      expect(exchange.responseBody).toBe('{"answer":"from the origin"}');
+      expect(exchange.responseDecodedFrom).toBe('gzip');
+      expect(exchange.responseHeaders['content-encoding']).toBeUndefined();
+    });
 
     /**
      * The same guarantee over h2, which is the path that actually matters here: `openrouter.ai`
@@ -678,7 +766,7 @@ describe('TLS interception', () => {
       const request = session.request({
         ':method': 'POST',
         ':path': '/v1/embeddings',
-        // Claims an encoding the body does not have. `decodeRequestBody` throws either because
+        // Claims an encoding the body does not have. `decodeBody` throws either because
         // the runtime has no zstd or because the stream is corrupt; both used to escape the
         // `end` handler as an uncaught exception.
         'content-encoding': 'zstd',
@@ -839,6 +927,137 @@ describe('TLS interception', () => {
     expect(netExchanges).toHaveLength(0);
     // The query stays in the trace -- it is what the agent asked for; only the match ignores it.
     expect(modelExchanges[0]!.path).toBe('/v1/chat/completions?api-version=2026-02-01');
+  });
+
+  /**
+   * A response body reaches the recording compressed only from an origin that ignores the
+   * stripped `accept-encoding`. What made it worth fixing is that the fallback was silently wrong
+   * rather than merely large: measured against such an origin, `orca replay` reported
+   * `exact=1 divergences=0` over a response the agent could not read.
+   */
+  describe('a response the origin compressed anyway', () => {
+    it('records the body the client saw, and says what it took off to get there', async () => {
+      const handle = await startProxy([`127.0.0.1:${model.port}`]);
+      await through({
+        proxyPort: handle.port,
+        host: '127.0.0.1',
+        port: model.port,
+        trust: [runCa.certPem],
+        method: 'POST',
+        path: '/v1/chat/completions',
+        body: JSON.stringify({ model: 'gpt-5.2', messages: [{ role: 'user', content: 'hello' }] }),
+        headers: { 'content-type': 'application/json', 'x-test-gzip': '1' },
+      });
+
+      expect(modelExchanges).toHaveLength(1);
+      const exchange = modelExchanges[0]!;
+      // Three failures from the one cause, each pinned here. No dialect can read a deflate
+      // stream, so `usage` came out 0/0 on a call that reports 3/1 uncompressed; the recorded
+      // body was base64 of the wire bytes, which is what a reader opens; and replay answers from
+      // that body under a `content-type` it synthesises and never a `content-encoding`, so the
+      // agent was handed the base64 text as the model's reply.
+      expect(exchange.rawResponse).toContain('"content":"hi"');
+      expect(exchange.rawResponse).not.toContain('orca-base64:');
+      expect(exchange.usage?.input_tokens).toBe(3);
+      expect(exchange.usage?.output_tokens).toBe(1);
+    });
+
+    it('stops claiming an encoding the recorded body no longer has', async () => {
+      // Asked on a path no dialect claims, because that is the exchange that keeps its response
+      // headers. A promoted model exchange carries none at all, which is why `decoded_from` has
+      // to travel separately.
+      const handle = await startProxy([`127.0.0.1:${model.port}`]);
+      await through({
+        proxyPort: handle.port,
+        host: '127.0.0.1',
+        port: model.port,
+        trust: [runCa.certPem],
+        method: 'POST',
+        path: '/not-a-model-endpoint',
+        body: '{}',
+        headers: { 'content-type': 'application/json', 'x-test-gzip': '1' },
+      });
+
+      expect(netExchanges).toHaveLength(1);
+      const exchange = netExchanges[0]!;
+      expect(exchange.responseBody).toContain('"content":"hi"');
+      // `content-encoding: gzip` beside a decoded body is a claim the recording cannot support,
+      // and a `content-length` counting compressed bytes is another. Neither fact is lost: the
+      // wire size is what `responseBytes` has always been.
+      expect(exchange.responseHeaders['content-encoding']).toBeUndefined();
+      expect(exchange.responseHeaders['content-length']).toBeUndefined();
+      expect(exchange.responseHeaders['content-type']).toBe('application/json');
+      expect(exchange.responseDecodedFrom).toBe('gzip');
+      expect(exchange.responseBytes).toBeLessThan(exchange.responseBody.length);
+    });
+
+    it('keeps the wire bytes, and says why, when the claimed encoding is not there', async () => {
+      const failures: string[] = [];
+      const handle = await createProxy({
+        mode: 'record',
+        onExchange: (e) => void modelExchanges.push(e),
+        tls: {
+          ca: runCa,
+          hosts: [`127.0.0.1:${model.port}`],
+          trustedOriginCerts: [originCa.certPem],
+          onNetExchange: (e) => void netExchanges.push(e),
+          onFailure: (f) => void failures.push(f.reason),
+        },
+      });
+      proxy = handle;
+      await through({
+        proxyPort: handle.port,
+        host: '127.0.0.1',
+        port: model.port,
+        trust: [runCa.certPem],
+        method: 'POST',
+        path: '/not-a-model-endpoint',
+        body: '{}',
+        headers: { 'content-type': 'application/json', 'x-test-gzip': 'lying' },
+      });
+
+      // Undecodable is not unrecordable. The bytes are kept exactly as they arrived and the
+      // header set is left describing them, because in this case it still does.
+      expect(netExchanges).toHaveLength(1);
+      expect(netExchanges[0]!.responseDecodedFrom).toBeUndefined();
+      expect(netExchanges[0]!.responseHeaders['content-encoding']).toBe('gzip');
+      expect(failures.some((reason) => reason.startsWith('response body left opaque'))).toBe(true);
+    });
+
+    it('leaves a stream the client walked away from mid-member alone, and says nothing', async () => {
+      // Half a deflate member cannot be inflated, so attempting it would report a failure on
+      // every turn of a harness that stops reading once it has its answer -- and `abandoned`
+      // already says the record is a prefix rather than the whole of it.
+      const failures: string[] = [];
+      const handle = await createProxy({
+        mode: 'record',
+        tls: {
+          ca: runCa,
+          hosts: [`127.0.0.1:${model.port}`],
+          trustedOriginCerts: [originCa.certPem],
+          onNetExchange: (e) => void netExchanges.push(e),
+          onFailure: (f) => void failures.push(f.reason),
+        },
+      });
+      proxy = handle;
+      await abandoned({
+        proxyPort: handle.port,
+        host: '127.0.0.1',
+        port: model.port,
+        trust: [runCa.certPem],
+        path: '/stream-gzip',
+        leaveAfter: 'first-chunk',
+      });
+      // Filed from `res.on('close')`, which lands after the client's own promise settles. The
+      // origin is left holding the rest of the member on purpose; `afterEach` releases it into a
+      // socket that has already gone.
+      await settle();
+
+      expect(netExchanges).toHaveLength(1);
+      expect(netExchanges[0]!.abandoned).toBe(true);
+      expect(netExchanges[0]!.responseDecodedFrom).toBeUndefined();
+      expect(failures).toEqual([]);
+    });
   });
 
   it.skipIf(zstdCompressSync === undefined)(

--- a/packages/proxy/test/tls-intercept.test.ts
+++ b/packages/proxy/test/tls-intercept.test.ts
@@ -414,6 +414,13 @@ describe('TLS interception', () => {
           setTimeout(() => res.socket?.destroy(), 30);
           return;
         }
+        if (req.url === '/not-modified') {
+          // What a cache revalidation answers, and RFC 7232 asks for the header fields a 200
+          // would have carried -- so `content-encoding` is here on a response with no body.
+          res.writeHead(304, { 'content-encoding': 'gzip', etag: '"abc"' });
+          res.end();
+          return;
+        }
         if (req.url === '/stream-gzip') {
           // A compressed stream, handed over in two writes so a client can leave mid-member. What
           // orca keeps is then a prefix of a deflate stream, which cannot be inflated.
@@ -1070,6 +1077,39 @@ describe('TLS interception', () => {
       expect(netExchanges[0]!.responseDecodedFrom).toBeUndefined();
       expect(netExchanges[0]!.responseHeaders['content-encoding']).toBe('gzip');
       expect(failures.some((reason) => reason.startsWith('response body left opaque'))).toBe(true);
+    });
+
+    it('says nothing about a response that carried no body at all', async () => {
+      const failures: string[] = [];
+      const handle = await createProxy({
+        mode: 'record',
+        tls: {
+          ca: runCa,
+          hosts: [`127.0.0.1:${model.port}`],
+          trustedOriginCerts: [originCa.certPem],
+          onNetExchange: (e) => void netExchanges.push(e),
+          onFailure: (f) => void failures.push(f.reason),
+        },
+      });
+      proxy = handle;
+      await through({
+        proxyPort: handle.port,
+        host: '127.0.0.1',
+        port: model.port,
+        trust: [runCa.certPem],
+        method: 'GET',
+        path: '/not-modified',
+      });
+
+      expect(netExchanges).toHaveLength(1);
+      expect(netExchanges[0]!.status).toBe(304);
+      expect(netExchanges[0]!.responseBody).toBe('');
+      expect(netExchanges[0]!.responseDecodedFrom).toBeUndefined();
+      // Every decoder throws "unexpected end of file" on an empty buffer, so attempting one here
+      // reported an opaque body on a response that never had one.
+      expect(failures).toEqual([]);
+      // Nothing was decoded, so the header set still describes what arrived.
+      expect(netExchanges[0]!.responseHeaders['content-encoding']).toBe('gzip');
     });
 
     it('leaves a stream the client walked away from mid-member alone, and says nothing', async () => {

--- a/packages/viewer/src/render.ts
+++ b/packages/viewer/src/render.ts
@@ -274,9 +274,15 @@ function parts(event: TraceEvent): RowParts {
       // `abandoned` says the agent stopped reading before the response ended, which is a thing
       // agents do on purpose once a streaming reply has answered them. Named on the row, because
       // that case arrives as `status 0` -- and a bare zero reads like a failure the run never had.
+      //
+      // `decoded_from` is named for the same reason: the payload below is the body the client saw,
+      // while `bytes` is what crossed the wire, and without this the two disagree with nothing on
+      // the row to say why.
+      const decodedFrom = a['decoded_from'];
       const parts = [
         status === undefined ? undefined : `status ${status}`,
         a['abandoned'] === true ? 'client left' : undefined,
+        typeof decodedFrom === 'string' ? `${decodedFrom} decoded` : undefined,
       ].filter((part): part is string => part !== undefined);
       return {
         label: pick(a, 'url', 'host'),

--- a/packages/viewer/test/render.test.ts
+++ b/packages/viewer/test/render.test.ts
@@ -86,6 +86,28 @@ describe('buildTimeline', () => {
     expect(rows[2]!.tone).toBe('normal');
   });
 
+  it('says a body arrived compressed, since `bytes` then counts different bytes', () => {
+    const rows = buildTimeline([
+      ev({
+        type: 'net.response',
+        actor: 'orca',
+        attrs: { host: 'api.example.com', status: 200, bytes: 396, decoded_from: 'gzip' },
+      }),
+      ev({
+        type: 'net.response',
+        actor: 'orca',
+        attrs: { host: 'api.example.com', status: 200, bytes: 6742 },
+      }),
+    ]);
+    // `bytes` is the wire count and the payload is the decoded body, so a row that shows one and
+    // links the other has to say which is which.
+    expect(rows[0]!.detail).toContain('gzip decoded');
+    expect(rows[0]!.detail).toContain('status 200');
+    expect(rows[0]!.tone).toBe('normal');
+    // The ordinary case says nothing, because there is nothing to reconcile.
+    expect(rows[1]!.detail).toBe('status 200');
+  });
+
   it('says a response was abandoned rather than showing a bare status 0', () => {
     const rows = buildTimeline([
       ev({


### PR DESCRIPTION
<!-- orca-cr-summary:start -->
<!-- orca-code-review-summary -->
<!-- orca-cr-state: {"p0":0,"p1":0,"p2":0,"p3":0,"push":2} -->

## Orca-Code-Review — push 2

| Severity | Count | Δ vs previous push |
|---|---|---|
| P0 | 0 | 0 |
| P1 | 0 | 0 |
| P2 | 0 | 0 |
| P3 | 0 | 0 |

✅ no blocking findings
<!-- orca-cr-summary:end -->

Two findings from an end-to-end pass over intercepted TLS. Both are about a trace asserting
something that is not so, which is the failure this project cannot have.

## 1. A response the origin compressed anyway

`accept-encoding` is stripped from every intercepted request precisely so an origin that honours
it answers in plaintext — the comment on `HOP_BY_HOP` says as much: *"a recorded gzip frame is a
recording nobody can read."* For a conforming origin that is the whole fix, and this PR changes
nothing there. Nothing covered the origin that compresses regardless: a gateway with compression
forced on, an edge handing back a pre-compressed error page. There the fallback was not merely
lossy — it was silently wrong.

Measured against an origin that gzips whether or not it was asked to:

|  | recorded usage | recorded body | what replay handed the client | what orca reported |
|---|---|---|---|---|
| before | **0 in / 0 out** | `orca-base64:H4sIAAAAAAAACu3ZP0/D…` | **no answer** | `exact=1 divergences=0` |
| after | 11 in / 3 out | the SSE the client saw | the answer | `exact=1 divergences=0` |

One cause, three consequences. No dialect can read a deflate stream, so usage came out `0/0` on a
call that reports `11/3` uncompressed. The body a reader opens is base64. And `replay` answers
from the recorded body under a `content-type` it synthesises and **never** a `content-encoding`
(`server.ts`, both reply sites) — so the agent was handed that base64 text as the model's reply,
while the run said it matched exactly.

That last point is why decoding is the fix rather than a design change: replay was already serving
a decoded body's headers, so the recording had to hold a decoded body to match.

It also makes the two capture routes agree. The base-URL route has always recorded a decoded body,
because `fetch` decompresses before `upstreamRes.text()` is read. Two routes disagreeing about
what a response body *is* makes a trace unreadable to whoever did not record it.

**Not attempted** on a capture that is a prefix rather than the whole stream — half a deflate
member cannot be inflated, and `truncated` / `abandoned` already say the record is incomplete. A
complete body that will not decode keeps its wire bytes and reports why, the same way an
undecodable request body does.

The recorded header set drops `content-encoding` and `content-length` once the body is decoded,
because both then describe something the recording no longer holds. Neither fact is lost: the wire
size is what `bytes` has always been, and what orca removed is recorded as `decoded_from`. Only
the recorded copy is touched — the client is still served the origin's own headers.

`decodeRequestBody` → `decodeBody`. It was always generic, and a function named for requests
decoding a response is a name a reader has to look past.

## 2. What promotion dropped

`alpn` has been on `net.request` since the interceptor learned h2, and the reason given in
`NetExchange` was plain: without it, *"did this run go through the h2 path"* is a question a trace
cannot answer. On the runs where that question gets asked, it still could not. An intercepted call
a dialect claims is promoted to `model.request` / `model.response`, and the promotion dropped the
field — so on a run where every model call is recognised there is no `net.*` and no `net.tunnel`
left holding it. Measured on a real Hermes run: **no event anywhere said which protocol carried
the call.**

`decoded_from` rides the same plumbing and needs it more: a promoted exchange keeps no response
headers at all, so the encoding orca decompressed had nowhere to survive.

Both stay **absent** where orca did not establish the connection itself. The base-URL route hands
the call to `fetch`, which picks a protocol for itself and decompresses before orca sees a body —
there is nothing orca could truthfully claim about either, and absent reads as "not recorded"
while `http/1.1` would read as a fact.

## Verification

- **A control, not just the failing case.** A second origin that honours `accept-encoding` answers
  in plaintext, so the strip does its job and only the non-conforming origin needed this. Against
  the real provider (`opencode.ai`), `decoded_from` is absent on every turn.
- **Pinned on both forwarders.** The h2 path builds its own header map and files its own exchange;
  the file's existing note says a property holds only where it is pinned, so there is an h2 test
  for the decode as well as an h1 one.
- **Mutation-tested.** Six mutations — never decode, keep the stale headers, inflate a prefix
  anyway, drop `alpn` in promotion, and the h2 decode — each breaks exactly the test written for
  it. A test that survives its own mutation is decoration.
- **Real agent, four rounds** over TLS interception: `alpn=http/1.1` on `model.request`, the
  answer reassembles to the canary, `replay` reuses `1/1`.
- Full suite: **no new failures** against `main` (24 pre-existing Windows-platform failures on
  both). `typecheck` clean. Each commit builds and tests on its own, so the branch bisects.

Independent of #44 — `git merge-tree` reports no conflict in either direction. The `orca scrub`
finding from the same pass is #46, which touches no file this PR does.



---

## Added while re-testing the branch

Two things this change had left half-said. Neither was reported by anyone; both were found by
going back over it.

**A response can carry `content-encoding` and no body at all.** RFC 7232 asks for exactly that —
a 304 sends the header fields a 200 would have sent — and 204 and HEAD arrive the same way.
`gunzipSync`, `inflateSync` and `brotliDecompressSync` all throw `unexpected end of file` on an
empty buffer, so the run reported

```
warn tls.handshake_failed reason="response body left opaque: unexpected end of file"
```

about a body that was never sent. That is a warning of exactly the kind the rest of this branch
removes, so it would have been an odd thing to ship alongside it. Nothing captured is now nothing
to decode.

**The timeline row never said a body arrived compressed.** `bytes` is the wire count while the
payload is the decoded body, so the two disagree with nothing on the row to reconcile them — the
same reason `abandoned` is named there rather than left as a bare `status 0`. The row now reads
`status 200 · gzip decoded`, and stays silent in the ordinary case because there is then nothing
to reconcile. Adding a field to the trace and leaving the one view that renders that event unaware
of it was an incomplete change.

Both are mutation-tested: removing the empty-body guard breaks the 304 test, and removing the row
text breaks the render test.
