### PR TITLE
say which frameworks work, now that a check says so

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       # The frameworks this speaks for. A check whose package is missing is skipped rather than
       # failed, so a contributor can run the suite without all of them — which makes installing
       # them here the thing that turns a skip into a failure.
-      - run: pip install openai anthropic litellm langgraph langchain-openai
+      - run: pip install openai anthropic litellm langgraph langchain-openai browser-use
       - run: node test/integrations/run.mjs
 
   python-sdk:

--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ whether orca understands the wire format it speaks once it arrives.
 | **OpenClaw** | `orca record openclaw` — the hook for the gateway, inherited variables for the agents it spawns | works |
 | **opencode** | `orca record opencode` | adapter shipped, both origins redirected |
 | **goose** (Block) | `orca record goose` — `OPENAI_HOST` **and** `OPENAI_BASE_URL`, `ANTHROPIC_HOST` → Responses API | works — driven end to end against goose 1.49.0, [what is different about it](#the-harness-that-reads-different-variables) |
-| **LangGraph / LangChain** | `OPENAI_BASE_URL`, `ANTHROPIC_BASE_URL` | should work — it goes through the official clients, but nothing here tests it yet |
+| **LangGraph / LangChain** | `OPENAI_BASE_URL`, `ANTHROPIC_BASE_URL` | works — a two-node graph, streaming and with a tool, records and replays at `exact=2` and forks live, [in CI](test/integrations/) |
 | **Hermes** (Nous Research) | `ORCA_BASE_URL_VARS=… orca record generic-openai -- hermes …` | should work — it overrides per provider; [name the variable](#a-base-url-variable-orca-has-never-heard-of) |
 | **Codex-in-the-IDE** | `orca record exec --tls-intercept -- code .` | works — the extension spawns the agent, and it inherits the capture |
 | **a bot with a hardcoded origin** | `orca record exec --tls-intercept -- <cmd>` | works — a Grok bot posting to a URL in its own source, [in detail](#an-agent-that-reads-nothing-at-all) |
@@ -776,6 +776,7 @@ interface first, with a second implementation showing it is not shaped around on
 **Reference:**
 
 - [`spec/orca-trace-v0.md`](spec/orca-trace-v0.md) — the normative trace format
+- [`docs/integrations.md`](docs/integrations.md) — recording a framework, one command each, every number asserted in CI
 - [`docs/architecture.md`](docs/architecture.md) — how capture, replay and fork actually work
 - [`docs/validation.md`](docs/validation.md) — what broke the first time this met a real agent
 - [`docs/launch-path.md`](docs/launch-path.md) — what is built, what is not, and what is next
@@ -794,8 +795,9 @@ already written down.
   about twenty lines — [docs/plugins.md](docs/plugins.md). If it does not, `node` may already cover
   it; a recording that comes back empty from a harness not listed [above](#which-agents) is worth
   an issue either way.
-- **Prove LangGraph.** It should work through the official clients and nothing here tests it. An
-  end-to-end test against a stub upstream would turn a "should" into a row that CI can turn red.
+- **Add a framework to the integration checks.** `test/integrations/` records a real framework
+  against a stub origin, kills the origin and replays it. Eight are covered; AutoGen, LlamaIndex,
+  Pydantic AI and smolagents are not. A new one is a script and a row.
 - **Reimplement the reader.** The spec is CC BY 4.0 on purpose. There is already a Python reader;
   Go and Rust are open.
 - **Break the replay.** The matching ladder is the heart of this and the fastest way to improve it

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -1,0 +1,177 @@
+# Recording a framework
+
+Most agent frameworks need no adapter. They read a base-URL variable, and `generic-openai` sets
+every one in common use at once:
+
+```console
+orca record generic-openai -- python your_agent.py
+```
+
+Each section below is one command, one measured result, and the one thing about that framework
+worth knowing before you run it. Every number here comes from `test/integrations/run.mjs`, which
+runs in CI — so a claim on this page fails a build rather than ageing quietly.
+
+---
+
+## LangGraph and LangChain
+
+```console
+orca record generic-openai -- python your_graph.py
+orca replay last
+```
+
+**Measured:** a two-node graph, streaming and with a bound tool. Recorded 2 exchanges, replayed
+with the origin down at `exact=2 divergences=0 unmatched=0`, and forked live from checkpoint 1 onto
+a different model.
+
+### What replay proves here, and what it does not
+
+LangGraph has its own time travel, and the two answer different questions. From LangChain's docs:
+
+> Replay **re-executes nodes — it doesn't just read from cache. LLM calls, API requests, and
+> interrupts fire again and may return different results.**
+
+That makes the *workflow* deterministic. The model stays probabilistic.
+
+`orca replay` serves the recorded responses back with the network off, so the conversation is
+byte-identical:
+
+| | asks the model again? | answers |
+|---|---|---|
+| LangGraph time travel | yes | "if I re-run from step 4, what happens?" |
+| `orca replay` | **no** | "does the recorded run still reproduce today?" |
+| `orca replay --from 4 --model X` | yes | "same prefix, different model — who is right?" |
+
+The third row is the one that corresponds to time travel, and it is the one that costs tokens.
+
+### Two things specific to LangGraph
+
+**Both variables are set, and only one of them matters.** LangChain reads `OPENAI_API_BASE` itself
+and hands the rest to the official client, which reads `OPENAI_BASE_URL`. Measured by removing each
+in turn: taking `OPENAI_API_BASE` away breaks nothing here. Both stay set because pre-1.0 SDKs and
+several ports read only that one.
+
+**Setting a base URL changes a LangChain default.** It leaves `stream_usage` off, because many
+non-OpenAI endpoints do not report streaming token counts. That is LangChain's behaviour, not
+orca's, but a recorded run will differ from an unrecorded one in exactly that field.
+
+**Checkpointer state is not in the trace.** An `InMemorySaver` thread id never reaches the wire, so
+a replay rebuilds it by re-running the graph. A database-backed checkpointer is a different matter
+and is not covered by the checks here.
+
+---
+
+## CrewAI, Aider, OpenHands
+
+```console
+orca record generic-openai -- python your_crew.py
+```
+
+All three route through **LiteLLM**, which reads `OPENAI_API_BASE`. That is the layer the checks
+exercise: one check covers all three, and anything else built on LiteLLM comes with it.
+
+**Measured:** `litellm.completion()` recorded and replayed at `exact=1 divergences=0`.
+
+CrewAI has a known wrinkle worth knowing about even though it does not affect this route:
+`LLM(base_url=…)` does not map to LiteLLM's `api_base`, so passing the URL in code can silently do
+nothing. Going through the environment sidesteps it.
+
+---
+
+## OpenAI Agents SDK
+
+```console
+orca record generic-openai -- python your_agent.py
+```
+
+The default provider reads `OPENAI_BASE_URL`, and the SDK is built on `AsyncOpenAI` — both covered.
+
+**Measured:** `AsyncOpenAI` recorded and replayed at `exact=1 divergences=0`.
+
+Two things to decide before a long run:
+
+**Tracing is a second egress.** The SDK ships its own traces to OpenAI. They are not model traffic
+and orca does not capture them; `set_tracing_disabled(True)` turns them off if you would rather the
+run talked to nothing but the proxy.
+
+**The websocket transport is not captured.** With the Responses websocket transport enabled the SDK
+reads `OPENAI_WEBSOCKET_BASE_URL`, and orca's proxy speaks HTTP. Under `--tls-intercept` an upgrade
+inside an intercepted connection is refused with `501` rather than half-relayed, so it fails loudly;
+outside it, the connection is tunnelled and works but is not recorded.
+
+---
+
+## browser-use
+
+```console
+orca record generic-openai -- python your_task.py
+```
+
+`ChatOpenAI` declares `base_url: str | httpx.URL | None = None` and passes it through, so an unset
+value falls to the SDK's own `OPENAI_BASE_URL`.
+
+**Measured:** recorded and replayed at `exact=1 divergences=0`, LLM layer only — the checks do not
+drive a browser.
+
+`ChatBrowserUse` is a different matter: it is browser-use's own hosted model, and its origin is not
+an environment variable. That route needs `--tls-intercept` and the host named explicitly.
+
+---
+
+## Vercel AI SDK, and anything with its origin compiled in
+
+```console
+orca record node -- node your_app.mjs
+```
+
+`@ai-sdk/openai` takes its origin as a constructor argument and reads nothing from the environment.
+The `node` adapter installs a preload through `NODE_OPTIONS` that redirects at `globalThis.fetch` —
+the one place every JS client agrees on.
+
+**Measured:** an agent posting to a hardcoded `https://api.openai.com/v1/chat/completions`,
+recorded and replayed at `exact=1 divergences=0`.
+
+---
+
+## Anthropic-backed agents
+
+```console
+orca record generic-openai -- python your_agent.py
+```
+
+`ANTHROPIC_BASE_URL` is set alongside the OpenAI pair, so an agent using the Anthropic SDK directly
+needs nothing extra. Claude Code has its own adapter — `orca record claude`.
+
+**Measured:** the Anthropic SDK reaching `/v1/messages`, recorded and replayed at `exact=1
+divergences=0`.
+
+---
+
+## When none of this works
+
+**The trace comes back empty.** `orca record` says so rather than exiting quietly:
+
+```
+warn capture.empty exchanges=0 cause="the agent never called the proxy — it may not read a
+  base-URL variable" set=ANTHROPIC_BASE_URL,OPENAI_API_BASE,OPENAI_BASE_URL next="orca doctor"
+```
+
+Three things it usually means, in order of likelihood:
+
+1. **The framework reads a variable orca does not set.** Name it:
+   `ORCA_BASE_URL_VARS=MY_LLM_ENDPOINT orca record generic-openai -- …`
+2. **The origin is in a config file, not the environment.** OpenCode and its forks are like this.
+   Interception is the route: `orca record exec --tls-intercept -- your-agent`.
+3. **The origin is compiled in.** For a JS agent, `orca record node -- node app.mjs`. For anything
+   else, `--tls-intercept` with the host named.
+
+**A gateway on plain HTTP is captured by neither route.** orca sets `HTTPS_PROXY` and not
+`HTTP_PROXY`, so plaintext upstream traffic is neither redirected nor decrypted.
+
+---
+
+## Adding a check
+
+A framework is supported here when `test/integrations/run.mjs` says so. Adding one is a script
+under `test/integrations/agents/` and a row in the corpus — see that directory's README for what
+each check has to prove and why it is end to end rather than a contract check.

--- a/docs/launch-path.md
+++ b/docs/launch-path.md
@@ -30,7 +30,7 @@ try it — because the first thing a viewer does after watching is point it at t
 | Claude Code | `ANTHROPIC_BASE_URL` | `/v1/messages` | **Works.** Adapter shipped, validated against a real bug-fix run. |
 | OpenAI Agents SDK | `OPENAI_BASE_URL` ✓ | `/v1/responses` | **Works** *(was: broke on turn one)*. Recorded, replayed offline, forkable. |
 | Codex CLI | `OPENAI_BASE_URL` ✓ | `/v1/responses` | **Works** *(was: broke on turn one)*. On a ChatGPT subscription it still needs `--tls-intercept` first. |
-| LangGraph / LangChain | `OPENAI_BASE_URL`, `ANTHROPIC_BASE_URL` | chat completions | **Should work.** Goes through the official clients, which read both. Still never tested, still undocumented — W3.5. |
+| LangGraph / LangChain | `OPENAI_BASE_URL`, `ANTHROPIC_BASE_URL` | chat completions | **Works** *(was: never tested)*. A two-node graph, streaming and with a tool: records, replays at `exact=2` with the origin down, and forks live. Asserted in CI — W3.5. |
 | Vercel AI SDK | none — redirected at `globalThis.fetch` | chat completions / `/v1/responses` | **Works** *(was: silent)*. `orca record node -- node app.mjs` installs a fetch hook; recorded, replayed offline. |
 
 Two failure modes, and the quiet one is worse in the long run.
@@ -111,7 +111,7 @@ land before the things that merely miss them.
 | **W3.2** ✅ | **Shipped.** Warn at the end of `orca record` when zero model exchanges were captured, with the likely cause. The empty-trace failure must never be silent. | Recording an unconfigured Vercel AI SDK app produces a warning, not a clean exit. |
 | **W3.3** ✅ | **Shipped.** A Responses API dialect: matches `/v1/responses`, translators in `providers/src/translate/`, SSE delta parsing, `withModel` so forks work. Unblocks the OpenAI Agents SDK and Codex at once. The dialect interface is already built for exactly this — the proxy is handed a list and knows nothing about which exist. | A Codex run records, replays offline and forks. |
 | **W3.4** ✅ | **Shipped.** `@orcareplay/node-instrument`: a Node `--import` hook rewriting provider origins on `globalThis.fetch`, injected by `orca record` through `NODE_OPTIONS`. Environment variables cannot reach the Vercel AI SDK, so reach the runtime. Covers every JS agent that hardcodes a base URL — a class, not a vendor. | An unmodified `@ai-sdk/openai` app records and replays. |
-| **W3.5** | Prove LangGraph rather than assuming it: a `langgraph` adapter id, an end-to-end test against a stub upstream, a how-to. Check its thread and checkpoint ids survive redaction — the entropy sweep has already eaten round-tripping protocol identifiers twice. | A two-node graph records, replays and forks in CI. |
+| **W3.5** ✅ | **Shipped** — an end-to-end check against a stub upstream and a how-to (`docs/integrations.md`), minus the adapter id. A `langgraph` adapter's `prepare` would be `generic-openai`'s verbatim, because orca launches the user's own script rather than a binary it knows, so the id would have bought a name and nothing else. Two findings worth keeping: the redaction worry did not materialise because an `InMemorySaver` thread id never reaches the wire at all, and removing `OPENAI_API_BASE` breaks none of the LangChain checks — they survive on the official client's `OPENAI_BASE_URL`. | A two-node graph records, replays and forks in CI. |
 | **W3.6** | Run `checkAdapterContract` as a per-integration matrix job and generate the README support table from the result. | "We support X" is a check, not a sentence. |
 
 ## 4. Proof that replay is reliable and traces are safe

--- a/test/integrations/README.md
+++ b/test/integrations/README.md
@@ -41,9 +41,10 @@ a matrix that only exercised a plain completion would have said nothing about ei
 | `litellm` | `OPENAI_API_BASE` through LiteLLM | **CrewAI, Aider, OpenHands** — they route through it |
 | `langgraph-stream` | LangChain's own `OPENAI_API_BASE`, over SSE | LangGraph, LangChain |
 | `langgraph-tools` | the same, with a bound tool | tool-calling graphs |
+| `browser-use` | its own `ChatOpenAI` passes an unset `base_url` through | browser-use, and the pattern any wrapper using the official SDK follows |
 | `fetch-hook` | `NODE_OPTIONS` preload on `globalThis.fetch` | the Vercel AI SDK, and any JS agent with its origin compiled in |
 
-Seven checks, and the third row is the reason the list is shorter than the set of frameworks it
+Eight checks, and the `litellm` row is the reason the list is shorter than the set of frameworks it
 speaks for: covering the layer underneath covers everything standing on it.
 
 ## What the checks are worth, measured

--- a/test/integrations/agents/browser_use_agent.py
+++ b/test/integrations/agents/browser_use_agent.py
@@ -1,0 +1,24 @@
+"""browser-use's LLM layer, without starting a browser.
+
+The question this answers is narrow on purpose: does the origin reach the proxy. `ChatOpenAI` here
+declares `base_url: str | httpx.URL | None = None` and passes it through, so an unset value falls
+to the official SDK's own `OPENAI_BASE_URL` — which is the whole reason browser-use needs no adapter
+and is worth a check rather than a claim.
+
+Driving an actual browser would need Chromium and would test Playwright, not orca.
+"""
+
+import asyncio
+
+from browser_use import ChatOpenAI
+from browser_use.llm.messages import UserMessage
+
+
+async def main() -> None:
+    llm = ChatOpenAI(model="stub-1")
+    print("base_url:", llm.get_client().base_url)
+    reply = await llm.ainvoke([UserMessage(content="hello")])
+    print("GOT:", reply.completion)
+
+
+asyncio.run(main())

--- a/test/integrations/run.mjs
+++ b/test/integrations/run.mjs
@@ -64,6 +64,10 @@ const CHECKS = [
     run: ['python', 'agents/langgraph_agent.py', 'stream'],
     needs: 'langgraph',
     exchanges: 2,
+    // The one check that also forks. A fork is the third of the three things the README claims,
+    // and it is the only one that leaves the recording behind and asks a model again — so it is
+    // exercised where the stub is still up, which is what keeps it free.
+    forks: true,
   },
   {
     id: 'langgraph-tools',
@@ -71,6 +75,13 @@ const CHECKS = [
     run: ['python', 'agents/langgraph_agent.py', 'tools'],
     needs: 'langgraph',
     exchanges: 2,
+  },
+  {
+    id: 'browser-use',
+    what: "browser-use's own ChatOpenAI, which passes an unset base_url straight through",
+    run: ['python', 'agents/browser_use_agent.py'],
+    needs: 'browser_use',
+    exchanges: 1,
   },
   {
     id: 'fetch-hook',
@@ -163,6 +174,30 @@ async function runCheck(check) {
     const runId = /run=(run_[0-9a-f]+)/.exec(recorded.out)?.[1];
     if (runId === undefined) throw new Error('no run id in the record output');
 
+    // A fork continues live from a checkpoint, so it runs while the stub is still up — which is
+    // also what keeps it free. `replayed=0 live=N` is the shape to look for: nothing served from
+    // the recording past the cursor, every turn after it answered by the origin.
+    if (check.forks) {
+      const forked = await orca(
+        [
+          'replay',
+          runId,
+          '--from',
+          '1',
+          '--model',
+          'stub-2',
+          '--upstream-openai',
+          `http://127.0.0.1:${origin.port}`,
+        ],
+        dir,
+      );
+      if (forked.code !== 0) throw new Error(`fork exited ${forked.code}`);
+      const f = /fork\.done .*live=(\d+) divergences=(\d+)/.exec(forked.out);
+      if (f === null) throw new Error('fork printed no verdict');
+      if (Number(f[1]) === 0) throw new Error('the fork answered nothing live');
+      if (Number(f[2]) !== 0) throw new Error(`${f[2]} divergence(s) in the fork`);
+    }
+
     // From here the recording is on its own. Anything that reaches out now fails.
     origin.stop();
 
@@ -183,7 +218,9 @@ async function runCheck(check) {
     if (divergences !== 0) throw new Error(`${divergences} divergence(s)`);
     if (unmatched !== 0) throw new Error(`${unmatched} unmatched`);
 
-    return { ok: `${total} exchanges, replayed exact with the origin down` };
+    return {
+      ok: `${total} exchanges, replayed exact with the origin down${check.forks ? ', forked live' : ''}`,
+    };
   } finally {
     origin.stop();
     await rm(dir, { recursive: true, force: true });


### PR DESCRIPTION
<!-- orca-cr-summary:start -->
<!-- orca-code-review-summary -->
<!-- orca-cr-state: {"p0":0,"p1":0,"p2":0,"p3":0,"push":1} -->

## Orca-Code-Review — push 1

| Severity | Count |
|---|---|
| P0 | 0 |
| P1 | 0 |
| P2 | 0 |
| P3 | 0 |

✅ no blocking findings
<!-- orca-cr-summary:end -->

#52 made *"we support X"* a line in CI. Three places in the repo still said the opposite, and one of
them was the support table people read first:

```diff
- | LangGraph / LangChain | … | should work — it goes through the official clients, but nothing here tests it yet |
+ | LangGraph / LangChain | … | works — a two-node graph, streaming and with a tool, records and replays at `exact=2` and forks live, in CI |
```

## `docs/integrations.md`

The how-to that was the missing half of W3.5. One command per framework, the measured result beside
it, and the one thing about that framework worth knowing before running it. Every number on the
page comes from `test/integrations/run.mjs`, so a claim there fails a build rather than ageing.

Two of those things are worth pulling out, because they are not obvious and nobody else documents
them:

**LangGraph's own time travel answers a different question.** From LangChain's docs — replay
*"re-executes nodes — LLM calls fire again and may return different results"*. That makes the
**workflow** deterministic and leaves the **model** probabilistic.

| | asks the model again? | answers |
|---|---|---|
| LangGraph time travel | yes | "if I re-run from step 4, what happens?" |
| `orca replay` | **no** | "does the recorded run still reproduce today?" |
| `orca replay --from 4 --model X` | yes | "same prefix, different model — who is right?" |

**The Agents SDK has two egresses orca does not capture**, and both are quiet: tracing ships to
OpenAI on its own, and the Responses websocket transport reads `OPENAI_WEBSOCKET_BASE_URL` while the
proxy speaks HTTP. Under `--tls-intercept` an upgrade is refused with `501` rather than half-relayed,
so it fails loudly; outside it, the connection tunnels and works but is not recorded.

## Two additions to the matrix

The page needed them to be **true** rather than argued.

**`browser-use`.** Its `ChatOpenAI` declares `base_url: str | httpx.URL | None = None` and passes it
through, which is exactly why it needs no adapter. That was read off the source once; now it is
asserted every run.

**The LangGraph check forks.** Recording and replaying were covered; forking is the third of the
three things the README claims and the matrix was not exercising it. It runs while the stub is still
up — which is what keeps it free — and `live=0` fails it. Mutation-checked by forcing `liveCalls`
to zero: the check goes red.

```
── openai-sdk         1 exchanges, replayed exact with the origin down
── openai-async       1 exchanges, replayed exact with the origin down
── anthropic-sdk      1 exchanges, replayed exact with the origin down
── litellm            1 exchanges, replayed exact with the origin down
── langgraph-stream   2 exchanges, replayed exact with the origin down, forked live
── langgraph-tools    2 exchanges, replayed exact with the origin down
── browser-use        1 exchanges, replayed exact with the origin down
── fetch-hook         1 exchanges, replayed exact with the origin down

8 checked, 0 failed, 0 skipped
```

## W3.5, marked shipped — without the adapter id it asked for

A `langgraph` adapter's `prepare` would be `generic-openai`'s **verbatim**: orca launches the user's
own script rather than a binary it knows, so the command comes from `userArgs` either way. The id
would have bought a name and nothing else. What was missing was the check and the how-to, and both
are here.

The redaction worry W3.5 raised — *"the entropy sweep has already eaten round-tripping protocol
identifiers twice"* — did not materialise, for a reason worth recording rather than celebrating: an
`InMemorySaver` thread id **never reaches the wire**, so the redactor never sees it. A
database-backed checkpointer is a different question and is not covered here.

## Verified

- matrix ×3, identical: **8 checked, 0 failed, 0 skipped**
- conformance 57 events, fidelity 0 regressions, Prettier and `tsc` clean
- main suite **1720 passed**, no failure `main` does not already have
- the one remaining "should work" in the README is Hermes, which genuinely is untested

🤖 Generated with [Claude Code](https://claude.com/claude-code)