### PR TITLE
release: wait for npm before telling the MCP Registry about it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,5 +96,27 @@ jobs:
           case "$v" in refs/*) v=$(node -p "require('./packages/cli/package.json').version") ;; esac
           node scripts/sync-server-json.mjs "$v"
           ./mcp-publisher validate
+
+          # Wait for npm to serve the version we just pushed.
+          #
+          # The registry validates that the npm package it is being told about actually exists,
+          # and npm's own publish output says the tarball "may take a few minutes to become
+          # available". 0.2.3 published at :06 and the registry call ran three seconds later, so
+          # it got a 404 for a version that had just gone out and failed the whole release over a
+          # race with a CDN. Poll instead of sleeping a fixed amount: propagation took under a
+          # minute that time and there is no reason to spend more than it needs.
+          for i in $(seq 1 30); do
+            if npm view "orcareplay@$v" version >/dev/null 2>&1; then
+              echo "npm is serving orcareplay@$v"
+              break
+            fi
+            if [ "$i" = 30 ]; then
+              echo "orcareplay@$v still not visible on npm after 5 minutes" >&2
+              exit 1
+            fi
+            echo "waiting for npm to serve orcareplay@$v ($i/30)"
+            sleep 10
+          done
+
           ./mcp-publisher login github-oidc
           ./mcp-publisher publish

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -49,6 +49,13 @@ git tag -a v0.3.0 -m "0.3.0" && git push --follow-tags
 > `scripts/publish-order.mjs` catches the manifest mismatch, and the `grep` catches the lockfile
 > one; the manifests can be perfectly consistent while the lockfile is not, so check both.
 
+> **The registry step waits for npm, and has to.** The MCP Registry validates that the npm version
+> it is being told about exists, and npm's own publish output says a tarball "may take a few minutes
+> to become available". 0.2.3 published at `:06` and the registry call ran three seconds later, got
+> a 404 for the version that had just gone out, and failed the release — after npm had succeeded, so
+> re-running the whole workflow was not an option. The step now polls `npm view` for up to five
+> minutes before publishing. `registry-only` exists for the case where it still needs a retry.
+
 The tag fires `.github/workflows/release.yml`, which:
 
 1. runs the full gate — format, build, 1000+ tests, conformance, neutrality;


### PR DESCRIPTION
<!-- orca-cr-summary:start -->
<!-- orca-code-review-summary -->
<!-- orca-cr-state: {"p0":0,"p1":0,"p2":0,"p3":0,"push":1} -->

## Orca-Code-Review — push 1

| Severity | Count |
|---|---|
| P0 | 0 |
| P1 | 0 |
| P2 | 0 |
| P3 | 0 |

✅ no blocking findings
<!-- orca-cr-summary:end -->

Found by hitting it on 0.2.3.

The MCP Registry validates that the npm version it is being registered for actually exists. npm published `orcareplay@0.2.3` at `08:52:06`, the registry step ran at `08:52:09`, and the registry replied:

```
NPM package 'orcareplay' exists, but version '0.2.3' was not found (status: 404).
A newly published release can take a moment to appear on the registry. Wait and retry.
```

npm's own output in the step above it says the same thing — *"Your package is being processed and may take a few minutes to become available."* So the release failed **after** npm had succeeded, which is the worst shape for this particular workflow: re-running it whole fails on npm, which refuses a version it already has. Finishing 0.2.3 took the `registry-only` dispatch path by hand.

Now it polls `npm view "orcareplay@$v"` for up to five minutes before publishing, rather than sleeping a fixed amount — propagation took under a minute in practice, and a fixed sleep is either too short on a bad day or wasted on a good one. It fails loudly if the version never appears, since at that point something other than a CDN is wrong.

`registry-only` stays: it is still the escape hatch when the registry rejects a publish on its own merits, which is what 0.2.2 hit with a description length limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)