### PR TITLE
docker: pin the image to 0.2.3, the release that has goose and hermes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ENV NODE_ENV=production
 WORKDIR /work
 
 # Pinned, not `latest`: an image that silently changes what it runs is the opposite of the point.
-RUN npm install -g --omit=dev orcareplay@0.2.2
+RUN npm install -g --omit=dev orcareplay@0.2.3
 
 # stdio transport — the client owns stdin/stdout, so no port is exposed.
 ENTRYPOINT ["orca", "mcp"]


### PR DESCRIPTION
<!-- orca-cr-summary:start -->
<!-- orca-code-review-summary -->
<!-- orca-cr-state: {"p0":0,"p1":0,"p2":0,"p3":0,"push":1} -->

## Orca-Code-Review — push 1

| Severity | Count |
|---|---|
| P0 | 0 |
| P1 | 0 |
| P2 | 0 |
| P3 | 0 |

✅ no blocking findings
<!-- orca-cr-summary:end -->

The `Dockerfile` still pinned `orcareplay@0.2.2`, which was published **before** the goose and Hermes adapters existed. Anyone building this image today gets an MCP server one release behind the README.

Pinning rather than `latest` is still right — an image that silently changes what it runs is the opposite of the point, and the comment in the file says so. The pin just has to move when a release does.

## Verified, not assumed

Introspection is all a directory health check exercises, so I ran it against the published 0.2.3 over stdio:

```console
$ printf ... | node .../orcareplay/dist/cli.js mcp
initialize -> {"name":"orcareplay","version":"0.2.3"} protocol 2025-06-18
tools/list -> orca_list_runs, orca_show_run, orca_checkpoints, orca_graph, orca_replay, orca_compare
```

## Why now

Glama, which several MCP directories use as a gate — `punkpeye/awesome-mcp-servers` will not merge an entry without a Glama score badge — builds the submitted Dockerfile and checks that the server starts and answers introspection. Submitting the 0.2.2 pin would have listed a stale server.

Worth a follow-up separately: this pin has no test holding it to the released version, so it can drift again. `release-image.yml` from the closed #43 had a guard for exactly that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)