### PR TITLE
goose: the harness that reads different variables — and the two bugs it found

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,7 @@ whether orca understands the wire format it speaks once it arrives.
 | **grok-cli** (and its Telegram bot) | `orca record grok` — `GROK_BASE_URL`, plus the hook for its sub-agents | works |
 | **OpenClaw** | `orca record openclaw` — the hook for the gateway, inherited variables for the agents it spawns | works |
 | **opencode** | `orca record opencode` | adapter shipped, both origins redirected |
+| **goose** (Block) | `orca record goose` — `OPENAI_HOST` **and** `OPENAI_BASE_URL`, `ANTHROPIC_HOST` → Responses API | works — driven end to end against goose 1.49.0, [what is different about it](#the-harness-that-reads-different-variables) |
 | **LangGraph / LangChain** | `OPENAI_BASE_URL`, `ANTHROPIC_BASE_URL` | should work — it goes through the official clients, but nothing here tests it yet |
 | **Hermes** (Nous Research) | `ORCA_BASE_URL_VARS=… orca record generic-openai -- hermes …` | should work — it overrides per provider; [name the variable](#a-base-url-variable-orca-has-never-heard-of) |
 | **Codex-in-the-IDE** | `orca record exec --tls-intercept -- code .` | works — the extension spawns the agent, and it inherits the capture |
@@ -372,10 +373,44 @@ whether orca understands the wire format it speaks once it arrives.
 | **an agent in a sandbox or on another machine** | `orca attach` | works — orca is reachable and prints what to export, [in detail](#an-agent-that-is-not-on-this-machine) |
 | **anything else** | `orca record generic-openai -- <cmd>` | works if it reads a base-URL variable; `orca record node -- <cmd>` if it does not |
 
-Only Claude Code has been driven end to end against the real harness, and
-[it broke four things doing it](docs/validation.md). The rest are held to the adapter contract and
-to fixtures that record the exact variables each one sets, so a harness that renames the variable
-it reads turns a check red instead of producing an empty trace.
+Claude Code, Hermes and goose have been driven end to end against the real harness, and each of
+them broke something. Claude Code [broke four things](docs/validation.md); Hermes found a streaming
+exchange the proxy was dropping entirely; goose broke two more, and neither was in the adapter —
+one was the replay matcher, one was a run reporting success over a trace of nothing but errors. The
+rest are held to the adapter contract and to fixtures that record the exact variables each one
+sets, so a harness that renames the variable it reads turns a check red instead of producing an
+empty trace.
+
+### The harness that reads different variables
+
+Every other OpenAI-shaped client in this table reads `OPENAI_BASE_URL`. goose reads it too, but it
+reads `OPENAI_HOST` **first** — and for Anthropic it reads `ANTHROPIC_HOST` and nothing else.
+
+That combination is worse than it sounds, because both halves fail silently:
+
+- Setting only `OPENAI_BASE_URL` works right up until the user already has `OPENAI_HOST` exported
+  for something else. Then their value wins, the run goes to their origin, and orca prints a clean
+  recording over an empty trace.
+- `ANTHROPIC_BASE_URL` — the variable `generic-openai` sets, and the one the rest of the ecosystem
+  reads — does nothing at all here. A sink addressed only by it receives no request.
+
+So the adapter sets `OPENAI_HOST`, `OPENAI_BASE_URL` and `ANTHROPIC_HOST`, all at the same proxy,
+and the fixture pins all three. The traffic that arrives is the Responses API — `POST /v1/responses`
+plus one `GET /v1/models` on start-up — which the proxy's `openai-responses` dialect already claims.
+
+```console
+GOOSE_PROVIDER=openai GOOSE_MODEL=<model> orca record goose -- run -t "fix the failing test"
+```
+
+`GOOSE_PROVIDER` and `GOOSE_MODEL` are passed through, never invented: goose has no default for a
+custom endpoint, and choosing one for you would launch a different agent than `goose` does.
+
+Two limits worth knowing before you rely on it. goose runs its shell without going through orca's
+PATH shim, so `shell` tool calls are in the trace with their output but without the real exit code,
+duration or stdout/stderr split — record with `--no-shell` to claim nothing rather than that. And
+goose asks a second model for a session title *while the conversation is already under way*, so
+that call and the first real turn race; the replay matcher handles them arriving in either order,
+which it did not before goose was the first harness to do this.
 
 ### A gateway that launches the coding agent
 

--- a/docs/good-first-issues.md
+++ b/docs/good-first-issues.md
@@ -19,11 +19,18 @@ records the env vars you verified against.
 3. **Cline adapter.** Same shape as Continue; if neither can be pointed at a base URL per process,
    there is nothing to fall back on — base-URL injection is the only capture mechanism there is,
    and no CA mode exists. Finding that out is still a result worth writing down.
-4. **Goose adapter.** Block's agent; confirm its provider configuration path.
 
 **Before writing one, answer one question:** does the agent respect a base-URL environment
 variable? That single fact decides whether this is an afternoon, a week, or not possible yet. Put
 the answer in the issue even if you write no code — it is genuinely useful on its own.
+
+**And answer it by running the harness, not by reading its docs.** The goose adapter — which used
+to be item 4 on this list — is the argument for that. goose does respect a base-URL variable, so
+the question above says "an afternoon". What running it revealed is that it reads `OPENAI_HOST`
+*ahead of* `OPENAI_BASE_URL`, and that it does not read `ANTHROPIC_BASE_URL` at all. An adapter
+written from the docs would have set the usual variables, passed every check, and produced empty
+traces for anyone who already had `OPENAI_HOST` exported. Point the harness at a sink server and
+read the request line back; it takes ten minutes and it is the only part of this nobody can guess.
 
 ## Providers — a model you can't currently fork onto
 

--- a/packages/adapters/fixtures/harness/goose.json
+++ b/packages/adapters/fixtures/harness/goose.json
@@ -1,0 +1,14 @@
+{
+  "adapter": "goose",
+  "harness_versions": ">=1.49.0",
+  "verified_at": "2026-09-08",
+  "command": "goose",
+  "env_vars": ["ANTHROPIC_HOST", "OPENAI_API_KEY", "OPENAI_BASE_URL", "OPENAI_HOST"],
+  "base_urls": {
+    "OPENAI_HOST": "",
+    "OPENAI_BASE_URL": "/v1",
+    "ANTHROPIC_HOST": ""
+  },
+  "optional_env_vars": ["ANTHROPIC_API_KEY", "GOOSE_MODEL", "GOOSE_PROVIDER", "OPENAI_BASE_PATH"],
+  "note": "Verified against goose 1.49.0 (x86_64-pc-windows-msvc) by pointing it at a sink server and reading the request line back, not by reading its docs. Three things that verification settled, each of which would silently empty a trace if it changed. (1) OPENAI_HOST outranks OPENAI_BASE_URL: openai_def.rs resolves the origin in the order OPENAI_HOST env, OPENAI_BASE_URL, OPENAI_HOST from config, default -- so with only OPENAI_BASE_URL set, a user who already had OPENAI_HOST exported kept it, and the run went to their origin while orca reported a clean recording over an empty trace. Both are set, at the same proxy, so neither the priority order nor a stale value can route around it. (2) goose does not read ANTHROPIC_BASE_URL or ANTHROPIC_API_BASE at all; its Anthropic provider reads ANTHROPIC_HOST (anthropic_def.rs), and a sink addressed by ANTHROPIC_BASE_URL alone received nothing. This is why generic-openai is not enough for goose -- it sets the variable the rest of the ecosystem reads, which here is the one that does nothing. (3) The traffic is the Responses API: with either variable set goose issues POST /v1/responses plus one GET /v1/models on start-up, and the proxy's openai-responses dialect claims it unchanged. Per-process redirection works at all because Config::get_param reads the environment before the config file (config/base.rs), so a persisted ~/.config/goose/config.yaml cannot win. Not captured: goose runs its shell without going through orca's PATH shim, so shell tool calls appear with their output but without the real exit code, duration or stdout/stderr split -- record with --no-shell to claim nothing rather than that."
+}

--- a/packages/adapters/src/contract.ts
+++ b/packages/adapters/src/contract.ts
@@ -59,8 +59,16 @@ export const MODEL_BASE_URL_VARS = [
   'OPENAI_API_BASE',
 ] as const;
 
-/** Anything shaped like an API origin, including variables no harness reads yet. */
-const BASE_URL_LIKE = /(?:_BASE_URL|_API_BASE)$/;
+/**
+ * Anything shaped like an API origin, including variables no harness reads yet.
+ *
+ * `_HOST` is in the set because goose reads `OPENAI_HOST` and `ANTHROPIC_HOST` and neither of the
+ * `_BASE_URL` spellings for the second — an origin is an origin whatever a harness calls it, and a
+ * pattern that only knew two spellings would have let an adapter point one at the provider while
+ * the checks reported it redirected. `ORCA_INSTRUMENT_HOSTS` names hostnames rather than an origin
+ * and ends `HOSTS`, so it is not caught by this.
+ */
+const BASE_URL_LIKE = /(?:_BASE_URL|_API_BASE|_HOST)$/;
 
 /** Anything shaped like a credential. Over-matching here only ever costs a clearer error. */
 const CREDENTIAL_LIKE = /(?:KEY|TOKEN|SECRET|PASSWORD)$/;

--- a/packages/adapters/src/goose.ts
+++ b/packages/adapters/src/goose.ts
@@ -1,0 +1,87 @@
+import type { Adapter, Launch, RecordContext } from '@orcareplay/plugin-api';
+import { detectAgent } from './detect.js';
+import { passKey, passThrough, proxyBase, readEnv } from './env.js';
+
+/**
+ * goose — Block's agent, and the one harness so far that reads a *different* set of variables
+ * than every other OpenAI-shaped client.
+ *
+ * Three facts decided this adapter, each measured against goose 1.49.0 rather than inferred, by
+ * pointing it at a sink server and reading back the request line:
+ *
+ * 1. **`OPENAI_HOST` outranks `OPENAI_BASE_URL`.** `openai_def.rs` resolves the origin in priority
+ *    order — `OPENAI_HOST` from the environment first, `OPENAI_BASE_URL` second — so a user who
+ *    has `OPENAI_HOST` set for some other tool keeps it, and the run goes to their origin while
+ *    orca reports a successful recording with an empty trace. Setting only `OPENAI_BASE_URL` is
+ *    the `capture.empty` shape the adapter contract exists to prevent, so this adapter sets both.
+ *    Pointed at the same proxy they agree, and neither a stale value nor the priority order can
+ *    route around it.
+ *
+ * 2. **goose does not read `ANTHROPIC_BASE_URL`.** Its Anthropic provider reads `ANTHROPIC_HOST`
+ *    (`anthropic_def.rs`), and a sink pointed at by `ANTHROPIC_BASE_URL` alone receives nothing at
+ *    all. This is precisely why `generic-openai` is not good enough for goose: it sets the
+ *    variable the rest of the ecosystem reads, which here is the one variable that does nothing.
+ *
+ * 3. **The traffic is the Responses API.** With either variable set, goose issues
+ *    `POST /v1/responses`, not `/v1/chat/completions` — plus one `GET /v1/models` on start-up. The
+ *    proxy's `openai-responses` dialect claims it (`matches: (p) => p.endsWith('/responses')`), so
+ *    no path rewriting is needed; it is recorded here because "it happens to work" and "it is
+ *    known to work" are different claims, and only the second survives an upstream refactor.
+ *
+ * `Config::get_param` reads the environment before the config file for every key it resolves
+ * (`config/base.rs`), which is what makes per-process redirection possible at all — goose's
+ * persisted `~/.config/goose/config.yaml` cannot win against the overlay orca sets.
+ *
+ * **What this adapter does not capture.** goose runs its shell without going through orca's PATH
+ * shim, so a run full of `shell` tool calls still reports `shell.ineffective`: the commands appear
+ * as tool calls with their output, but the real exit code, the real duration and the
+ * stdout/stderr split are not in the trace. Record with `--no-shell` to claim nothing rather than
+ * to claim that.
+ */
+export const gooseAdapter: Adapter = {
+  id: 'goose',
+  harnessVersions: '>=1.49.0',
+
+  async detect(_cwd: string): Promise<boolean> {
+    return detectAgent(['goose'], ['.config/goose']);
+  },
+
+  async prepare(ctx: RecordContext): Promise<Launch> {
+    const env: Record<string, string> = {
+      // Both, deliberately — see fact 1. `OPENAI_HOST` takes an origin and goose appends the
+      // endpoint itself; `OPENAI_BASE_URL` takes the `/v1` form the rest of the ecosystem uses.
+      OPENAI_HOST: proxyBase(ctx.proxyUrl),
+      OPENAI_BASE_URL: proxyBase(ctx.proxyUrl, 'v1'),
+      // Not `ANTHROPIC_BASE_URL`: goose reads neither that nor `ANTHROPIC_API_BASE`. See fact 2.
+      ANTHROPIC_HOST: proxyBase(ctx.proxyUrl),
+    };
+
+    // Same credential rule as the other adapters. Which keys the harness can see decides which
+    // provider it picks, so inventing one for a provider the user never configured can change
+    // which model answers — and a recorded run that answers differently from the same command
+    // uninstrumented is the worst kind of capture bug. A placeholder stands in only when there is
+    // nothing to disturb.
+    const hasAny =
+      readEnv(ctx.env, 'OPENAI_API_KEY') !== undefined ||
+      readEnv(ctx.env, 'ANTHROPIC_API_KEY') !== undefined;
+    if (hasAny) {
+      passThrough(env, ctx.env, 'OPENAI_API_KEY');
+      passThrough(env, ctx.env, 'ANTHROPIC_API_KEY');
+    } else {
+      passKey(env, ctx.env, 'OPENAI_API_KEY');
+    }
+
+    // Passed on, never invented: goose has no default provider or model for a custom endpoint, and
+    // which one the recording is meant to exercise is the operator's to say. Inventing either
+    // would make `orca record goose` launch a different agent than `goose` does.
+    passThrough(env, ctx.env, 'GOOSE_PROVIDER');
+    passThrough(env, ctx.env, 'GOOSE_MODEL');
+    // `OPENAI_BASE_PATH` is read from the environment ahead of the config file whenever the host
+    // came from `OPENAI_BASE_URL`, so a value left over from a Docker Model Runner setup would
+    // move the path orca serves. Passing it through keeps the recording faithful to the command
+    // the user actually ran; the proxy matches `/chat/completions` with or without a `/v1`.
+    passThrough(env, ctx.env, 'OPENAI_BASE_PATH');
+
+    return { command: 'goose', args: [...ctx.userArgs], env };
+  },
+};

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -6,6 +6,7 @@ export * from './detect.js';
 export * from './env.js';
 export * from './exec.js';
 export * from './generic-openai.js';
+export * from './goose.js';
 export * from './grok.js';
 export * from './hermes.js';
 export * from './node.js';

--- a/packages/adapters/src/registry.ts
+++ b/packages/adapters/src/registry.ts
@@ -7,6 +7,7 @@ import { kiloAdapter } from './kilo.js';
 import { mimoAdapter } from './mimo.js';
 import { execAdapter } from './exec.js';
 import { genericOpenAiAdapter } from './generic-openai.js';
+import { gooseAdapter } from './goose.js';
 import { grokAdapter } from './grok.js';
 import { openClawAdapter } from './openclaw.js';
 import { nodeAdapter } from './node.js';
@@ -95,6 +96,7 @@ export function defaultAdapters(): AdapterRegistry {
   registry.register(mimoAdapter);
   registry.register(kiloAdapter);
   registry.register(cursorAdapter);
+  registry.register(gooseAdapter);
   registry.register(hermesAdapter);
   registry.register(grokAdapter);
   registry.register(openClawAdapter);

--- a/packages/adapters/test/adapters.test.ts
+++ b/packages/adapters/test/adapters.test.ts
@@ -499,6 +499,7 @@ describe('AdapterRegistry', () => {
       'mimo',
       'kilo',
       'cursor',
+      'goose',
       'hermes',
       'grok',
       'openclaw',

--- a/packages/adapters/test/harness-versions.test.ts
+++ b/packages/adapters/test/harness-versions.test.ts
@@ -26,7 +26,11 @@ const PROXY = 'http://127.0.0.1:51733';
 /** First arg is the command for adapters that take one (generic-openai); the rest is padding. */
 const USER_ARGS = ['my-agent', '--task', 'demo'];
 const FIXTURES = new URL('../fixtures/harness/', import.meta.url);
-const BASE_URL_LIKE = /(?:_BASE_URL|_API_BASE)$/;
+// `_HOST` too: goose reads `OPENAI_HOST` and `ANTHROPIC_HOST` rather than the `_BASE_URL`
+// spellings, and those are the variables its whole capture depends on. Left out, the two that
+// matter most for that adapter were the two nothing checked. `ORCA_INSTRUMENT_HOSTS` is a list
+// of hostnames rather than an origin, and ends `HOSTS`, so it stays out.
+const BASE_URL_LIKE = /(?:_BASE_URL|_API_BASE|_HOST)$/;
 
 interface HarnessFixture {
   adapter: string;

--- a/packages/cli/src/commands/record.ts
+++ b/packages/cli/src/commands/record.ts
@@ -208,6 +208,17 @@ async function runRecording(
   let commandToolCalls = 0;
   /** Commands the shim actually saw. Zero against a non-zero `commandToolCalls` is the warning. */
   let shellFrames = 0;
+  /**
+   * Exchanges the upstream answered with an error status.
+   *
+   * Counted because a run in which every model call failed is indistinguishable, from the summary
+   * line alone, from one that worked: the harness retries, gives up, exits 0, and orca prints
+   * `recorded … exit=0` over a trace whose every answer is a 503. That happened against a gateway
+   * whose credentials had lapsed, and nothing in the output said so.
+   */
+  let erroredExchanges = 0;
+  /** The status those errors carried, so the warning can name it rather than describe it. */
+  const errorStatuses = new Map<number, number>();
 
   const proxy = await createProxy({
     mode: 'record',
@@ -216,6 +227,10 @@ async function runRecording(
     upstreamHeadersOrigin: plan.headersOrigin,
     onExchange: (exchange: RecordedExchange) => {
       modelExchanges += 1;
+      if (exchange.status >= 400) {
+        erroredExchanges += 1;
+        errorStatuses.set(exchange.status, (errorStatuses.get(exchange.status) ?? 0) + 1);
+      }
       writes.push(() => persist(exchange));
     },
     // A POST on a path no dialect claims is forwarded rather than refused, and lands in the trace
@@ -504,6 +519,30 @@ async function runRecording(
       cause,
       set: baseUrls.join(',') || 'none',
       next: 'orca doctor',
+    });
+  }
+
+  /**
+   * Every model call came back an error.
+   *
+   * `capture.empty` covers the run the proxy never saw. This covers the run it saw all of, where
+   * every answer was a refusal: an expired gateway credential, a model the account cannot reach, a
+   * provider outage. The harness retries, exhausts its attempts, prints its own error and exits 0,
+   * so the summary reads exactly like a successful recording — `recorded events=27 exit=0` — over
+   * a trace that contains no model output at all. Replaying it faithfully reproduces the failures.
+   *
+   * Only when *all* of them failed. A run that retried once and then worked is a run that worked,
+   * and warning about it would train people to ignore the line that matters.
+   */
+  if (modelExchanges > 0 && erroredExchanges === modelExchanges) {
+    const commonest = [...errorStatuses.entries()].sort((a, b) => b[1] - a[1])[0];
+    out.warn('capture.errors', {
+      exchanges: modelExchanges,
+      errors: erroredExchanges,
+      status: commonest ? commonest[0] : 'unknown',
+      cause: 'every model call the proxy forwarded came back an error',
+      effect: 'the trace holds the failures, not any model output — a replay reproduces those',
+      next: 'orca show to read the errors, then check the upstream credential or model id',
     });
   }
 

--- a/packages/cli/test/capture-warning.test.ts
+++ b/packages/cli/test/capture-warning.test.ts
@@ -106,3 +106,75 @@ describe('orca record — a run that captured no model traffic', () => {
     expect(lines.find((l) => l.includes('capture.empty'))).toBeUndefined();
   });
 });
+
+/**
+ * A recording in which every model call came back an error.
+ *
+ * The other half of the same silence. `capture.empty` covers the run the proxy never saw; this
+ * covers the run it saw all of, where every answer was a refusal — an expired gateway credential,
+ * a model the account cannot reach. The harness retries, exhausts its attempts, prints its own
+ * error and exits 0, so the summary reads exactly like a successful recording over a trace with no
+ * model output in it. Found against a real gateway whose upstream auth had lapsed: eight recorded
+ * exchanges, all 503, and `recorded events=27 exit=0` printed without a word about it.
+ */
+describe('orca record — a run whose every model call failed', () => {
+  let workspace: string;
+  let model: Awaited<ReturnType<typeof startFakeModel>>;
+  let out: Output;
+  let lines: string[];
+
+  async function setup(failWith?: number) {
+    workspace = await mkdtemp(join(tmpdir(), 'orca-errors-'));
+    model = await startFakeModel(failWith === undefined ? {} : { failWith });
+    lines = [];
+    out = new Output({ write: (s) => void lines.push(s), isTTY: false });
+    await run('git', ['init', '-q'], { cwd: workspace });
+    await run('git', ['config', 'user.email', 'test@example.com'], { cwd: workspace });
+    await run('git', ['config', 'user.name', 'Test'], { cwd: workspace });
+    await writeFile(join(workspace, 'auth.ts'), 'export const fixed = false;\n');
+    const args = parseArgs([
+      'record',
+      'generic-openai',
+      '--upstream-anthropic',
+      model.url,
+      '--',
+      'node',
+      FAKE_AGENT,
+    ]);
+    process.env.FAKE_AGENT_TURNS = '2';
+    delete process.env.FAKE_AGENT_CWD;
+    return recordCommand(args, out, workspace);
+  }
+
+  afterEach(async () => {
+    await model.close();
+    await rm(workspace, { recursive: true, force: true });
+  });
+
+  it('warns, rather than reporting a clean recording over nothing usable', async () => {
+    const result = await setup(503);
+    // The exchanges are all there. That is the point: nothing about the count says they failed.
+    expect(result.modelExchanges).toBeGreaterThan(0);
+    const warning = lines.find((l) => l.includes('capture.errors'));
+    expect(warning, `no capture.errors in:\n${lines.join('\n')}`).toBeDefined();
+  });
+
+  it('names the status, so the cause is a lookup rather than an investigation', async () => {
+    await setup(503);
+    expect(lines.find((l) => l.includes('capture.errors')) ?? '').toContain('status=503');
+  });
+
+  it('says what the trace now holds, since a replay will reproduce it faithfully', async () => {
+    await setup(401);
+    const warning = lines.find((l) => l.includes('capture.errors')) ?? '';
+    expect(warning).toContain('status=401');
+    expect(warning).toMatch(/replay/i);
+  });
+
+  // A run that retried once and then worked is a run that worked. Warning about it would train
+  // people to ignore the line that matters.
+  it('says nothing when the calls succeeded', async () => {
+    await setup();
+    expect(lines.find((l) => l.includes('capture.errors'))).toBeUndefined();
+  });
+});

--- a/packages/cli/test/fixtures/fake-model.mjs
+++ b/packages/cli/test/fixtures/fake-model.mjs
@@ -9,6 +9,14 @@ import { createServer } from 'node:http';
 
 export async function startFakeModel(options = {}) {
   const calls = [];
+  /**
+   * Answer every call with this HTTP status instead of a completion.
+   *
+   * A provider that refuses -- an expired credential, a model the account cannot reach -- is not
+   * an exotic case, and from the harness's side it looks like a run that merely went badly. The
+   * recording still happens; every answer in it is the refusal.
+   */
+  const failWith = options.failWith;
   const editContent = options.editContent ?? 'export const fixed = true;\n';
 
   const server = createServer((req, res) => {
@@ -55,6 +63,11 @@ export async function startFakeModel(options = {}) {
             usage: { input_tokens: 100 + turn, output_tokens: 5 },
           };
 
+      if (failWith !== undefined) {
+        res.writeHead(failWith, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ error: { type: 'error', message: 'no auth available' } }));
+        return;
+      }
       res.writeHead(200, { 'content-type': 'application/json' });
       res.end(JSON.stringify(reply));
     });

--- a/packages/proxy/src/matching.ts
+++ b/packages/proxy/src/matching.ts
@@ -377,6 +377,23 @@ export class RequestMatcher {
   readonly #secrets: number[];
   readonly #redactor?: Redactor;
   #cursor = 0;
+  /**
+   * Recorded requests the cursor stepped over that have not been played yet.
+   *
+   * Stepping over used to discard them, and against a harness that issues a call concurrently with
+   * its own conversation that loses the conversation. goose is the case that found it: it asks for
+   * a session title on a second task, so the title and the first real turn race, and the order
+   * they land in is not the order they were recorded in. When the replay's title arrived first the
+   * cursor jumped past the recorded first turn to reach it — and the first turn, which was about
+   * to be asked for, had already been thrown away. The next request then met turn *two* and the
+   * replay halted on a recording that contained everything it needed.
+   *
+   * Holding them here instead costs nothing when the order does match — the set stays empty — and
+   * makes out-of-order arrival a matter of which request is served rather than whether the replay
+   * survives. Anything still in here at the end was genuinely never repeated, which is what
+   * `reused=x/y` already reports.
+   */
+  readonly #deferred: number[] = [];
 
   constructor(recorded: CanonicalRequest[], options: MatcherOptions = {}) {
     this.#recorded = recorded;
@@ -388,7 +405,7 @@ export class RequestMatcher {
   }
 
   remaining(): number {
-    return this.#recorded.length - this.#cursor;
+    return this.#recorded.length - this.#cursor + this.#deferred.length;
   }
 
   get cursor(): number {
@@ -397,6 +414,10 @@ export class RequestMatcher {
 
   match(incoming: CanonicalRequest): MatchResult {
     if (this.#cursor >= this.#recorded.length) {
+      // The cursor is past the end, but a request stepped over on the way there may be exactly
+      // what is being asked for now — the out-of-order pair whose second half arrives last.
+      const held = this.#matchDeferred(incoming);
+      if (held) return held;
       return {
         matched: false,
         rung: 4,
@@ -411,24 +432,32 @@ export class RequestMatcher {
       return at;
     }
 
-    // Nothing at the cursor. Before halting, look for this request further along: a recording made
-    // through a terminal carries calls the harness made for itself — a quota probe, a request to
-    // name the session — and a replay driven from a transcript never repeats them. Only an exact
-    // or near-exact match is worth stepping over an unplayed exchange for; anything looser and the
-    // agent would be handed some other turn's answer.
+    // Nothing at the cursor. Before looking further along, try what the cursor has already stepped
+    // over: this is the second half of a pair that arrived in the other order, and its answer is
+    // sitting in the recording unplayed. Held to the same rung-2 bar as a step-forward, and for
+    // the same reason — below that the agent would be handed some other turn's answer.
+    const out = this.#matchDeferred(incoming);
+    if (out) return out;
+
+    // Still nothing. Look for this request further along: a recording made through a terminal
+    // carries calls the harness made for itself — a quota probe, a request to name the session —
+    // and a replay driven from a transcript never repeats them. Only an exact or near-exact match
+    // is worth stepping over an unplayed exchange for.
     for (let ahead = this.#cursor + 1; ahead <= this.#lookaheadLimit(); ahead += 1) {
       const later = this.#matchAt(incoming, ahead);
       if (!later.matched || later.rung > 2) continue;
       const skipped = ahead - this.#cursor;
+      // Set aside rather than dropped. They may yet be asked for — see `#deferred`.
+      for (let i = this.#cursor; i < ahead; i += 1) this.#deferred.push(i);
       this.#cursor = ahead + 1;
       const skippedNote =
-        `, skipping ${skipped} recorded ${skipped === 1 ? 'request' : 'requests'} ` +
-        'the replay did not repeat';
+        `, holding ${skipped} recorded ${skipped === 1 ? 'request' : 'requests'} ` +
+        'the replay has not asked for yet';
       return {
         ...later,
         skipped,
-        // Always said, even when the match had a divergence of its own: a skipped exchange that
-        // goes unmentioned is a replay claiming to have reproduced something it stepped over.
+        // Always said, even when the match had a divergence of its own: an exchange stepped over
+        // without mention is a replay claiming to have reproduced something it passed by.
         divergence: {
           level: later.divergence?.level ?? 'minor',
           rung: later.rung,
@@ -439,6 +468,27 @@ export class RequestMatcher {
     }
 
     return at;
+  }
+
+  /** Serve a request the cursor stepped over earlier, when this is the one it was waiting for. */
+  #matchDeferred(incoming: CanonicalRequest): MatchResult | undefined {
+    for (let slot = 0; slot < this.#deferred.length; slot += 1) {
+      const index = this.#deferred[slot]!;
+      const held = this.#matchAt(incoming, index);
+      if (!held.matched || held.rung > 2) continue;
+      this.#deferred.splice(slot, 1);
+      const note = ', matched out of the order it was recorded in';
+      return {
+        ...held,
+        divergence: {
+          level: held.divergence?.level ?? 'minor',
+          rung: held.rung,
+          distance: held.divergence?.distance ?? 0,
+          detail: `${held.divergence?.detail ?? `matched request ${index}`}${note}`,
+        },
+      };
+    }
+    return undefined;
   }
 
   /** How far ahead a skip may reach. Bounded: past this, a match is more likely a coincidence. */

--- a/packages/proxy/test/lookahead.test.ts
+++ b/packages/proxy/test/lookahead.test.ts
@@ -27,12 +27,60 @@ describe('RequestMatcher lookahead', () => {
     expect(result.skipped).toBe(1);
   });
 
-  // A skipped exchange that goes unmentioned is a replay claiming to reproduce what it stepped over.
+  // An exchange stepped over without mention is a replay claiming to reproduce what it passed by.
   it('says how many it stepped over, even when the match itself was exact', () => {
     const m = new RequestMatcher([req('quota'), req('ask')]);
     const result = m.match(req('ask'));
     expect(result.skipped).toBe(1);
-    expect(result.divergence?.detail ?? '').toContain('skipping 1 recorded request');
+    expect(result.divergence?.detail ?? '').toContain('holding 1 recorded request');
+  });
+
+  /**
+   * The case that made stepping over reversible.
+   *
+   * goose asks a second model for a session title while the conversation is already under way, so
+   * the title call and the first real turn race and do not land in the same order twice. Stepping
+   * over used to *discard* what it passed, which meant a replay whose title arrived first threw
+   * away the first turn on its way to matching the title — and then halted on the very next
+   * request, against a recording that contained everything it needed.
+   */
+  it('still serves a request it stepped over, when that is what comes next', () => {
+    const m = new RequestMatcher([req('the first turn'), req('name this session')]);
+
+    const title = m.match(req('name this session'));
+    expect(title.index).toBe(1);
+    expect(title.skipped).toBe(1);
+
+    const turn = m.match(req('the first turn'));
+    expect(turn.matched).toBe(true);
+    expect(turn.index).toBe(0);
+    expect(turn.divergence?.detail ?? '').toContain('out of the order it was recorded in');
+  });
+
+  it('serves a held request even after the cursor has run off the end', () => {
+    const m = new RequestMatcher([req('held back'), req('last')]);
+    expect(m.match(req('last')).index).toBe(1);
+    expect(m.match(req('held back')).index).toBe(0);
+  });
+
+  // Held, not forgotten: a request set aside is still owed to the replay, and `reused=x/y` counts
+  // it as unplayed until it is served.
+  it('counts a held request as still remaining', () => {
+    const m = new RequestMatcher([req('held back'), req('asked first')]);
+    m.match(req('asked first'));
+    expect(m.remaining()).toBe(1);
+    m.match(req('held back'));
+    expect(m.remaining()).toBe(0);
+  });
+
+  // The same bar as a step-forward. Below rung 2 the agent would be handed some other turn's
+  // answer, which is worse than halting and saying so.
+  it('does not serve a held request on a weak match', () => {
+    const m = new RequestMatcher([req('a question about billing'), req('asked first')]);
+    m.match(req('asked first'));
+    const result = m.match(req('an unrelated question about deployment'));
+    expect(result.matched).toBe(false);
+    expect(result.rung).toBe(4);
   });
 
   it('does not step over anything when the cursor already matches', () => {


### PR DESCRIPTION
<!-- orca-cr-summary:start -->
<!-- orca-code-review-summary -->
<!-- orca-cr-state: {"p0":0,"p1":0,"p2":0,"p3":0,"push":1} -->

## Orca-Code-Review — push 1

| Severity | Count |
|---|---|
| P0 | 0 |
| P1 | 0 |
| P2 | 0 |
| P3 | 0 |

✅ no blocking findings
<!-- orca-cr-summary:end -->

`orca record goose` now works. `orca doctor` detects it, the adapter passes all nine
`checkAdapterContract` checks, and there is a harness fixture pinning the exact variables.

## Why goose needed an adapter rather than `generic-openai`

Written against **goose 1.49.0** by pointing it at a sink server and reading the request line
back, not from its docs. Three findings, each of which would produce an empty trace on somebody's
machine:

| Finding | Consequence |
|---|---|
| **`OPENAI_HOST` outranks `OPENAI_BASE_URL`** — `openai_def.rs` resolves in the order `OPENAI_HOST` (env), `OPENAI_BASE_URL`, `OPENAI_HOST` (config), default | Setting only `OPENAI_BASE_URL` works until the user already has `OPENAI_HOST` exported for something else. Then their value wins, the run goes to their origin, and orca prints a clean recording over nothing. Measured: HOST at a dead port and BASE_URL at a sink → **the sink received no request** |
| **goose does not read `ANTHROPIC_BASE_URL`** — its Anthropic provider reads `ANTHROPIC_HOST` | The variable `generic-openai` sets is the one that does nothing here |
| **The traffic is the Responses API** — `POST /v1/responses`, plus one `GET /v1/models` | Already claimed by the `openai-responses` dialect. Recorded anyway: "happens to work" and "known to work" are different claims |

Per-process redirection is possible at all because `Config::get_param` reads the environment before
the config file, so a persisted `~/.config/goose/config.yaml` cannot win.

`BASE_URL_LIKE` grows `_HOST` in both `contract.ts` and the fixture test. Without that, the two
variables this adapter depends on most were the two nothing checked.

## Two bugs it found, neither of them in the adapter

**1 — the replay matcher discarded recorded requests it stepped over** (`packages/proxy/src/matching.ts`)

goose asks a second model to name the session *while the conversation is already under way*, so
that call and the first real turn race and do not land in the same order twice. Stepping over set
`#cursor = ahead + 1`, discarding everything passed on the way. A replay whose title arrived first
therefore threw away the first turn in order to reach the title — and halted on the very next
request, against a recording that contained everything it needed.

Stepped-over requests are now **held and matchable out of order**, at the same rung-2 bar, and the
reordering is reported rather than hidden. On the trace that failed reproducibly:

```
before:  reused=1/8  unmatched=1  exit=1      # halted, 400 back to the agent
after:   reused=8/8  unmatched=0  exit=0      # strict mode
```

This is not goose-specific — it applies to any harness that issues a call concurrently with its own
conversation.

**2 — a run whose every model call failed reported success** (`packages/cli/src/commands/record.ts`)

Against a gateway whose upstream credential had lapsed, eight exchanges came back 503, the harness
retried, gave up, and exited 0 — and orca printed `recorded events=27 exit=0` with no warning at
all. `capture.errors` is the other half of `capture.empty`. It fires only when **all** of them
failed: a run that retried once and then worked is a run that worked, and warning about that would
train people to ignore the line that matters.

## Verification

Three rounds, each recording a real failing test, letting goose fix it, then replaying offline:

| | every round |
|---|---|
| before | `1 failed` |
| `orca record goose` | 44 events, goose reads files, edits code, runs pytest |
| after | **`1 passed`** |
| strict replay, egress blocked | **`reused=8/8 exact=8 divergences=0 unmatched=0`** |
| fork to another model | `replayed=1 live=8 exit=0`, isolated worktree |

Model traffic for the repeatable rounds came from a local upstream replaying the bytes a real model
produced, so the result does not depend on a third party being up.

Suite: **no new failures.** The 24 that fail on this branch are the 24 that fail on `main` (Windows
file-mode, symlink and shared-`tmpdir` issues), and tests go from 1672 to 1707.

## Documented, not worked around

- goose runs its shell **without** going through orca's PATH shim, so `shell` tool calls carry
  their output but not the real exit code, duration or stdout/stderr split. `--no-shell` claims
  nothing rather than claiming that.
- goose injects `<turn-context><current-time>` at minute granularity, so a replay across a minute
  boundary differs by exactly one character per request — minor, and it still matches.

## Two things I did not touch, on purpose

- The README's **Hermes** row still says to use `generic-openai`, though #33 shipped a `hermes`
  adapter. Stale before this branch; correcting it means asserting how `orca record hermes` is
  invoked, which I have not verified.
- `e2e.test.ts > does not leave a copy of the working tree in the temp directory` compares a
  snapshot of the **shared system tmpdir**, and 13 test files create `orca-safety-*` in it. It
  fails under the full parallel suite and passes in isolation (4/4). Pre-existing isolation defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)