### PR TITLE
check the frameworks we say we support, against a stub origin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,26 @@ jobs:
       # This is what makes the format a format rather than whatever the writer happens to emit.
       - run: node scripts/conformance.mjs
 
+  integrations:
+    name: framework integrations
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: npm ci
+      - run: npx tsc --build
+      # The frameworks this speaks for. A check whose package is missing is skipped rather than
+      # failed, so a contributor can run the suite without all of them — which makes installing
+      # them here the thing that turns a skip into a failure.
+      - run: pip install openai anthropic litellm langgraph langchain-openai
+      - run: node test/integrations/run.mjs
+
   python-sdk:
     name: python sdk
     runs-on: ubuntu-latest

--- a/test/integrations/README.md
+++ b/test/integrations/README.md
@@ -1,0 +1,75 @@
+# Integration checks
+
+`orca record generic-openai -- python your_agent.py` is documented as working for LangGraph,
+CrewAI, the OpenAI Agents SDK and anything else that reads a base-URL variable. Until this
+directory existed, that was a sentence.
+
+Each check here records a real framework against a stub origin, kills the origin, replays the
+recording offline, and asserts the numbers. It is the difference between "we support X" and a line
+in CI that goes red.
+
+## Why end to end rather than the adapter contract
+
+`checkAdapterContract` guards against adapter rot — a harness renames the variable it reads and the
+adapter keeps setting the old one. It cannot see whether anything was actually captured.
+
+`orca record opencode` once produced a trace with two events and no model exchange, twice over, for
+two independent reasons. The contract was green for both. What catches that shape is running the
+thing and counting what came back.
+
+## Why a stub origin
+
+Three properties, and every one of them is load-bearing:
+
+- **Free.** A matrix that costs tokens per run is a matrix somebody eventually turns off.
+- **Deterministic.** Replay is judged on matching the recorded bytes. An origin that varied its
+  answer would make an exact match indistinguishable from a lucky one.
+- **Offline.** The second half of every check kills the origin before replaying. If a replay reaches
+  the network the check fails by construction rather than by assertion.
+
+The stub answers the shapes real frameworks use, not the simplest one: streaming SSE, tool calls,
+and the Anthropic messages endpoint. Those are where a recording proxy is most likely to break, and
+a matrix that only exercised a plain completion would have said nothing about either.
+
+## What each check proves
+
+| check | the mechanism it covers | what else rides on it |
+|---|---|---|
+| `openai-sdk` | the official Python SDK reads `OPENAI_BASE_URL` | every framework that lets the SDK build its own client |
+| `openai-async` | the same for `AsyncOpenAI` | the OpenAI Agents SDK |
+| `anthropic-sdk` | `ANTHROPIC_BASE_URL` | Claude-backed agents that are not Claude Code |
+| `litellm` | `OPENAI_API_BASE` through LiteLLM | **CrewAI, Aider, OpenHands** — they route through it |
+| `langgraph-stream` | LangChain's own `OPENAI_API_BASE`, over SSE | LangGraph, LangChain |
+| `langgraph-tools` | the same, with a bound tool | tool-calling graphs |
+| `fetch-hook` | `NODE_OPTIONS` preload on `globalThis.fetch` | the Vercel AI SDK, and any JS agent with its origin compiled in |
+
+Seven checks, and the third row is the reason the list is shorter than the set of frameworks it
+speaks for: covering the layer underneath covers everything standing on it.
+
+## What the checks are worth, measured
+
+A green matrix proves nothing on its own. Each redirect was removed in turn to see which checks
+notice:
+
+| removed from `generic-openai` | what fails |
+|---|---|
+| `OPENAI_BASE_URL` | `openai-sdk`, `openai-async` |
+| `ANTHROPIC_BASE_URL` | `anthropic-sdk` |
+| `OPENAI_API_BASE` | **nothing** |
+
+The last row is the finding. LangChain reads `OPENAI_API_BASE` itself, but it hands the rest to the
+official client, which reads `OPENAI_BASE_URL` — so the LangGraph checks survive losing the variable
+that appears to be theirs. Both are still set, because pre-1.0 SDKs and several ports read only the
+second, and this matrix does not cover those. It is worth knowing that today nothing here would
+notice if that line went away.
+
+## Running them
+
+```console
+node test/integrations/run.mjs            # all of them
+node test/integrations/run.mjs litellm    # one
+```
+
+Python checks are skipped, not failed, when the package they need is not installed — a contributor
+without `langgraph` on their machine should still be able to run the suite. CI installs them, so a
+skip there is a failure.

--- a/test/integrations/agents/anthropic_sdk.py
+++ b/test/integrations/agents/anthropic_sdk.py
@@ -1,0 +1,10 @@
+"""The Anthropic SDK with no base_url, so ANTHROPIC_BASE_URL has to reach it."""
+
+from anthropic import Anthropic
+
+client = Anthropic()
+print("base_url:", client.base_url)
+reply = client.messages.create(
+    model="claude-stub", max_tokens=64, messages=[{"role": "user", "content": "hello"}]
+)
+print("GOT:", reply.content[0].text)

--- a/test/integrations/agents/hardcoded_origin.mjs
+++ b/test/integrations/agents/hardcoded_origin.mjs
@@ -1,0 +1,14 @@
+/**
+ * A JS agent with its origin compiled in, which no environment variable can reach.
+ *
+ * This is the case the fetch hook exists for — the Vercel AI SDK takes its origin as a constructor
+ * argument and reads nothing from the environment, and so does anything that types a URL into its
+ * own source.
+ */
+const res = await fetch('https://api.openai.com/v1/chat/completions', {
+  method: 'POST',
+  headers: { 'content-type': 'application/json', authorization: 'Bearer stub' },
+  body: JSON.stringify({ model: 'stub-1', messages: [{ role: 'user', content: 'hello' }] }),
+});
+const doc = await res.json();
+console.log('GOT:', doc.choices[0].message.content);

--- a/test/integrations/agents/langgraph_agent.py
+++ b/test/integrations/agents/langgraph_agent.py
@@ -1,0 +1,54 @@
+"""A two-node LangGraph, in the two shapes people actually write.
+
+`stream` and `tools` rather than a plain completion: SSE has to be parsed and re-emitted, and a
+tool call round-trips a structured payload through the trace. Those are the two places a recording
+proxy is most likely to break.
+"""
+
+import sys
+from typing import Annotated, TypedDict
+
+from langchain_core.messages import HumanMessage
+from langchain_core.tools import tool
+from langchain_openai import ChatOpenAI
+from langgraph.graph import END, START, StateGraph
+from langgraph.graph.message import add_messages
+
+MODE = sys.argv[1] if len(sys.argv) > 1 else "stream"
+
+
+class State(TypedDict):
+    messages: Annotated[list, add_messages]
+
+
+@tool
+def get_weather(city: str) -> str:
+    """Look up the weather in a city."""
+    return f"it is sunny in {city}"
+
+
+llm = (
+    ChatOpenAI(model="stub-1").bind_tools([get_weather])
+    if MODE == "tools"
+    else ChatOpenAI(model="stub-1", streaming=True)
+)
+
+
+def first(state: State):
+    return {"messages": [llm.invoke(state["messages"])]}
+
+
+def second(state: State):
+    return {"messages": [llm.invoke(state["messages"] + [HumanMessage("again")])]}
+
+
+graph = StateGraph(State)
+graph.add_node("first", first)
+graph.add_node("second", second)
+graph.add_edge(START, "first")
+graph.add_edge("first", "second")
+graph.add_edge("second", END)
+
+out = graph.compile().invoke({"messages": [HumanMessage("what is the weather in Paris")]})
+print("TURNS:", len(out["messages"]))
+print("GOT:", out["messages"][-1].content or "(tool call)")

--- a/test/integrations/agents/litellm_agent.py
+++ b/test/integrations/agents/litellm_agent.py
@@ -1,0 +1,11 @@
+"""LiteLLM directly — the layer CrewAI, Aider and OpenHands all route through.
+
+Covering it covers them, which is why this file exists instead of three more.
+"""
+
+import litellm
+
+reply = litellm.completion(
+    model="openai/stub-1", messages=[{"role": "user", "content": "hello"}]
+)
+print("GOT:", reply.choices[0].message.content)

--- a/test/integrations/agents/openai_async.py
+++ b/test/integrations/agents/openai_async.py
@@ -1,0 +1,17 @@
+"""`AsyncOpenAI`, which is what the OpenAI Agents SDK builds on."""
+
+import asyncio
+
+from openai import AsyncOpenAI
+
+
+async def main() -> None:
+    client = AsyncOpenAI()
+    print("base_url:", client.base_url)
+    reply = await client.chat.completions.create(
+        model="stub-1", messages=[{"role": "user", "content": "hello"}]
+    )
+    print("GOT:", reply.choices[0].message.content)
+
+
+asyncio.run(main())

--- a/test/integrations/agents/openai_sdk.py
+++ b/test/integrations/agents/openai_sdk.py
@@ -1,0 +1,10 @@
+"""The official Python SDK with no base_url — the shape every env-var framework reduces to."""
+
+from openai import OpenAI
+
+client = OpenAI()
+print("base_url:", client.base_url)
+reply = client.chat.completions.create(
+    model="stub-1", messages=[{"role": "user", "content": "hello"}]
+)
+print("GOT:", reply.choices[0].message.content)

--- a/test/integrations/run.mjs
+++ b/test/integrations/run.mjs
@@ -1,0 +1,223 @@
+#!/usr/bin/env node
+/**
+ * Record a real framework, kill the origin, replay offline, assert the numbers.
+ *
+ * Each check answers one question: does `orca record` actually capture this, and does the
+ * recording still reproduce with nothing to talk to. The second half is why the origin is stopped
+ * before the replay — a replay that reached the network would fail here by construction rather
+ * than by assertion.
+ *
+ *   node test/integrations/run.mjs            # all of them
+ *   node test/integrations/run.mjs litellm    # one
+ */
+import { execFile, spawn } from 'node:child_process';
+import { cp, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+
+const exec = promisify(execFile);
+const here = dirname(fileURLToPath(import.meta.url));
+const root = join(here, '..', '..');
+const cli = join(root, 'packages', 'cli', 'dist', 'cli.js');
+
+/**
+ * The corpus.
+ *
+ * `needs` is the import that has to resolve for the check to mean anything; without it the check
+ * is skipped rather than failed, so a contributor who has not installed every framework can still
+ * run the suite. CI installs them, which is what turns a skip there into a failure.
+ */
+const CHECKS = [
+  {
+    id: 'openai-sdk',
+    what: 'the official Python SDK, configured only by the environment',
+    run: ['python', 'agents/openai_sdk.py'],
+    needs: 'openai',
+    exchanges: 1,
+  },
+  {
+    id: 'openai-async',
+    what: 'AsyncOpenAI, which the OpenAI Agents SDK builds on',
+    run: ['python', 'agents/openai_async.py'],
+    needs: 'openai',
+    exchanges: 1,
+  },
+  {
+    id: 'anthropic-sdk',
+    what: 'the Anthropic SDK reaching /v1/messages',
+    run: ['python', 'agents/anthropic_sdk.py'],
+    needs: 'anthropic',
+    exchanges: 1,
+  },
+  {
+    id: 'litellm',
+    what: 'LiteLLM — the layer CrewAI, Aider and OpenHands route through',
+    run: ['python', 'agents/litellm_agent.py'],
+    needs: 'litellm',
+    exchanges: 1,
+  },
+  {
+    id: 'langgraph-stream',
+    what: 'a two-node LangGraph over streaming SSE',
+    run: ['python', 'agents/langgraph_agent.py', 'stream'],
+    needs: 'langgraph',
+    exchanges: 2,
+  },
+  {
+    id: 'langgraph-tools',
+    what: 'the same graph with a bound tool',
+    run: ['python', 'agents/langgraph_agent.py', 'tools'],
+    needs: 'langgraph',
+    exchanges: 2,
+  },
+  {
+    id: 'fetch-hook',
+    what: 'a JS agent with its origin compiled in',
+    adapter: 'node',
+    run: ['node', 'agents/hardcoded_origin.mjs'],
+    exchanges: 1,
+  },
+];
+
+/** Whether the framework this check speaks for is installed at all. */
+async function installed(module) {
+  if (module === undefined) return true;
+  try {
+    await exec('python', ['-c', `import ${module}`], { timeout: 30_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Start the stub and resolve once it has printed the port it took. */
+function startOrigin() {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [join(here, 'stub-origin.mjs'), '0'], {
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    let out = '';
+    child.stdout.on('data', (chunk) => {
+      out += chunk;
+      const port = Number(out.trim());
+      if (Number.isInteger(port) && port > 0) resolve({ port, stop: () => child.kill() });
+    });
+    child.on('error', reject);
+    child.on('exit', () => reject(new Error('the stub origin exited before it was ready')));
+    setTimeout(() => reject(new Error('the stub origin did not start in 10s')), 10_000).unref();
+  });
+}
+
+/** Run the CLI, returning what it printed whether or not it succeeded. */
+async function orca(argv, cwd) {
+  const env = {
+    ...process.env,
+    NO_COLOR: '1',
+    // A key has to be present or the SDKs refuse to build a client; it never leaves the machine.
+    OPENAI_API_KEY: 'stub-key',
+    ANTHROPIC_API_KEY: 'stub-key',
+  };
+  try {
+    const { stdout, stderr } = await exec(process.execPath, [cli, ...argv], {
+      cwd,
+      env,
+      timeout: 180_000,
+      maxBuffer: 32 * 1024 * 1024,
+    });
+    return { code: 0, out: `${stdout}${stderr}` };
+  } catch (e) {
+    return { code: e.status ?? -1, out: `${e.stdout ?? ''}${e.stderr ?? ''}`, killed: e.killed };
+  }
+}
+
+async function runCheck(check) {
+  if (!(await installed(check.needs))) return { skipped: `${check.needs} is not installed` };
+
+  const dir = await mkdtemp(join(tmpdir(), `orca-int-${check.id}-`));
+  const origin = await startOrigin();
+  try {
+    await cp(join(here, 'agents'), join(dir, 'agents'), { recursive: true });
+
+    const adapter = check.adapter ?? 'generic-openai';
+    const recorded = await orca(
+      [
+        'record',
+        adapter,
+        '--upstream-openai',
+        `http://127.0.0.1:${origin.port}`,
+        '--upstream-anthropic',
+        `http://127.0.0.1:${origin.port}`,
+        '--',
+        ...check.run,
+      ],
+      dir,
+    );
+    if (recorded.code !== 0) throw new Error(`record exited ${recorded.code}`);
+    if (!recorded.out.includes('GOT:')) throw new Error('the agent did not produce its answer');
+    if (/capture\.empty/.test(recorded.out)) {
+      throw new Error('recorded nothing — the traffic never reached the proxy');
+    }
+
+    const runId = /run=(run_[0-9a-f]+)/.exec(recorded.out)?.[1];
+    if (runId === undefined) throw new Error('no run id in the record output');
+
+    // From here the recording is on its own. Anything that reaches out now fails.
+    origin.stop();
+
+    const replayed = await orca(['replay', runId, '--in-place'], dir);
+    if (replayed.code !== 0) throw new Error(`replay exited ${replayed.code}`);
+
+    const m = /reused=(\d+)\/(\d+) exact=(\d+) divergences=(\d+) unmatched=(\d+)/.exec(
+      replayed.out,
+    );
+    if (m === null) throw new Error('replay printed no verdict');
+    const [, reused, total, exact, divergences, unmatched] = m.map(Number);
+
+    if (total !== check.exchanges)
+      throw new Error(`recorded ${total} exchanges, wanted ${check.exchanges}`);
+    if (reused !== total)
+      throw new Error(`${total - reused} turn(s) could not be served from the recording`);
+    if (exact !== total) throw new Error(`${exact}/${total} matched byte for byte`);
+    if (divergences !== 0) throw new Error(`${divergences} divergence(s)`);
+    if (unmatched !== 0) throw new Error(`${unmatched} unmatched`);
+
+    return { ok: `${total} exchanges, replayed exact with the origin down` };
+  } finally {
+    origin.stop();
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+const only = process.argv[2];
+const selected = only ? CHECKS.filter((c) => c.id === only) : CHECKS;
+if (selected.length === 0) {
+  console.error(`no check named ${only}. known: ${CHECKS.map((c) => c.id).join(', ')}`);
+  process.exit(2);
+}
+
+let failed = 0;
+let skipped = 0;
+for (const check of selected) {
+  process.stdout.write(`── ${check.id.padEnd(18)} `);
+  let result;
+  try {
+    result = await runCheck(check);
+  } catch (e) {
+    result = { failed: String(e.message).split('\n')[0] };
+  }
+  if (result.skipped) {
+    skipped += 1;
+    console.log(`skipped — ${result.skipped}`);
+  } else if (result.failed) {
+    failed += 1;
+    console.log(`FAILED — ${result.failed}`);
+    console.log(`   ${check.what}`);
+  } else {
+    console.log(result.ok);
+  }
+}
+
+console.log(`\n${selected.length} checked, ${failed} failed, ${skipped} skipped`);
+process.exit(failed === 0 ? 0 : 1);

--- a/test/integrations/stub-origin.mjs
+++ b/test/integrations/stub-origin.mjs
@@ -1,0 +1,102 @@
+/**
+ * A deterministic OpenAI- and Anthropic-shaped origin.
+ *
+ * Deterministic on purpose: a replay is judged on matching the bytes it recorded, so an origin that
+ * varied its answer would make an exact match indistinguishable from a lucky one.
+ *
+ * It answers the shapes frameworks actually use rather than the simplest one — streaming SSE, tool
+ * calls, and `/v1/messages` — because those are where a recording proxy is most likely to break and
+ * a stub that only served a plain completion would have proved nothing about either.
+ */
+import { createServer } from 'node:http';
+
+const REPLY = 'the stub answered';
+
+function completion(seen) {
+  const wantsTool = Array.isArray(seen.tools) && seen.tools.length > 0;
+  const message = wantsTool
+    ? {
+        role: 'assistant',
+        content: null,
+        tool_calls: [
+          {
+            id: 'call_stub_1',
+            type: 'function',
+            function: {
+              name: seen.tools[0]?.function?.name ?? 'unknown',
+              arguments: '{"city":"Paris"}',
+            },
+          },
+        ],
+      }
+    : { role: 'assistant', content: REPLY };
+
+  return {
+    id: 'chatcmpl-stub-1',
+    object: 'chat.completion',
+    created: 1756000000,
+    model: seen.model ?? 'stub-1',
+    choices: [{ index: 0, message, finish_reason: wantsTool ? 'tool_calls' : 'stop' }],
+    usage: { prompt_tokens: 9, completion_tokens: 4, total_tokens: 13 },
+  };
+}
+
+/** The same answer as the delta frames a streaming client expects. */
+function stream(seen) {
+  const base = {
+    id: 'chatcmpl-stub-1',
+    object: 'chat.completion.chunk',
+    created: 1756000000,
+    model: seen.model ?? 'stub-1',
+  };
+  const frames = [
+    { ...base, choices: [{ index: 0, delta: { role: 'assistant' }, finish_reason: null }] },
+    { ...base, choices: [{ index: 0, delta: { content: 'the stub ' }, finish_reason: null }] },
+    { ...base, choices: [{ index: 0, delta: { content: 'answered' }, finish_reason: null }] },
+    { ...base, choices: [{ index: 0, delta: {}, finish_reason: 'stop' }] },
+  ];
+  return `${frames.map((f) => `data: ${JSON.stringify(f)}\n\n`).join('')}data: [DONE]\n\n`;
+}
+
+function anthropic(seen) {
+  return {
+    id: 'msg_stub_1',
+    type: 'message',
+    role: 'assistant',
+    model: seen.model ?? 'claude-stub',
+    content: [{ type: 'text', text: REPLY }],
+    stop_reason: 'end_turn',
+    usage: { input_tokens: 9, output_tokens: 4 },
+  };
+}
+
+const server = createServer((req, res) => {
+  let body = '';
+  req.on('data', (chunk) => (body += chunk));
+  req.on('end', () => {
+    let seen = {};
+    try {
+      seen = JSON.parse(body || '{}');
+    } catch {
+      // A body this stub cannot parse is still a request worth answering; the shape under test is
+      // whether orca captured it, not whether the client sent valid JSON.
+    }
+
+    if (req.url?.includes('/messages')) {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify(anthropic(seen)));
+      return;
+    }
+    if (seen.stream === true) {
+      res.writeHead(200, { 'content-type': 'text/event-stream', 'cache-control': 'no-cache' });
+      res.end(stream(seen));
+      return;
+    }
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify(completion(seen)));
+  });
+});
+
+server.listen(Number(process.argv[2] ?? 0), '127.0.0.1', () => {
+  process.stdout.write(`${server.address().port}\n`);
+});


### PR DESCRIPTION
<!-- orca-cr-summary:start -->
<!-- orca-code-review-summary -->
<!-- orca-cr-state: {"p0":0,"p1":0,"p2":0,"p3":0,"push":1} -->

## Orca-Code-Review — push 1

| Severity | Count |
|---|---|
| P0 | 0 |
| P1 | 0 |
| P2 | 0 |
| P3 | 0 |

✅ no blocking findings
<!-- orca-cr-summary:end -->

The README says LangGraph, CrewAI and the Agents SDK work under `orca record generic-openai -- …`.
Its own row for LangGraph says **"Should work. Still never tested, still undocumented."** Both were
true.

```console
$ node test/integrations/run.mjs
── openai-sdk         1 exchanges, replayed exact with the origin down
── openai-async       1 exchanges, replayed exact with the origin down
── anthropic-sdk      1 exchanges, replayed exact with the origin down
── litellm            1 exchanges, replayed exact with the origin down
── langgraph-stream   2 exchanges, replayed exact with the origin down
── langgraph-tools    2 exchanges, replayed exact with the origin down
── fetch-hook         1 exchanges, replayed exact with the origin down

7 checked, 0 failed, 0 skipped
```

Each check records a real framework against a deterministic stub, **stops the stub**, replays the
recording, and asserts `reused`, `exact`, `divergences` and `unmatched`. The origin goes down before
the replay on purpose: a replay that reached the network fails here by construction rather than by
assertion.

## Why end to end rather than the adapter contract

`checkAdapterContract` guards against adapter rot. It cannot see whether anything was *captured*.

`orca record opencode` once produced a trace with two events and no model exchange — twice over,
for two independent reasons (#36, #38). The contract was green for both. What catches that shape is
running the thing and counting what came back.

## Seven checks, more than seven frameworks

They cover **layers, not vendors**:

| check | mechanism | what rides on it |
|---|---|---|
| `openai-sdk` / `openai-async` | the official SDK reads `OPENAI_BASE_URL` | the OpenAI Agents SDK, and anything letting the SDK build its client |
| `anthropic-sdk` | `ANTHROPIC_BASE_URL` → `/v1/messages` | Claude-backed agents that are not Claude Code |
| `litellm` | `OPENAI_API_BASE` through LiteLLM | **CrewAI, Aider, OpenHands** |
| `langgraph-stream` / `langgraph-tools` | LangChain, over SSE and with a bound tool | LangGraph, LangChain |
| `fetch-hook` | `NODE_OPTIONS` preload on `globalThis.fetch` | the Vercel AI SDK, any JS agent with its origin compiled in |

The stub answers streaming SSE, tool calls and `/v1/messages` rather than the simplest shape — those
are where a recording proxy is most likely to break, and a matrix exercising only a plain completion
would have said nothing about either.

## Measured, not assumed

A green matrix proves nothing on its own, so each redirect was removed in turn:

| removed from `generic-openai` | what fails |
|---|---|
| `OPENAI_BASE_URL` | `openai-sdk`, `openai-async` |
| `ANTHROPIC_BASE_URL` | `anthropic-sdk` |
| `OPENAI_API_BASE` | **nothing** |

The last row is a finding worth keeping, and it is in the README rather than only in this
description. LangChain reads `OPENAI_API_BASE` itself but hands the rest to the official client,
which reads `OPENAI_BASE_URL` — so the LangGraph checks survive losing the variable that looks like
theirs. Both stay set, because pre-1.0 SDKs and several ports read only the second and this matrix
does not cover those. It is worth knowing that today nothing here would notice if that line went
away.

## Running them

```console
node test/integrations/run.mjs            # all
node test/integrations/run.mjs litellm    # one
```

A check whose package is not installed is **skipped, not failed**, so the suite runs for a
contributor who has not installed all five. CI installs them, which is what makes a skip there a
failure.

## Verified

- three consecutive runs, identical each time
- single-check selection, and an unknown name exits with the list of known ones
- the skip path exercised by pointing a check at a package that does not exist
- `vitest` does not pick these up — its `include` is `packages/*/test/**/*.test.ts`
- main suite unchanged: **1670 passed**, no failure `main` does not already have

Once this is green, the LangGraph row in the README can say **works** — with a line in CI behind it
rather than a sentence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)