### PR TITLE
refuse a flag whose value cannot be honoured

### DIFF
--- a/packages/cli/src/args.ts
+++ b/packages/cli/src/args.ts
@@ -15,6 +15,15 @@ export interface ParsedArgs {
   flags: Record<string, FlagValue>;
   /** Everything after a bare `--`, forwarded verbatim to the agent. */
   passthrough: string[];
+  /**
+   * Flags that became `true` only because nothing followed them.
+   *
+   * Recorded rather than inferred from the value: `--model=true` is also `true`, and telling a
+   * person their value is missing when they typed one is its own kind of wrong.
+   */
+  missingValue: Set<string>;
+  /** Flags given more than once with values that disagree. The last one silently won. */
+  conflicting: Set<string>;
   /** Read a flag as a comma-separated list. */
   list(name: string): string[];
   has(name: string): boolean;
@@ -36,7 +45,7 @@ export interface ParsedArgs {
  * token, and `orca compare --models last` would guess wrong. `--flag=value` and `--no-flag` still
  * work for these; they are handled before this point.
  */
-const VALUELESS = new Set([
+export const VALUELESS = new Set([
   'ui',
   'json',
   'loose',
@@ -53,7 +62,26 @@ const VALUELESS = new Set([
   'tls-intercept',
   'version',
   'help',
+  // Added with the flags themselves and, the first time, not: `orca replay --quiet run_a1b2c3`
+  // parsed as `quiet="run_a1b2c3"` with no positional left, so replay fell back to `last` and
+  // reproduced a different run than the one asked for, in silence. `flags.test.ts` now reads the
+  // source and holds this list to every flag the code treats as a boolean, so the next one added
+  // without an entry here fails a test rather than a user.
+  'quiet',
+  'full',
+  'h',
 ]);
+
+/**
+ * Flags read as a number.
+ *
+ * The counterpart to `VALUELESS`, and needed for the same reason: `num()` returns its fallback for
+ * anything it cannot parse, so `--from four` replayed the whole run instead of forking at a
+ * checkpoint, and `--port eighty` bound a random port and printed it as though that were the
+ * request. Knowing which flags are numeric is what lets a value be checked once, up front, rather
+ * than nine times by hand — which is what `orca gc --keep` had been doing alone.
+ */
+export const NUMERIC = new Set(['from', 'to', 'port', 'keep']);
 
 function coerce(raw: string): FlagValue {
   if (raw === 'true') return true;
@@ -70,6 +98,13 @@ function isFlag(token: string): boolean {
 
 export function parseArgs(argv: string[]): ParsedArgs {
   const flags: Record<string, FlagValue> = {};
+  const missingValue = new Set<string>();
+  const conflicting = new Set<string>();
+  /** Record an assignment, noticing when it silently overwrites a different one. */
+  const set = (name: string, value: FlagValue): void => {
+    if (name in flags && flags[name] !== value) conflicting.add(name);
+    flags[name] = value;
+  };
   const positionals: string[] = [];
   let passthrough: string[] = [];
 
@@ -89,21 +124,28 @@ export function parseArgs(argv: string[]): ParsedArgs {
 
     const eq = body.indexOf('=');
     if (eq !== -1) {
-      flags[body.slice(0, eq)] = coerce(body.slice(eq + 1));
+      const name = body.slice(0, eq);
+      set(name, coerce(body.slice(eq + 1)));
+      // An explicit value, however wrong its shape, was given. It is not missing.
+      missingValue.delete(name);
       continue;
     }
 
     if (isLong && body.startsWith('no-')) {
-      flags[body.slice(3)] = false;
+      const name = body.slice(3);
+      set(name, false);
+      missingValue.delete(name);
       continue;
     }
 
     const next = own[i + 1];
     if (!VALUELESS.has(body) && next !== undefined && !isFlag(next)) {
-      flags[body] = coerce(next);
+      set(body, coerce(next));
+      missingValue.delete(body);
       i += 1;
     } else {
-      flags[body] = true;
+      set(body, true);
+      if (!VALUELESS.has(body)) missingValue.add(body);
     }
   }
 
@@ -114,6 +156,8 @@ export function parseArgs(argv: string[]): ParsedArgs {
     positionals,
     flags,
     passthrough,
+    missingValue,
+    conflicting,
     list(name) {
       const v = flags[name];
       if (v === undefined || typeof v === 'boolean') return [];

--- a/packages/cli/src/commands/replay.ts
+++ b/packages/cli/src/commands/replay.ts
@@ -460,7 +460,7 @@ async function replayExact(args: ParsedArgs, out: Output, ctx: Ctx): Promise<Rep
       launch.args,
       { ...process.env, ...launch.env },
       workspace.dir,
-      args.bool('json'),
+      agentStdoutFor(args),
     );
   } catch (err) {
     // A listening proxy keeps node's event loop alive, so a throw here printed the error and then
@@ -799,7 +799,7 @@ async function replayFork(
       launch.args,
       { ...process.env, ...launch.env },
       worktree,
-      args.bool('json'),
+      agentStdoutFor(args),
     );
   } catch (err) {
     // The same two failures `orca record` had. A listening proxy keeps Node's event loop alive, so
@@ -940,19 +940,31 @@ async function replayWorkspace(args: ParsedArgs, out: Output, ctx: Ctx): Promise
   };
 }
 
+/** Where the replayed agent's own stdout should go, given the flags. */
+function agentStdoutFor(args: ParsedArgs): 'inherit' | 'stderr' | 'ignore' {
+  if (args.bool('quiet')) return 'ignore';
+  return args.bool('json') ? 'stderr' : 'inherit';
+}
+
 /**
  * Launch the agent for a replay or a fork.
  *
- * `quietStdout` is for `--json`: orca's stdout is the result document there, so the replayed
- * agent's own output moves to stderr rather than landing in the middle of it. stdin and stderr
- * stay inherited, so a harness that prompts still can.
+ * Where the replayed agent's own stdout goes:
+ *
+ *   inherit  the default — you asked to watch the run happen again, so you watch it
+ *   stderr   `--json`: orca's stdout is the result document, so the agent's output moves aside
+ *            rather than landing in the middle of it
+ *   ignore   `--quiet`: the run is being replayed for its verdict, not for its narration
+ *
+ * stdin and stderr stay inherited in every case, so a harness that prompts still can and a
+ * harness that fails still says why.
  */
 async function runChild(
   command: string,
   argv: string[],
   env: NodeJS.ProcessEnv,
   cwd = process.cwd(),
-  quietStdout = false,
+  agentStdout: 'inherit' | 'stderr' | 'ignore' = 'inherit',
 ): Promise<number> {
   // Same resolution as record and as detection; see resolveLaunch.
   const target = await resolveLaunch(command, argv);
@@ -961,9 +973,12 @@ async function runChild(
       env,
       cwd,
       shell: target.shell,
-      stdio: quietStdout ? ['inherit', 'pipe', 'inherit'] : 'inherit',
+      stdio:
+        agentStdout === 'inherit'
+          ? 'inherit'
+          : ['inherit', agentStdout === 'ignore' ? 'ignore' : 'pipe', 'inherit'],
     });
-    child.stdout?.pipe(process.stderr);
+    if (agentStdout === 'stderr') child.stdout?.pipe(process.stderr);
     child.on('error', (err) =>
       reject(new Error(`could not launch "${command}": ${String(err)}\n  is it on your PATH?`)),
     );

--- a/packages/cli/src/flags.ts
+++ b/packages/cli/src/flags.ts
@@ -1,3 +1,4 @@
+import { NUMERIC, VALUELESS } from './args.js';
 import type { ParsedArgs } from './args.js';
 
 /**
@@ -46,6 +47,7 @@ export const BY_COMMAND: Record<string, readonly string[]> = {
     'mcp-config',
     ...TLS,
     ...UPSTREAM,
+    'quiet',
   ],
   compare: ['from', 'models', 'verify', 'share', 'loose', ...TLS, ...UPSTREAM],
   show: [],
@@ -94,12 +96,16 @@ export function assertKnownFlags(args: ParsedArgs): void {
   if (allowed === undefined) return;
   const known = [...allowed, ...GLOBAL];
   const unknown = Object.keys(args.flags).filter((name) => !known.includes(name));
-  if (unknown.length === 0) return;
+  // Names first: "unknown flag --modle" is a better answer than "--modle needs a value".
+  if (unknown.length === 0) {
+    assertUsableValues(args, known);
+    return;
+  }
 
   const [first] = unknown;
   const suggestion = nearest(first!, known);
   throw new Error(
-    `unknown flag --${first} for "orca ${args.command}"` +
+    `unknown flag ${dashed(first!)} for "orca ${args.command}"` +
       (suggestion === undefined ? '' : `\n  did you mean --${suggestion}?`) +
       `\n  flags for this command: ${allowed.length === 0 ? '(none)' : allowed.map((f) => `--${f}`).join(' ')}`,
   );
@@ -174,4 +180,69 @@ export function assertNoStrayPositionals(args: ParsedArgs): void {
       takesLine +
       forAgent,
   );
+}
+
+/**
+ * A flag as the person would have typed it.
+ *
+ * Every short flag here is one character, so the count of dashes follows from the length. Telling
+ * someone `--o needs a value` when they typed `-o` sends them looking for a flag that does not
+ * exist.
+ */
+function dashed(name: string): string {
+  return name.length === 1 ? `-${name}` : `--${name}`;
+}
+
+/**
+ * Reject a flag whose value cannot be honoured.
+ *
+ * `assertKnownFlags` settled the names; the values were still taken on trust. Every accessor falls
+ * back in silence when a value is missing or of the wrong shape, so the instruction vanished and
+ * the run reported success having done something else:
+ *
+ *   `--model` with nothing after it turned a fork into a plain replay, and the two models being
+ *   compared agreed because only one of them ever ran. `--match a --match b` redacted `b` alone and
+ *   reported its count as though that were the whole job. `--from four` replayed everything instead
+ *   of forking at a checkpoint. `--json=maybe` turned JSON output off while it was being asked for.
+ *
+ * Same reasoning as `assertNoStrayPositionals` beside it, third part of the command line: an
+ * instruction orca cannot carry out must not be carried past in silence.
+ *
+ * `orca gc --keep` checked its own by hand and was the only command that did. Doing it here is the
+ * same check for all of them, and one place to fix when it is wrong.
+ */
+function assertUsableValues(args: ParsedArgs, allowed: readonly string[]): void {
+  for (const name of Object.keys(args.flags)) {
+    const value = args.flags[name];
+
+    // Repeating a flag is how most CLIs take a list, so people write it. Say which form is one here
+    // rather than only saying no.
+    if (args.conflicting.has(name)) {
+      const listForm = [`${name}s`, `${name}es`].find((f) => allowed.includes(f));
+      throw new Error(
+        `${dashed(name)} given more than once, and only the last would have counted` +
+          (listForm === undefined
+            ? '\n  give it once'
+            : `\n  for several, use one --${listForm}: --${listForm} a,b,c`),
+      );
+    }
+
+    if (NUMERIC.has(name)) {
+      if (args.missingValue.has(name) || typeof value === 'string') {
+        throw new Error(`${dashed(name)} needs a number, like ${dashed(name)} 4`);
+      }
+      continue;
+    }
+
+    // `--flag`, `--flag=true` and `--no-flag` all arrive as a boolean. Anything else is a value on
+    // a switch, and the switch would then have read as off.
+    if (VALUELESS.has(name)) {
+      if (typeof value === 'string') {
+        throw new Error(`${dashed(name)} takes no value; it is either given or it is not`);
+      }
+      continue;
+    }
+
+    if (args.missingValue.has(name)) throw new Error(`${dashed(name)} needs a value`);
+  }
 }

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -33,6 +33,7 @@ const HELP = `orca ${ORCA_VERSION} — record, replay and fork debugger for AI a
         --replay <run>           serve a recording back to that agent instead of recording,
                                  for a run whose agent is not on this machine
   orca replay [run]              reproduce a run exactly, network off
+        --quiet                  discard the replayed agent's own output, keep the verdict
         --ui                     open the timeline when it finishes
   orca replay [run] --from N     fork from a checkpoint and continue live
         --model <id>             continue on a different model

--- a/packages/cli/test/flag-values.test.ts
+++ b/packages/cli/test/flag-values.test.ts
@@ -1,0 +1,162 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { NUMERIC, VALUELESS, parseArgs } from '../src/args.js';
+import { assertKnownFlags } from '../src/flags.js';
+
+/**
+ * A flag whose value the parser could not honour.
+ *
+ * `assertKnownFlags` settled the names: an invented flag is refused rather than ignored. The values
+ * were still taken on trust, and every accessor falls back silently when one is missing or of the
+ * wrong shape — so the instruction disappeared and the run reported success having done something
+ * else. Four shapes, all of them things a person actually types:
+ *
+ *   orca replay last --model            the value forgotten, or eaten by the shell
+ *   orca scrub last --match a --match b the flag repeated, because that is how most CLIs take a list
+ *   orca replay last --from four        a word where a number goes
+ *   orca replay last --json=maybe       a value on a flag that is only ever on or off
+ *
+ * `orca gc --keep` already checked its own by hand, which is the argument for doing it here: one
+ * command got it right and the other nine did not, and nothing made that visible.
+ */
+describe('flags whose value cannot be honoured', () => {
+  const check = (argv: string[]) => () => assertKnownFlags(parseArgs(argv));
+
+  describe('a value that was not given', () => {
+    it('refuses a value-taking flag left empty at the end of the line', () => {
+      expect(check(['replay', 'last', '--model'])).toThrow(/--model needs a value/);
+    });
+
+    it('refuses one whose value is the next flag, which is the same mistake', () => {
+      expect(check(['replay', 'last', '--model', '--json'])).toThrow(/--model needs a value/);
+    });
+
+    /**
+     * The silent version of this one changed what the command did: `--model` set nothing, so the
+     * fork the person asked for became a plain replay of the run they already had, and the two
+     * "different models" agreed because only one of them ever ran.
+     */
+    it('says what the flag is for, so the message is enough to act on', () => {
+      expect(check(['replay', 'last', '--from'])).toThrow(/--from needs a number/);
+    });
+
+    it('leaves a flag given a real value alone', () => {
+      expect(check(['replay', 'last', '--model', 'x'])).not.toThrow();
+      expect(check(['replay', 'last', '--model=x'])).not.toThrow();
+      // An explicitly empty value is a value: the person said so.
+      expect(check(['replay', 'last', '--model='])).not.toThrow();
+    });
+
+    /** A negation is not a missing value; it is the value `false`. */
+    it('leaves a negated flag alone', () => {
+      expect(check(['record', 'claude', '--no-fs'])).not.toThrow();
+    });
+
+    /** And a flag that never takes one is not missing anything. */
+    it('leaves a valueless flag alone', () => {
+      expect(check(['replay', 'last', '--json', '--quiet'])).not.toThrow();
+    });
+  });
+
+  describe('a flag given twice', () => {
+    /**
+     * Repeating a flag is how most CLIs take a list, so people write it. Here the second assignment
+     * overwrote the first without a word: `orca scrub last --match a --match b --match c` redacted
+     * only `c`, and reported the count for `c` as though that were the whole job.
+     */
+    it('refuses conflicting repeats rather than keeping the last', () => {
+      expect(check(['scrub', 'last', '--match', 'a', '--match', 'b'])).toThrow(
+        /--match given more than once/,
+      );
+    });
+
+    it('points at the form that does take a list', () => {
+      expect(check(['scrub', 'last', '--match', 'a', '--match', 'b'])).toThrow(/--matches a,b/);
+    });
+
+    it('catches the equals form and the mixture too', () => {
+      expect(check(['scrub', 'last', '--match=a', '--match=b'])).toThrow(/given more than once/);
+      expect(check(['scrub', 'last', '--match', 'a', '--match=b'])).toThrow(/given more than once/);
+    });
+
+    /** Repeating a flag with the same value asks for nothing contradictory, so it is allowed. */
+    it('allows a repeat that says the same thing twice', () => {
+      expect(check(['scrub', 'last', '--match', 'a', '--match', 'a'])).not.toThrow();
+      expect(check(['replay', 'last', '--json', '--json'])).not.toThrow();
+    });
+  });
+
+  describe('a value of the wrong shape', () => {
+    /**
+     * `num()` returns its fallback for a word, so `--from four` replayed the whole run instead of
+     * forking at a checkpoint, and `--port four` bound a random port and printed it as though that
+     * had been the request.
+     */
+    it('refuses a word where a number belongs', () => {
+      expect(check(['replay', 'last', '--from', 'four'])).toThrow(/--from needs a number/);
+      expect(check(['ui', 'last', '--port', 'eighty'])).toThrow(/--port needs a number/);
+    });
+
+    it('takes a number in either form, including a negative one', () => {
+      expect(check(['replay', 'last', '--from', '4'])).not.toThrow();
+      expect(check(['replay', 'last', '--from=4'])).not.toThrow();
+      expect(check(['replay', 'last', '--from', '-1'])).not.toThrow();
+    });
+
+    /**
+     * `bool()` returns its fallback for a string, so `--json=maybe` turned JSON output *off* while
+     * the person was asking for it — and a script reading stdout got a human table.
+     */
+    it('refuses a value on a flag that is only ever on or off', () => {
+      expect(check(['replay', 'last', '--json=maybe'])).toThrow(/--json takes no value/);
+    });
+
+    it('allows the spellings that do mean on and off', () => {
+      expect(check(['replay', 'last', '--json'])).not.toThrow();
+      expect(check(['replay', 'last', '--json=true'])).not.toThrow();
+      expect(check(['replay', 'last', '--no-json'])).not.toThrow();
+    });
+  });
+
+  /**
+   * The three sets are the whole of the classification, and a flag read one way and declared
+   * another is a hole in it. Read from the source, because a hand-kept list drifts the moment the
+   * code moves — which is exactly how `--quiet` and `--full` came to be missing from `VALUELESS`.
+   */
+  describe('the classification against the source it mirrors', () => {
+    const SRC = join(dirname(fileURLToPath(import.meta.url)), '..', 'src');
+
+    function readAs(accessor: string): Set<string> {
+      const found = new Set<string>();
+      const walk = (dir: string): void => {
+        for (const entry of readdirSync(dir, { withFileTypes: true })) {
+          const path = join(dir, entry.name);
+          if (entry.isDirectory()) walk(path);
+          else if (entry.name.endsWith('.ts')) {
+            const re = new RegExp(`args\\.(?:${accessor})\\('([^']+)'`, 'g');
+            for (const m of readFileSync(path, 'utf8').matchAll(re)) found.add(m[1]!);
+          }
+        }
+      };
+      walk(SRC);
+      return found;
+    }
+
+    it('declares every flag the code reads as a number', () => {
+      const missing = [...readAs('num')].filter((n) => !NUMERIC.has(n)).sort();
+      expect(missing).toEqual([]);
+    });
+
+    it('never declares a flag both valueless and numeric', () => {
+      const both = [...NUMERIC].filter((n) => VALUELESS.has(n)).sort();
+      expect(both).toEqual([]);
+    });
+
+    it('never declares a numeric flag that the code reads as a string or a list', () => {
+      const contradictory = [...readAs('str|list')].filter((n) => NUMERIC.has(n)).sort();
+      expect(contradictory).toEqual([]);
+    });
+  });
+});

--- a/packages/cli/test/flags.test.ts
+++ b/packages/cli/test/flags.test.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
-import { parseArgs } from '../src/args.js';
+import { VALUELESS, parseArgs } from '../src/args.js';
 import {
   BY_COMMAND,
   GLOBAL,
@@ -104,6 +104,34 @@ describe('the allowlist against the source it mirrors', () => {
     const unreachable = [...flagsReadInSource()].filter((name) => !allowed.has(name)).sort();
     // A flag the code reads and no command allows can never be passed: the command throws first.
     expect(unreachable).toEqual([]);
+  });
+
+  /**
+   * A flag the code reads as a boolean has to be declared valueless, or the parser hands it the
+   * next word and the positional it belonged to disappears.
+   *
+   * That is the failure `VALUELESS` was written for, and it happened again the moment a flag was
+   * added without an entry: `orca replay --quiet run_a1b2c3` parsed as `quiet="run_a1b2c3"` with an
+   * empty positional list, so replay fell back to `last` and reproduced a different run than the
+   * one named — silently, and `--quiet` had by then suppressed the output that might have given it
+   * away. Reading the source rather than restating the list is the point: the list can only stay
+   * right if adding a flag without registering it fails here.
+   */
+  it('registers every flag the code reads as a boolean, or the parser eats the next word', () => {
+    const asBoolean = new Set<string>();
+    const walk = (dir: string): void => {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const path = join(dir, entry.name);
+        if (entry.isDirectory()) walk(path);
+        else if (entry.name.endsWith('.ts')) {
+          for (const m of readFileSync(path, 'utf8').matchAll(/args\.bool\('([^']+)'/g)) {
+            asBoolean.add(m[1]!);
+          }
+        }
+      }
+    };
+    walk(SRC);
+    expect([...asBoolean].filter((name) => !VALUELESS.has(name)).sort()).toEqual([]);
   });
 
   it('has an entry for every command the dispatcher handles', () => {


### PR DESCRIPTION
<!-- orca-cr-summary:start -->
<!-- orca-code-review-summary -->
<!-- orca-cr-state: {"p0":0,"p1":0,"p2":0,"p3":0,"push":1} -->

## Orca-Code-Review — push 1

| Severity | Count |
|---|---|
| P0 | 0 |
| P1 | 0 |
| P2 | 0 |
| P3 | 0 |

✅ no blocking findings
<!-- orca-cr-summary:end -->

`assertKnownFlags` settled the names. #18 settled the positionals. The **values** were still taken
on trust — and every accessor falls back in silence when one is missing or of the wrong shape, so
the instruction vanished and the run reported success having done something else.

## Four shapes, all of them things a person types

| you type | it did | it does now |
|---|---|---|
| `orca replay last --model` | **fork became a plain replay** | `--model needs a value` |
| `orca scrub last --match a --match b` | redacted `b` alone, reported its count as the whole job | `--match given more than once` + points at `--matches a,b,c` |
| `orca replay last --from four` | replayed everything instead of forking | `--from needs a number, like --from 4` |
| `orca replay last --json=maybe` | **turned JSON output off** while it was being asked for | `--json takes no value` |

The first is the one that changes what the command *does* rather than merely losing it. `bool()`
returns its fallback for a string, so the fork silently became a replay — and the two models being
compared agreed, because only one of them ever ran.

`orca gc --keep` checked its own by hand and was the only command that did. This moves the check to
where the other two live: same check for every command, one place to fix.

## The two sets, held to the source

`VALUELESS` already existed. `NUMERIC` is its counterpart. `flags.test.ts` now reads
`packages/cli/src/**` and asserts both against what the code actually does — a flag read via
`args.bool()` must be declared valueless, one read via `args.num()` must be declared numeric.

That is not decoration. `--quiet` was added to `replay` without a `VALUELESS` entry, so:

```
orca replay --quiet run_a1b2c3   →   quiet="run_a1b2c3", positionals: []
```

The run id was eaten, replay fell back to `last`, and it reproduced a **different run than the one
named** — with the output that might have given it away suppressed by the same flag. The test makes
the next such omission fail here rather than at a user.

## Two decisions worth stating

**Whether a value is missing is recorded by the parser, not inferred from the result.**
`--model=true` is also `true`, and telling someone their value is missing when they typed one is its
own kind of wrong.

**Only a repeat that *disagrees* is refused.** `--json --json` asks for nothing contradictory, and
neither does `--match a --match a`.

Short flags print with one dash — `--o needs a value` sends someone looking for a flag that does not
exist.

## Verified

- **8 shapes refused**, each with its own message
- **15 ordinary invocations untouched**, including `--from -1`, `--from=4`, `--model=`,
  `--no-fs`, `--matches a,b,c`, and `record claude -- -p hi`
- **6 mutants**, each check removed in turn: 2, 3, 2, 1, 2 and 3 tests go red respectively, each for
  the stated reason
- Full suite **1688 passed**, compared per-test against `main` — **no failure `main` does not
  already have**
- Three repeat runs of `packages/cli/`: identical each time

🤖 Generated with [Claude Code](https://claude.com/claude-code)