### PR TITLE
fix(cli): name the route for a command only `--json` answers

### DIFF
--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -128,6 +128,16 @@ For a script, an agent, or CI — every command below also answers as data:
 Docs: https://github.com/Continuum-AI-Corp/OrcaReplay
 `;
 
+/**
+ * The commands `--json` answers and the terminal does not.
+ *
+ * A set rather than a special case. It holds one name today, and the point of the shape is that
+ * adding a second `--json`-only view does not quietly bring back `orca events` telling a reader
+ * that a command `--help` had just listed does not exist. `json-only.test.ts` derives the same set
+ * from the two switches in this file and fails when this disagrees with them.
+ */
+const JSON_ONLY = new Set(['events']);
+
 export async function main(argv: string[], cwd = process.cwd()): Promise<number> {
   const args = parseArgs(argv);
   if (args.bool('json')) return jsonMain(args, cwd);
@@ -217,6 +227,19 @@ export async function main(argv: string[], cwd = process.cwd()): Promise<number>
         await serveMcp({ orca: new Orca({ cwd }), input: process.stdin, output: process.stdout });
         return 0;
       default:
+        // `--json` answers one view that the terminal does not, and `--help` lists it beside seven
+        // that it does. A reader scanning that line reasonably types `orca events`, and being told
+        // there is no such command — by the same tool that had just named it — reads as the CLI
+        // contradicting itself. Name the route instead.
+        if (JSON_ONLY.has(args.command)) {
+          out.failure({
+            event: 'json_only_command',
+            what: `${args.command} answers as data, not as a table`,
+            why: 'these are the raw trace records; `orca show` is the same events, rendered',
+            next: `orca ${args.command} --json`,
+          });
+          return 2;
+        }
         out.failure({
           event: 'unknown_command',
           what: `there is no "${args.command}" command`,

--- a/packages/cli/test/json-only.test.ts
+++ b/packages/cli/test/json-only.test.ts
@@ -1,0 +1,88 @@
+import { execFile } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+import { describe, expect, it } from 'vitest';
+
+const run = promisify(execFile);
+const here = dirname(fileURLToPath(import.meta.url));
+const cli = join(here, '..', 'dist', 'cli.js');
+const mainSource = join(here, '..', 'src', 'main.ts');
+
+/** The `case 'x':` labels of one switch. */
+function commandsIn(source: string): Set<string> {
+  return new Set([...source.matchAll(/^\s*case '([a-z-]+)':/gm)].map((m) => m[1]!));
+}
+
+/**
+ * `--json` answers one view the terminal does not, and `--help` lists it in the same `·`-separated
+ * line as seven that it does:
+ *
+ *     --json         one JSON document on stdout, diagnostics on stderr
+ *                    list · show · events · checkpoints · graph · record · replay · compare
+ *
+ * Seven of those are commands. `events` is not, and typing it said so in the flattest terms
+ * available:
+ *
+ *     $ orca events
+ *     error unknown_command
+ *       there is no "events" command
+ *
+ * from a tool whose own `--help` had just named it — which reads as the CLI contradicting itself
+ * rather than as one view being data-only.
+ *
+ * Adding `orca events` as a terminal command was the other option and is the wrong one:
+ * `buildTimeline` is `events.map(...)`, so `orca show` already renders every event in the trace.
+ * A second table of the same rows would be a worse `show`. What was missing was the sentence
+ * saying so.
+ */
+describe('commands that only --json answers', () => {
+  it('are exactly the ones JSON_ONLY names', async () => {
+    const source = await readFile(mainSource, 'utf8');
+    // Everything before `jsonMain` is the terminal switch; everything after is the `--json` one.
+    const split = source.indexOf('async function jsonMain(');
+    expect(split, 'main.ts no longer has a jsonMain to split on').toBeGreaterThan(0);
+
+    const terminal = commandsIn(source.slice(0, split));
+    const json = commandsIn(source.slice(split));
+    const jsonOnly = [...json].filter((c) => !terminal.has(c)).sort();
+
+    const declared = /const JSON_ONLY = new Set\((\[[^\]]*\])\)/.exec(source);
+    expect(declared, 'JSON_ONLY is gone or no longer a literal set').not.toBeNull();
+    const named = (JSON.parse(declared![1]!.replace(/'/g, '"')) as string[]).sort();
+
+    // The whole point of the set. A new `--json`-only view that nobody adds here would otherwise
+    // bring the "there is no X command" answer back for a name `--help` lists.
+    expect(named).toEqual(jsonOnly);
+  });
+
+  it('say which route answers them, rather than that they do not exist', async () => {
+    const { stdout, stderr } = await run(process.execPath, [cli, 'events'], {
+      env: { ...process.env, NO_COLOR: '1' },
+      timeout: 30_000,
+    }).catch((e: { stdout?: string; stderr?: string }) => ({
+      stdout: e.stdout ?? '',
+      stderr: e.stderr ?? '',
+    }));
+    const said = `${stdout}${stderr}`;
+
+    expect(said, 'help lists it, so the CLI must not deny it exists').not.toMatch(
+      /there is no "events" command/,
+    );
+    // Naming the route is the fix. A message that only says "not here" leaves the reader where
+    // they started.
+    expect(said).toContain('orca events --json');
+  });
+
+  it('leaves a genuine typo answering as a typo', async () => {
+    const { stdout, stderr } = await run(process.execPath, [cli, 'evnets'], {
+      env: { ...process.env, NO_COLOR: '1' },
+      timeout: 30_000,
+    }).catch((e: { stdout?: string; stderr?: string }) => ({
+      stdout: e.stdout ?? '',
+      stderr: e.stderr ?? '',
+    }));
+    expect(`${stdout}${stderr}`).toMatch(/there is no "evnets" command/);
+  });
+});


### PR DESCRIPTION
<!-- orca-cr-summary:start -->
<!-- orca-code-review-summary -->
<!-- orca-cr-state: {"p0":0,"p1":0,"p2":0,"p3":0,"push":1} -->

## Orca-Code-Review — push 1

| Severity | Count |
|---|---|
| P0 | 0 |
| P1 | 0 |
| P2 | 0 |
| P3 | 0 |

✅ no blocking findings
<!-- orca-cr-summary:end -->

## The bug

```console
$ orca events
error unknown_command
  there is no "events" command
  next: orca help
```

From a tool whose own `--help` had just listed it:

```
  --json         one JSON document on stdout, diagnostics on stderr
                 list · show · events · checkpoints · graph · record · replay · compare
                 · doctor
```

Seven of those eight are terminal commands. `events` is the one that is not, and the failure it gave reads as the CLI contradicting itself rather than as one view being data-only. Exit code 2, so a script sees a usage error for a name the tool documents.

## Why not just add the command

That was the other option, and it is the wrong one. `buildTimeline` is `events.map(...)` — one row per event, nothing folded and nothing dropped — so `orca show` already renders every event in the trace:

```console
$ orca events --json | jq length
6
$ orca show | grep -c '^[0-9]'
6
```

A second table of the same rows would be a worse `show`. What was missing was the sentence saying so, and where to go instead:

```console
$ orca events
error json_only_command
  events answers as data, not as a table
  these are the raw trace records; `orca show` is the same events, rendered
  next: orca events --json
```

## Why a set and not a special case

The bug is a class, not an instance: a future `--json`-only view added without a line here brings the same contradiction back. So `JSON_ONLY` is a set, and a test derives the same set from the two switches in `main.ts` — everything before `jsonMain` is the terminal one, everything after is the `--json` one — and fails when the declaration disagrees with them.

## Verification

| mutation | result |
|---|---|
| `JSON_ONLY = new Set([])` | 2 red |
| add an unregistered `--json`-only case | 1 red, naming the missing name |

| | |
|---|---|
| `json-only.test.ts` | 3/3 |
| full suite ×2 | 1739 passed, **zero new failures** vs. `main` |
| `test/integrations/run.mjs` | 8 checked, 0 failed, 0 skipped |
| conformance / fidelity / neutrality | 57 events, 1 replay, 0 failures |

A genuine typo still answers as a typo — `orca evnets` is unchanged, and there is a test pinning that too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)