### PR TITLE
scrub: a blob's name is its contents' digest, so scrubbing one moves it

### DIFF
--- a/packages/cli/src/commands/scrub.ts
+++ b/packages/cli/src/commands/scrub.ts
@@ -12,6 +12,9 @@ const DIR_MODE = 0o700;
 
 const BLOB_PREFIX = 'sha256:';
 
+/** What `BlobStore` treats as a blob. Anything else under `blobs/` is a partial write. */
+const BLOB_NAME = /^[0-9a-f]{64}$/;
+
 /** Bounds how much object content one `git cat-file --batch` holds in memory at a time. */
 const BATCH_BYTES = 8 * 1024 * 1024;
 
@@ -140,6 +143,17 @@ export async function scrubCommand(
     if (text === undefined) continue;
     const scrubbed = scrubText(text);
     if (scrubbed.value === text) continue;
+    removals += scrubbed.removals;
+    filesChanged += 1;
+    // A file whose name is not a digest is a `put` that crashed between its write and its
+    // rename. Nothing references it, and its name never claimed anything about its contents,
+    // so it is rewritten where it lies -- moving it would mint a hex-named file no event
+    // points at. It is still scrubbed: a scrubber that skips a file holding the material is
+    // the one failure this command must not have.
+    if (!BLOB_NAME.test(basename(path))) {
+      pending.push({ path, contents: scrubbed.value });
+      continue;
+    }
     const digest = createHash('sha256').update(scrubbed.value, 'utf8').digest('hex');
     moved.set(basename(path), { digest, bytes: Buffer.byteLength(scrubbed.value, 'utf8') });
     pending.push({
@@ -148,8 +162,6 @@ export async function scrubCommand(
       movedFrom: path,
     });
     stale.add(path);
-    removals += scrubbed.removals;
-    filesChanged += 1;
   }
   // Never delete a path something is being written to. Two blobs can scrub to the same content, and
   // one blob can scrub to content another blob already holds; either way the file that survives is
@@ -399,7 +411,12 @@ function retargetBlobs(value: unknown, moved: Map<string, MovedBlob>, depth = 0)
   return hit;
 }
 
-/** How many files the blob store will hold once the moves are committed. */
+/**
+ * How many blobs the store will hold once the moves are committed.
+ *
+ * Counted the way `BlobStore.count()` counts, by digest-named files only, so the manifest
+ * keeps reporting the same number the store itself would.
+ */
 function blobCountAfter(
   before: readonly string[],
   stale: ReadonlySet<string>,
@@ -409,7 +426,7 @@ function blobCountAfter(
   for (const write of pending) {
     if (write.movedFrom !== undefined) after.add(write.path);
   }
-  return after.size;
+  return [...after].filter((path) => BLOB_NAME.test(basename(path))).length;
 }
 
 /** Why a scrubbed event line cannot be written, or undefined when it can. */

--- a/packages/cli/src/commands/scrub.ts
+++ b/packages/cli/src/commands/scrub.ts
@@ -1,6 +1,6 @@
 import { createHash, randomBytes } from 'node:crypto';
-import { readFile, readdir, rename, rm, stat, unlink, writeFile } from 'node:fs/promises';
-import { join, relative } from 'node:path';
+import { mkdir, readFile, readdir, rename, rm, stat, unlink, writeFile } from 'node:fs/promises';
+import { basename, dirname, join, relative } from 'node:path';
 import { Redactor, resolveRunSelector } from '@orcareplay/core';
 import { runGit, runGitRaw } from '@orcareplay/fs-capture';
 import { validateEvent, validateManifest } from '@orcareplay/schema';
@@ -8,6 +8,9 @@ import type { ParsedArgs } from '../args.js';
 import type { Output } from '../out.js';
 
 const FILE_MODE = 0o600;
+const DIR_MODE = 0o700;
+
+const BLOB_PREFIX = 'sha256:';
 
 /** Bounds how much object content one `git cat-file --batch` holds in memory at a time. */
 const BATCH_BYTES = 8 * 1024 * 1024;
@@ -30,6 +33,14 @@ export interface ScrubResult {
 interface PendingWrite {
   path: string;
   contents: string;
+  /** Where a moved blob is coming from, so the plan can say so rather than name a new file. */
+  movedFrom?: string;
+}
+
+/** Where a scrubbed blob's content now lives, keyed by the digest it used to be filed under. */
+interface MovedBlob {
+  digest: string;
+  bytes: number;
 }
 
 /** What one pass of the detectors did to a piece of text. */
@@ -99,6 +110,52 @@ export async function scrubCommand(
   const manifest = parseScrubbedManifest(scrubbedManifest.value, runDir);
   removals += scrubbedManifest.removals;
 
+  const pending: PendingWrite[] = [];
+  /** The redaction ledger, which is appended to rather than scrubbed — reported, never counted. */
+  let ledger: string | undefined;
+
+  /**
+   * Blobs hold most of the volume, so most of what needs removing lives there — and they go before
+   * events, because scrubbing a blob *moves* it.
+   *
+   * A blob's name is the sha256 of its contents (spec §2.2), which is not decoration: `put`
+   * recognises content it already holds by that path existing and then does not write the file, and
+   * that is what keeps a trace linear in new content rather than quadratic in turns. Rewriting a
+   * blob under its old name left a store where the name no longer described the contents, so a
+   * later `put` of the original material would conclude it was already stored and hand back a
+   * reference to scrubbed content instead. `orca scrub` says this out loud already, about the
+   * workspace snapshots it declines to rewrite: git objects are addressed by their own contents.
+   * These are too.
+   */
+  const blobsRoot = join(runDir, 'blobs');
+  const blobPaths = await walk(blobsRoot);
+  const moved = new Map<string, MovedBlob>();
+  /** Old blob files, deleted only once every new one is in place. */
+  const stale = new Set<string>();
+  for (const path of blobPaths) {
+    const buf = await readFile(path);
+    // Skip binary. A NUL byte, or a UTF-8 round trip that loses bytes, means rewriting this file
+    // as text would corrupt it — and a secret is not going to be hiding in a PNG anyway.
+    const text = asText(buf);
+    if (text === undefined) continue;
+    const scrubbed = scrubText(text);
+    if (scrubbed.value === text) continue;
+    const digest = createHash('sha256').update(scrubbed.value, 'utf8').digest('hex');
+    moved.set(basename(path), { digest, bytes: Buffer.byteLength(scrubbed.value, 'utf8') });
+    pending.push({
+      path: join(blobsRoot, digest.slice(0, 2), digest),
+      contents: scrubbed.value,
+      movedFrom: path,
+    });
+    stale.add(path);
+    removals += scrubbed.removals;
+    filesChanged += 1;
+  }
+  // Never delete a path something is being written to. Two blobs can scrub to the same content, and
+  // one blob can scrub to content another blob already holds; either way the file that survives is
+  // the one being written, and the name it is written under may be some other blob's old name.
+  for (const write of pending) stale.delete(write.path);
+
   // events.jsonl, line by line, so a truncated final line stays tolerable.
   const eventsPath = join(runDir, 'events.jsonl');
   const original = await readFile(eventsPath, 'utf8');
@@ -108,36 +165,35 @@ export async function scrubCommand(
     lineNumber += 1;
     if (line.trim() === '') continue;
     const scrubbed = scrubText(line);
-    if (scrubbed.value === line) {
-      scrubbedLines.push(line);
-      continue;
+    let kept = line;
+    if (scrubbed.value !== line) {
+      // Never write a line that would no longer parse or validate: a scrub that corrupts the trace
+      // is worse than one that leaves something behind, because it destroys the evidence too. But
+      // putting the original back means the match is still on disk, so it is reported rather than
+      // swallowed — and it is not counted, or `removed=N` would name removals that never happened.
+      const reason = rejectionReason(scrubbed.value);
+      if (reason === undefined) {
+        removals += scrubbed.removals;
+        kept = scrubbed.value;
+      } else {
+        reverted += 1;
+        const seq = seqOf(line);
+        out.warn(
+          'scrub_reverted',
+          seq === undefined ? { line: lineNumber, reason } : { seq, reason },
+        );
+      }
     }
-    // Never write a line that would no longer parse or validate: a scrub that corrupts the trace
-    // is worse than one that leaves something behind, because it destroys the evidence too. But
-    // putting the original back means the match is still on disk, so it is reported rather than
-    // swallowed — and it is not counted, or `removed=N` would name removals that never happened.
-    const reason = rejectionReason(scrubbed.value);
-    if (reason !== undefined) {
-      reverted += 1;
-      const seq = seqOf(line);
-      out.warn(
-        'scrub_reverted',
-        seq === undefined ? { line: lineNumber, reason } : { seq, reason },
-      );
-      scrubbedLines.push(line);
-      continue;
-    }
-    removals += scrubbed.removals;
-    scrubbedLines.push(scrubbed.value);
+    // Applied to whichever text won, a reverted line included: the blob has moved either way, and
+    // a reference left pointing at the old name is a reference to a file that is about to be gone.
+    // It has no revert of its own because it cannot invalidate a line — a digest is replaced by a
+    // digest of the same shape.
+    scrubbedLines.push(moved.size === 0 ? kept : retargetLine(kept, moved));
   }
   if (reverted > 0) {
     out.plain(`  ${reverted} event(s) were put back unchanged — what they matched is STILL here`);
     out.plain('  next: widen the match, or delete the run outright');
   }
-
-  const pending: PendingWrite[] = [];
-  /** The redaction ledger, which is appended to rather than scrubbed — reported, never counted. */
-  let ledger: string | undefined;
 
   const nextEvents = `${scrubbedLines.join('\n')}\n`;
   const eventsRewritten = nextEvents !== original;
@@ -146,27 +202,12 @@ export async function scrubCommand(
     filesChanged += 1;
   }
 
-  // Blobs hold most of the volume, so most of what needs removing lives there.
-  const blobsRoot = join(runDir, 'blobs');
-  for (const path of await walk(blobsRoot)) {
-    const buf = await readFile(path);
-    // Skip binary. A NUL byte, or a UTF-8 round trip that loses bytes, means rewriting this file
-    // as text would corrupt it — and a secret is not going to be hiding in a PNG anyway.
-    const text = asText(buf);
-    if (text === undefined) continue;
-    const scrubbed = scrubText(text);
-    if (scrubbed.value !== text) {
-      pending.push({ path, contents: scrubbed.value });
-      removals += scrubbed.removals;
-      filesChanged += 1;
-    }
-  }
-
   const fs = await handleShadowStore(runDir, args.bool('drop-fs'), dryRun, (text) => {
     return scrubText(text).value !== text;
   });
 
-  if (eventsRewritten) {
+  const integrity = manifest.integrity;
+  if (isRecord(integrity) && (eventsRewritten || moved.size > 0)) {
     // Refresh the digest so `verifyIntegrity` still passes over the scrubbed file. Only when the
     // file was actually rewritten: recomputing it unconditionally would quietly repair a digest
     // that never matched, which is exactly the tampering the digest exists to expose.
@@ -174,13 +215,23 @@ export async function scrubCommand(
     // Hashed from the bytes about to be written rather than re-read from disk, because under
     // `--dry-run` nothing is written — and a digest that depends on the write having happened is
     // a digest that silently means two different things.
-    const integrity = manifest.integrity;
-    if (isRecord(integrity)) {
-      manifest.integrity = {
-        ...integrity,
-        events_sha256: createHash('sha256').update(nextEvents, 'utf8').digest('hex'),
-      };
-    }
+    manifest.integrity = {
+      ...integrity,
+      ...(eventsRewritten
+        ? { events_sha256: createHash('sha256').update(nextEvents, 'utf8').digest('hex') }
+        : {}),
+      // The store changes shape when a blob moves, and not only by renaming: two blobs whose one
+      // difference was the material being removed scrub to the same content and become one file.
+      // A count left describing the store as it was is the same false claim as a stale digest.
+      ...(moved.size === 0 ? {} : { blob_count: blobCountAfter(blobPaths, stale, pending) }),
+    };
+  }
+  const counts = manifest.counts;
+  if (isRecord(counts) && moved.size > 0 && typeof counts['blobs'] === 'number') {
+    // Written from the same number as `integrity.blob_count`, and read in its place by any viewer
+    // opening a run sealed before that field existed. Leaving one refreshed and the other not
+    // would make the same run report two different sizes depending on which reader opened it.
+    manifest.counts = { ...counts, blobs: blobCountAfter(blobPaths, stale, pending) };
   }
   const manifestAfter = `${JSON.stringify(manifest, null, 2)}\n`;
   if (manifestAfter !== manifestBefore) {
@@ -210,13 +261,24 @@ export async function scrubCommand(
     // named three files under a heading that said two.
     for (const write of pending) {
       if (write.path === ledger) continue;
-      out.plain(`  would rewrite ${relative(runDir, write.path)}`);
+      out.plain(
+        write.movedFrom === undefined
+          ? `  would rewrite ${relative(runDir, write.path)}`
+          : `  would rewrite ${relative(runDir, write.movedFrom)} and move it to ` +
+              `${relative(runDir, write.path)}, which is what its scrubbed contents hash to`,
+      );
     }
     if (ledger !== undefined)
       out.plain(`  would record the removals in ${relative(runDir, ledger)}`);
     if (fs.matches > 0) out.plain(`  ${fs.matches} shadow-store object(s) would still match`);
   } else {
     await commit(pending);
+    // Last, and only once every new file is in place. Until then the old blobs are what the
+    // references still reach, so a scrub interrupted before this leaves a run that is whole and
+    // partly unscrubbed rather than one that is scrubbed and unreadable — and re-running the same
+    // command finishes it, because the leftover file is found and scrubbed again to the digest it
+    // already sits under.
+    for (const path of stale) await rm(path, { force: true });
     out.phase('scrubbed', { run: runDir, removed: removals, files: filesChanged });
   }
   if (removals === 0 && reverted === 0 && fs.matches === 0 && fs.unreadable === undefined) {
@@ -251,6 +313,9 @@ export async function scrubCommand(
  */
 async function commit(pending: PendingWrite[]): Promise<void> {
   for (const write of pending) {
+    // A moved blob's digest usually starts with two hex characters no other blob in this run does,
+    // so its shard does not exist yet. Every other write here lands in a directory that does.
+    await mkdir(dirname(write.path), { recursive: true, mode: DIR_MODE });
     const tmp = `${write.path}.${randomBytes(6).toString('hex')}.tmp`;
     try {
       await writeFile(tmp, write.contents, { mode: FILE_MODE });
@@ -284,6 +349,67 @@ function collectLiterals(args: ParsedArgs): string[] {
     literals.push(...values);
   }
   return literals;
+}
+
+/**
+ * Point an event's payload at where its blob now lives.
+ *
+ * Walks the payload rather than substituting over the whole line, so a digest that appears inside
+ * recorded text is left alone; and rewrites `bytes` along with the digest, because scrubbing
+ * changes a body's length and a reference that reports the old one is the same kind of false claim
+ * as the old digest was.
+ */
+function retargetLine(line: string, moved: Map<string, MovedBlob>): string {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line);
+  } catch {
+    // A truncated final line, which the text pass leaves alone for the same reason.
+    return line;
+  }
+  if (!isRecord(parsed) || !retargetBlobs(parsed['payload'], moved)) return line;
+  return JSON.stringify(parsed);
+}
+
+/**
+ * Returns whether anything moved, so a line holding no moved reference is written back
+ * byte-for-byte rather than re-serialised.
+ *
+ * Depth-bounded at the same six levels the viewer's own blob walk uses, so the two agree about
+ * where a reference can be.
+ */
+function retargetBlobs(value: unknown, moved: Map<string, MovedBlob>, depth = 0): boolean {
+  if (depth > 6 || value === null || typeof value !== 'object') return false;
+  if (Array.isArray(value)) {
+    let hit = false;
+    for (const item of value) hit = retargetBlobs(item, moved, depth + 1) || hit;
+    return hit;
+  }
+  const record = value as Record<string, unknown>;
+  const ref = record['$blob'];
+  if (typeof ref === 'string') {
+    const target = moved.get(ref.startsWith(BLOB_PREFIX) ? ref.slice(BLOB_PREFIX.length) : ref);
+    if (target === undefined) return false;
+    record['$blob'] = `${BLOB_PREFIX}${target.digest}`;
+    record['bytes'] = target.bytes;
+    return true;
+  }
+  let hit = false;
+  for (const item of Object.values(record)) hit = retargetBlobs(item, moved, depth + 1) || hit;
+  return hit;
+}
+
+/** How many files the blob store will hold once the moves are committed. */
+function blobCountAfter(
+  before: readonly string[],
+  stale: ReadonlySet<string>,
+  pending: readonly PendingWrite[],
+): number {
+  const after = new Set(before.filter((path) => !stale.has(path)));
+  for (const write of pending) {
+    if (write.movedFrom !== undefined) after.add(write.path);
+  }
+  return after.size;
 }
 
 /** Why a scrubbed event line cannot be written, or undefined when it can. */

--- a/packages/cli/test/scrub.test.ts
+++ b/packages/cli/test/scrub.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -261,16 +262,172 @@ describe('scrub — binary safety', () => {
 
     const { BlobStore } = await import('@orcareplay/core');
     const store = new BlobStore(join(writer.runDir, 'blobs'));
-    const ref = await store.put(`prose with NEEDLE inside ${'z'.repeat(100)}`);
+    await store.put(`prose with NEEDLE inside ${'z'.repeat(100)}`);
 
     await scrubCommand(parseArgs(['scrub', 'last', '--match', 'NEEDLE']), out, cwd);
 
-    const after = Buffer.from(await store.get(ref)).toString('utf8');
-    expect(after).not.toContain('NEEDLE');
-    expect(after).toContain('prose with');
+    // Read back by what the scrubbed content hashes to, not by the digest it used to have: a
+    // blob's name is its contents' digest, so scrubbing one moves it. Asking for the old digest
+    // is asking for the material this command exists to destroy.
+    const files = await blobFiles(writer.runDir);
+    expect(files).toHaveLength(1);
+    expect(files[0]!.text).not.toContain('NEEDLE');
+    expect(files[0]!.text).toContain('prose with');
+    expect(Buffer.from(await store.get(files[0]!.name)).toString('utf8')).toBe(files[0]!.text);
     await rm(cwd, { recursive: true, force: true });
   });
 });
+
+/**
+ * A blob's name *is* the sha256 of its contents (spec §2.2), and `BlobStore.put` is built on it:
+ * content already held is recognised by its path existing, and the file is then not written at
+ * all. Scrubbing a blob in place left a store where that no longer held, so the next `put` of the
+ * original material would conclude it was already stored and hand back a reference to scrubbed
+ * content. `orca scrub` says as much already about the workspace snapshots it declines to rewrite
+ * -- git objects are addressed by their own contents. So are these.
+ */
+describe('scrub — the blob store stays content-addressed', () => {
+  let cwd: string;
+  let out: Output;
+  let lines: string[];
+
+  beforeEach(async () => {
+    cwd = await mkdtemp(join(tmpdir(), 'orca-scrub-addr-'));
+    lines = [];
+    out = new Output({ write: (s) => void lines.push(s), isTTY: false });
+  });
+
+  afterEach(async () => {
+    await rm(cwd, { recursive: true, force: true });
+  });
+
+  /** A payload over the 4096-byte inline limit, which is the only way to reach a blob at all. */
+  async function runWithSpilledPayload(text: string): Promise<string> {
+    const writer = await TraceWriter.create(join(cwd, '.orca', 'runs'), {
+      adapter: { id: 'test' },
+      argv: ['test'],
+      cwd,
+      orcaVersion: '0.1.0',
+    });
+    await writer.append({ type: 'run.start', actor: 'orca', turn: 0 });
+    await writer.append({ type: 'note', actor: 'orca', turn: 1, payload: text as never });
+    await writer.append({ type: 'run.end', actor: 'orca', turn: 1 });
+    await writer.close(0);
+    return writer.runDir;
+  }
+
+  it('moves a scrubbed blob to the digest its contents now have, and the reference with it', async () => {
+    const runDir = await runWithSpilledPayload(`NEEDLE and then ${'z'.repeat(5000)}`);
+    const before = await blobFiles(runDir);
+    expect(before).toHaveLength(1);
+    expect(before[0]!.name).toBe(before[0]!.digest);
+
+    await scrubCommand(parseArgs(['scrub', 'last', '--match', 'NEEDLE']), out, cwd);
+
+    const after = await blobFiles(runDir);
+    expect(after).toHaveLength(1);
+    expect(after[0]!.text).not.toContain('NEEDLE');
+    // The invariant: a name is a claim about the contents. And the old file is gone rather than
+    // left behind holding what was removed.
+    expect(after[0]!.name).toBe(after[0]!.digest);
+    expect(after[0]!.name).not.toBe(before[0]!.name);
+
+    const events = (await readFile(join(runDir, 'events.jsonl'), 'utf8'))
+      .split('\n')
+      .filter((line) => line.trim() !== '')
+      .map((line) => JSON.parse(line) as { payload?: { $blob?: string; bytes?: number } });
+    const ref = events.find((event) => event.payload?.$blob !== undefined)?.payload;
+    expect(ref?.$blob).toBe(`sha256:${after[0]!.name}`);
+    // Scrubbing changes a body's length, so a `bytes` left at the old one is the same false claim
+    // in smaller print.
+    expect(ref?.bytes).toBe(Buffer.byteLength(after[0]!.text, 'utf8'));
+  });
+
+  it('moves every reference to a blob two events share', async () => {
+    // Content addressing means one file, two references: every model turn resends the whole
+    // conversation, so identical content arriving twice is the ordinary case rather than a corner
+    // -- and moving the file while updating one of them would leave the other pointing nowhere.
+    const writer = await TraceWriter.create(join(cwd, '.orca', 'runs'), {
+      adapter: { id: 'test' },
+      argv: ['test'],
+      cwd,
+      orcaVersion: '0.1.0',
+    });
+    const shared = `NEEDLE and then ${'z'.repeat(5000)}`;
+    await writer.append({ type: 'run.start', actor: 'orca', turn: 0 });
+    await writer.append({ type: 'note', actor: 'orca', turn: 1, payload: shared as never });
+    await writer.append({ type: 'note', actor: 'orca', turn: 2, payload: shared as never });
+    await writer.append({ type: 'run.end', actor: 'orca', turn: 2 });
+    await writer.close(0);
+    expect(await blobFiles(writer.runDir)).toHaveLength(1);
+
+    await scrubCommand(parseArgs(['scrub', 'last', '--match', 'NEEDLE']), out, cwd);
+
+    const files = await blobFiles(writer.runDir);
+    expect(files).toHaveLength(1);
+    expect(files[0]!.name).toBe(files[0]!.digest);
+    const refs = (await readFile(join(writer.runDir, 'events.jsonl'), 'utf8'))
+      .split('\n')
+      .filter((line) => line.trim() !== '')
+      .map((line) => JSON.parse(line) as { payload?: { $blob?: string } })
+      .flatMap((event) => (event.payload?.$blob === undefined ? [] : [event.payload.$blob]));
+    expect(refs).toHaveLength(2);
+    expect(refs).toEqual([`sha256:${files[0]!.name}`, `sha256:${files[0]!.name}`]);
+  });
+
+  it('leaves the manifest describing the store it now has', async () => {
+    const runDir = await runWithSpilledPayload(`NEEDLE and then ${'z'.repeat(5000)}`);
+
+    await scrubCommand(parseArgs(['scrub', 'last', '--match', 'NEEDLE']), out, cwd);
+
+    const manifest = JSON.parse(await readFile(join(runDir, 'manifest.json'), 'utf8')) as {
+      integrity?: { events_sha256?: string; blob_count?: number };
+      counts?: { blobs?: number };
+    };
+    const files = await blobFiles(runDir);
+    expect(manifest.integrity?.blob_count).toBe(files.length);
+    // Read in `blob_count`'s place by any viewer opening a run sealed before that field existed,
+    // so the same run must not report two different sizes depending on which reader opens it.
+    expect(manifest.counts?.blobs).toBe(files.length);
+    // Still sealed: a scrubbed trace that failed its own integrity check would make people skip
+    // scrubbing.
+    expect(manifest.integrity?.events_sha256).toBe(
+      createHash('sha256')
+        .update(await readFile(join(runDir, 'events.jsonl'), 'utf8'), 'utf8')
+        .digest('hex'),
+    );
+  });
+
+  it('names the move in the plan, rather than a file nobody has yet', async () => {
+    await runWithSpilledPayload(`NEEDLE and then ${'z'.repeat(5000)}`);
+
+    await scrubCommand(parseArgs(['scrub', 'last', '--match', 'NEEDLE', '--dry-run']), out, cwd);
+
+    const plan = lines.join('\n');
+    expect(plan).toContain('and move it to');
+    expect(plan).toContain('which is what its scrubbed contents hash to');
+  });
+});
+
+/** Every file in a run's blob store, with the digest its contents actually have. */
+async function blobFiles(
+  runDir: string,
+): Promise<{ name: string; digest: string; text: string }[]> {
+  const root = join(runDir, 'blobs');
+  const found: { name: string; digest: string; text: string }[] = [];
+  for (const shard of await readdir(root, { withFileTypes: true }).catch(() => [])) {
+    if (!shard.isDirectory()) continue;
+    for (const name of await readdir(join(root, shard.name))) {
+      const bytes = await readFile(join(root, shard.name, name));
+      found.push({
+        name,
+        digest: createHash('sha256').update(bytes).digest('hex'),
+        text: bytes.toString('utf8'),
+      });
+    }
+  }
+  return found;
+}
 
 /**
  * The failure mode that matters for a scrubber is not "removed too little" — it is "reported a

--- a/packages/cli/test/scrub.test.ts
+++ b/packages/cli/test/scrub.test.ts
@@ -375,6 +375,26 @@ describe('scrub — the blob store stays content-addressed', () => {
     expect(refs).toEqual([`sha256:${files[0]!.name}`, `sha256:${files[0]!.name}`]);
   });
 
+  it('scrubs a partial write in place rather than minting a blob out of it', async () => {
+    const runDir = await runWithSpilledPayload(`NEEDLE and then ${'z'.repeat(5000)}`);
+    // What `BlobStore.put` leaves behind when it crashes between its write and its rename.
+    const stray = join(runDir, 'blobs', 'aa', `${'a'.repeat(64)}.deadbeef.tmp`);
+    await mkdir(join(runDir, 'blobs', 'aa'), { recursive: true });
+    await writeFile(stray, `NEEDLE in a partial write ${'y'.repeat(200)}`, 'utf8');
+
+    await scrubCommand(parseArgs(['scrub', 'last', '--match', 'NEEDLE']), out, cwd);
+
+    // Still scrubbed — skipping a file that holds the material is the one failure this command
+    // must not have.
+    expect(await readFile(stray, 'utf8')).not.toContain('NEEDLE');
+    // But not moved: nothing references it, and a hex name would file it in the store proper.
+    expect(await blobFiles(runDir)).toHaveLength(1);
+    const manifest = JSON.parse(await readFile(join(runDir, 'manifest.json'), 'utf8')) as {
+      integrity?: { blob_count?: number };
+    };
+    expect(manifest.integrity?.blob_count).toBe(1);
+  });
+
   it('leaves the manifest describing the store it now has', async () => {
     const runDir = await runWithSpilledPayload(`NEEDLE and then ${'z'.repeat(5000)}`);
 
@@ -409,7 +429,12 @@ describe('scrub — the blob store stays content-addressed', () => {
   });
 });
 
-/** Every file in a run's blob store, with the digest its contents actually have. */
+/**
+ * Every blob in a run's store, with the digest its contents actually have.
+ *
+ * Digest-named files only, which is what `BlobStore` counts as a blob -- a `<digest>.<rand>.tmp`
+ * in the same directory is a `put` that crashed, not an entry in the store.
+ */
 async function blobFiles(
   runDir: string,
 ): Promise<{ name: string; digest: string; text: string }[]> {
@@ -418,6 +443,7 @@ async function blobFiles(
   for (const shard of await readdir(root, { withFileTypes: true }).catch(() => [])) {
     if (!shard.isDirectory()) continue;
     for (const name of await readdir(join(root, shard.name))) {
+      if (!/^[0-9a-f]{64}$/.test(name)) continue;
       const bytes = await readFile(join(root, shard.name, name));
       found.push({
         name,


### PR DESCRIPTION
<!-- orca-cr-summary:start -->
<!-- orca-code-review-summary -->
<!-- orca-cr-state: {"p0":0,"p1":0,"p2":0,"p3":0,"push":2} -->

## Orca-Code-Review — push 2

| Severity | Count | Δ vs previous push |
|---|---|---|
| P0 | 0 | 0 |
| P1 | 0 | 0 |
| P2 | 0 | 0 |
| P3 | 0 | 0 |

✅ no blocking findings
<!-- orca-cr-summary:end -->

A blob is filed at `blobs/<first two hex>/<full sha256 of its contents>` (spec §2.2), and that is
not decoration. `BlobStore.put` recognises content it already holds by that path existing and then
**does not write the file** — which is what keeps a trace linear in new content rather than
quadratic in turns. `orca scrub` rewrote a matched blob in place, under the name of the content it
used to hold.

Measured on a run with two blobs, scrubbing one literal:

```
file  46614443af56f784…   contents hash to  28b1107764d88031…
events.jsonl still references the old name: 1
```

**Nothing observable breaks today**, because nothing verifies a blob against its name — worth
saying plainly rather than overselling it. What breaks is the next write into that store: a `put`
of the original material finds the path, concludes the content is already there, and hands back a
reference to scrubbed content. And `put` skipping the write is not a bug to fix there — it is the
invariant this was breaking.

`orca scrub` already says exactly this out loud, about the workspace snapshots it declines to
touch:

> the workspace snapshots still contain what you asked to remove: git objects are addressed by
> their own contents, so they cannot be rewritten in place

Its own blob store is addressed the same way.

## What changed

Blobs are scrubbed **first**, written under the digest their scrubbed contents have, and the
references moved with them before the event lines are serialised.

- Moving a reference updates `bytes` as well as the digest — scrubbing changes a body's length,
  and a count left at the old one is the same false claim in smaller print.
- It is applied to a line whose own text was **reverted** too. The blob has moved either way, and
  a reference left behind points at a file that is about to be gone. It has no revert of its own,
  because a digest is replaced by a digest.
- The payload is walked rather than the line substituted over, so a digest that appears inside
  recorded text is left alone — depth-bounded at the same six levels the viewer's own blob walk
  uses, so the two agree about where a reference can be.
- Old files are deleted **last**, after every new one is in place. Until then the old blobs are
  what the references still reach, so a scrub interrupted there leaves a run that is whole and
  partly unscrubbed rather than one that is scrubbed and unreadable — and re-running the same
  command finishes it. Nothing is deleted that something is also being written to: two blobs can
  scrub to the same content, and the name one is written under may be another's old name.
- `--dry-run` names the move (`would rewrite … and move it to …, which is what its scrubbed
  contents hash to`) instead of naming a file nobody has yet.

One honest note: `blob_count` / `counts.blobs` are recomputed, but the fold that would change them
— two blobs converging on one file — is not reachable today, because placeholders are salted per
value. That assertion in the tests pins **consistency**, not a regression; the recompute is there
so the manifest cannot drift, not because a fold was observed.

## Verification

- **Mutation-tested.** Five mutations — write back under the old name, leave the reference at the
  old digest, leave `bytes` stale, move only the first of two references, and name a file instead
  of the move — each breaks exactly the test written for it.
- **A blob two events share** is covered on its own: content addressing means one file and two
  references, and moving the file while updating one of them would leave the other pointing
  nowhere. Every model turn resends the whole conversation, so that is the ordinary case.
- **Six real Hermes recordings** scrubbed: the literal is gone from both the blob store and
  `events.jsonl`, every file is named by its own digest, no reference dangles, `show` still reads
  the usage out of the moved blob, `replay` still reuses `1/1`, `export` still writes, and a
  second scrub is a no-op (`removed=0 files=0`).
- Full suite: **no new failures** against `main`. `typecheck` clean.

Touches only `commands/scrub.ts` and its test, so it shares no file with #44 or #45 — verified
with `git merge-tree` against both.


---

## Added while re-testing the branch

**A partial write is not a blob.** `walk` returns every file under `blobs/`, and `BlobStore.put`
writes `<digest>.<rand>.tmp` before renaming it into place, so a crash inside `put` leaves a file
there that is not a blob. Rewriting it where it lies is right, and is what happened before this
branch: nothing references it, and its name never claimed anything about its contents. Moving it
is not — it would mint a hex-named file no event points at, and push `blob_count` past what
`BlobStore.count()` reports, which counts only hex64 names. This branch is about the manifest
describing the store it actually has, so it should not be the thing that makes it stop. The stray
file is still scrubbed, because a scrubber that skips a file holding the material is the one
failure this command must not have.

**The interruption claim, measured rather than asserted.** The commit message above says an
interrupted scrub leaves a run that is whole and partly unscrubbed, and that re-running finishes
it. That state is reachable without killing anything — run the scrub, then put the old blob file
back, which is where a crash between the last write and the first unlink leaves it:

```
crash state:  2 blobs · every name matches its contents · 0 dangling refs · material still on disk in 1 file
re-run:       removed=1 files=1
after:        1 blob · every name matches · 0 dangling · material gone
              show still reads it, export still writes it
```

An assertion in a commit message that nobody has run is not evidence, so now it has been run.
