### PR TITLE
check CrewAI and the Agents SDK themselves, and fix what that found

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,10 +60,15 @@ jobs:
       - run: npm ci
       - run: npx tsc --build
       # The frameworks this speaks for. A check whose package is missing is skipped rather than
-      # failed, so a contributor can run the suite without all of them — which makes installing
-      # them here the thing that turns a skip into a failure.
-      - run: pip install openai anthropic litellm langgraph langchain-openai browser-use
-      - run: node test/integrations/run.mjs
+      # failed, so a contributor can run the suite without all of them.
+      - run: >
+          pip install openai anthropic litellm langgraph langchain-openai browser-use
+          crewai openai-agents openhands-sdk
+      # `--require-all`, because installing them above was never what enforced it. Two checks were
+      # added without a line here and CI stayed green on the skips, while the README said "in CI"
+      # about both. A skip is now a failure on this runner, so forgetting the line above fails
+      # loudly instead of quietly making a claim untrue.
+      - run: node test/integrations/run.mjs --require-all
 
   python-sdk:
     name: python sdk

--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ whether orca understands the wire format it speaks once it arrives.
 | **Claude Code** | `ANTHROPIC_BASE_URL` | works — validated against a real bug fix, [in detail](docs/validation.md) |
 | **Codex CLI** (API key) | `OPENAI_BASE_URL` → Responses API | works |
 | **Codex CLI** (ChatGPT login) | `--tls-intercept` → Responses API | works, [with a decision to make](#when-the-harness-will-not-be-redirected) |
-| **OpenAI Agents SDK** | `OPENAI_BASE_URL` → Responses API | works — the `AsyncOpenAI` client it is built on records and replays at `exact=1`, [in CI](test/integrations/); [its own tracing is a second egress](docs/integrations.md#openai-agents-sdk) |
+| **OpenAI Agents SDK** | `OPENAI_BASE_URL` → Responses API | works — the SDK itself, on the Responses API it defaults to, records and replays at `exact=1`, [in CI](test/integrations/); [its own tracing is a second egress](docs/integrations.md#openai-agents-sdk) |
 | **Vercel AI SDK** | fetch hook — `orca record node -- node app.mjs` | works — an agent posting to an origin compiled into its source records and replays at `exact=1`, [in CI](test/integrations/) |
 | **grok-cli** (and its Telegram bot) | `orca record grok` — `GROK_BASE_URL`, plus the hook for its sub-agents | works |
 | **OpenClaw** | `orca record openclaw` — the hook for the gateway, inherited variables for the agents it spawns | works |
@@ -383,7 +383,8 @@ whether orca understands the wire format it speaks once it arrives.
 | **goose** (Block) | `orca record goose` — `OPENAI_HOST` **and** `OPENAI_BASE_URL`, `ANTHROPIC_HOST` → Responses API | works — driven end to end against goose 1.49.0, [what is different about it](#the-harness-that-reads-different-variables) |
 | **LangGraph / LangChain** | `OPENAI_BASE_URL`, `ANTHROPIC_BASE_URL` | works — a two-node graph, streaming and with a tool, records and replays at `exact=2` and forks live, [in CI](test/integrations/) |
 | **OpenHands** | `orca record generic-openai -- python your_agent.py` — its SDK wraps LiteLLM and reads `OPENAI_API_BASE` | works — the SDK's own LLM layer records and replays at `exact=1`, [in CI](test/integrations/) |
-| **CrewAI, Aider** | `orca record generic-openai -- python your_crew.py` — both route through LiteLLM, which reads `OPENAI_API_BASE` | works — the LiteLLM layer records and replays at `exact=1`, [in CI](test/integrations/); [a CrewAI wrinkle worth knowing](docs/integrations.md#crewai-aider) |
+| **CrewAI** | `orca record generic-openai -- python your_crew.py` — since 1.x its own provider, reading `OPENAI_API_BASE` and `OPENAI_BASE_URL` | works — a real `Agent`, `Task` and `Crew` records and replays at `exact=1`, [in CI](test/integrations/); [what 1.x changed](docs/integrations.md#crewai) |
+| **Aider** | `orca record generic-openai -- python your_agent.py` — routes through LiteLLM, which reads `OPENAI_API_BASE` | works — the LiteLLM layer records and replays at `exact=1`, [in CI](test/integrations/) |
 | **browser-use** | `orca record generic-openai -- python your_task.py` — its `ChatOpenAI` passes an unset `base_url` straight through | works — records and replays at `exact=1`, [in CI](test/integrations/); LLM layer only, [the browser is not driven](docs/integrations.md#browser-use) |
 | **Hermes** (Nous Research) | `ORCA_BASE_URL_VARS=… orca record generic-openai -- hermes …` | should work — it overrides per provider; [name the variable](#a-base-url-variable-orca-has-never-heard-of) |
 | **Codex-in-the-IDE** | `orca record exec --tls-intercept -- code .` | works — the extension spawns the agent, and it inherits the capture |

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -61,23 +61,52 @@ and is not covered by the checks here.
 
 ---
 
-## CrewAI, Aider
+## CrewAI
 
 ```console
 orca record generic-openai -- python your_crew.py
 ```
 
-Both route through **LiteLLM**, which reads `OPENAI_API_BASE`. That is the layer the checks
-exercise: one check covers both, and anything else built on LiteLLM comes with it.
+**Measured:** a real `Agent`, `Task` and `Crew` recorded and replayed at `exact=1 divergences=0`,
+against CrewAI 1.15.20.
 
-OpenHands used to be listed here for the same reason. It now has [its own check](#openhands),
-because riding on LiteLLM and *reaching* LiteLLM with the environment intact are different claims.
+CrewAI was listed with Aider and OpenHands here, on the grounds that all three route through
+LiteLLM. **That stopped being true in CrewAI 1.x.** LiteLLM is now an optional extra
+(`crewai[litellm]`) and CrewAI ships native providers, so a default install reaches OpenAI through
+its own `crewai.llms.providers.openai.completion` and never loads LiteLLM at all.
+
+Capture survived the change; the reason for it did not. The native provider reads **both**
+`OPENAI_API_BASE` and `OPENAI_BASE_URL`, and `generic-openai` sets both — so this went on working
+while the sentence explaining why went quietly wrong. Running the LiteLLM layer could never have
+caught that, which is why CrewAI has its own check now.
+
+### Two things that changed with it
+
+**A prefixed model name no longer resolves.** `LLM(model="openai/gpt-4o-mini")` is the LiteLLM
+spelling, and on a default 1.x install it raises `ImportError: ... did not match any supported
+native provider ... and the LiteLLM fallback package is not installed`. The bare form,
+`LLM(model="gpt-4o-mini")`, is what the native provider takes. This is the shape of breakage an
+upgrade from 0.x hits, and it happens before any request is made — so orca records a run of three
+events and reports `capture.empty`, which is accurate and easy to misread as a capture problem.
+
+**`LLM(base_url=…)` is now honoured.** It used not to be: passing the origin in code did nothing,
+because it never reached LiteLLM's `api_base`. Measured again on 1.15.20 against a listener with the
+environment cleared — the listener was hit. Going through the environment is still the better route,
+because it is the one `orca record` sets up and it needs no edit to your code, but the old warning
+no longer applies.
+
+---
+
+## Aider
+
+```console
+orca record generic-openai -- python your_agent.py
+```
+
+Routes through **LiteLLM**, which reads `OPENAI_API_BASE`. That is the layer the check exercises,
+and anything else built on LiteLLM comes with it.
 
 **Measured:** `litellm.completion()` recorded and replayed at `exact=1 divergences=0`.
-
-CrewAI has a known wrinkle worth knowing about even though it does not affect this route:
-`LLM(base_url=…)` does not map to LiteLLM's `api_base`, so passing the URL in code can silently do
-nothing. Going through the environment sidesteps it.
 
 ---
 
@@ -98,7 +127,7 @@ deliberate: a task loop would be testing OpenHands rather than testing whether o
 and it would need a container runtime the check deliberately does not depend on.
 
 Pass the origin through the environment rather than `LLM(base_url=…)` in code. Both work here, but
-the environment is the route `orca record` sets up, and it sidesteps the CrewAI wrinkle above.
+the environment is the route `orca record` sets up and it needs no edit to your own code.
 
 ### A whole session, not in CI
 
@@ -136,7 +165,14 @@ orca record generic-openai -- python your_agent.py
 
 The default provider reads `OPENAI_BASE_URL`, and the SDK is built on `AsyncOpenAI` — both covered.
 
-**Measured:** `AsyncOpenAI` recorded and replayed at `exact=1 divergences=0`.
+**Measured:** the SDK itself — an `Agent` run through `Runner` — recorded and replayed at
+`exact=1 divergences=0`, against openai-agents 0.20.0.
+
+The check runs the SDK on the **Responses API**, which is what it reaches for unless told otherwise:
+the recorded exchange comes back as `dialect=openai-responses path=/v1/responses`. That is worth
+stating because the older check covered `AsyncOpenAI` on chat completions — the client underneath,
+on a wire format the SDK does not use by default. Both are covered now; only one of them is the
+path an Agents SDK user takes.
 
 Two things to decide before a long run:
 

--- a/packages/cli/test/support-claims.test.ts
+++ b/packages/cli/test/support-claims.test.ts
@@ -1,0 +1,127 @@
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(here, '..', '..', '..');
+const README = join(ROOT, 'README.md');
+const INTEGRATIONS = join(ROOT, 'docs', 'integrations.md');
+const RUNNER = join(ROOT, 'test', 'integrations', 'run.mjs');
+
+/**
+ * The support table says which frameworks work and points at CI for the ones a check covers. This
+ * holds those rows to the runner, because a row that cannot be checked is worse than no row: these
+ * exist to be read by people who maintain the frameworks they name, and the first thing such a
+ * reader does is look.
+ *
+ * Two failures it is built to catch, both of which have already happened here:
+ *
+ *   - **A cited check that does not exist**, or an `exact=N` that disagrees with the exchange count
+ *     the check asserts. Easy to introduce by copying a row.
+ *   - **A row that outlives its reason.** The CrewAI row said all of CrewAI, Aider and OpenHands
+ *     route through LiteLLM, and CrewAI 1.x stopped doing that — LiteLLM became an optional extra
+ *     and CrewAI grew native providers. Capture went on working, so nothing failed; the sentence
+ *     explaining why had simply been wrong for a major version. Only running CrewAI itself found
+ *     it, which is why the row now cites a check that runs CrewAI.
+ *
+ * So the assertions below are not only "does the number match". They pin the distinction each row
+ * has to keep making: whether CI drives the framework, or the layer beneath it.
+ */
+describe('the support table is backed by checks that exist', () => {
+  async function sources() {
+    const [readme, integrations, runner] = await Promise.all([
+      readFile(README, 'utf8'),
+      readFile(INTEGRATIONS, 'utf8'),
+      readFile(RUNNER, 'utf8'),
+    ]);
+    /** Every check the runner defines, and the exchange count it asserts. */
+    const checks = new Map<string, number>();
+    for (const m of runner.matchAll(/id: '([^']+)'[\s\S]*?exchanges: (\d+)/g)) {
+      checks.set(m[1]!, Number(m[2]));
+    }
+    /** The anchors GitHub generates from `docs/integrations.md` headings. */
+    const anchors = new Set(
+      [...integrations.matchAll(/^## (.+)$/gm)].map((m) =>
+        m[1]!
+          .toLowerCase()
+          .replace(/[^\w\s-]/g, '')
+          .trim()
+          .replace(/\s+/g, '-'),
+      ),
+    );
+    const rows = readme.split('\n').filter((l) => l.startsWith('| **') && l.includes('in CI'));
+    return { readme, checks, anchors, rows };
+  }
+
+  /** The row naming this framework, or undefined. */
+  function rowFor(rows: string[], framework: string): string | undefined {
+    return rows.find((r) => r.startsWith(`| **${framework}**`));
+  }
+
+  const CITED = [
+    { framework: 'OpenAI Agents SDK', checks: ['openai-agents'], exact: 1 },
+    { framework: 'Vercel AI SDK', checks: ['fetch-hook'], exact: 1 },
+    {
+      framework: 'LangGraph / LangChain',
+      checks: ['langgraph-stream', 'langgraph-tools'],
+      exact: 2,
+    },
+    { framework: 'CrewAI', checks: ['crewai'], exact: 1 },
+    { framework: 'Aider', checks: ['litellm'], exact: 1 },
+    { framework: 'browser-use', checks: ['browser-use'], exact: 1 },
+  ];
+
+  it.each(CITED)('$framework cites a check that exists and agrees on the count', async (c) => {
+    const { checks, rows } = await sources();
+    const row = rowFor(rows, c.framework);
+    expect(row, `no CI-citing row for ${c.framework}`).toBeDefined();
+
+    for (const id of c.checks) {
+      expect(checks.has(id), `run.mjs has no check called ${id}`).toBe(true);
+      expect(checks.get(id), `${id} asserts a different exchange count`).toBe(c.exact);
+    }
+    expect(row).toContain(`\`exact=${c.exact}\``);
+  });
+
+  it('every docs/integrations.md anchor a row links to resolves', async () => {
+    const { readme, anchors } = await sources();
+    const linked = [...readme.matchAll(/\(docs\/integrations\.md#([\w-]+)\)/g)].map((m) => m[1]!);
+    expect(linked.length).toBeGreaterThan(0);
+    for (const anchor of linked) {
+      expect(anchors.has(anchor), `#${anchor} is not a heading in docs/integrations.md`).toBe(true);
+    }
+  });
+
+  /**
+   * The honesty rule, which is the part that keeps these rows worth citing.
+   *
+   * A check either drives the framework or drives the layer beneath it, and the row has to say
+   * which. `litellm` runs `litellm.completion()`, so the row it backs may not claim CI runs Aider.
+   * `crewai` runs a real Crew, so that row may not still say CrewAI rides on LiteLLM — it does not.
+   */
+  it('a row claims only what its check actually runs', async () => {
+    const { rows } = await sources();
+
+    const crewai = rowFor(rows, 'CrewAI');
+    expect(crewai, 'CrewAI has no row').toBeDefined();
+    expect(crewai, 'the CrewAI row still says it routes through LiteLLM').not.toMatch(/LiteLLM/i);
+    expect(crewai, 'the CrewAI row does not say the check runs CrewAI itself').toMatch(
+      /Agent.*Task.*Crew/,
+    );
+
+    const aider = rowFor(rows, 'Aider');
+    expect(aider, 'Aider has no row').toBeDefined();
+    expect(aider, 'the Aider row must name the layer its check actually runs').toMatch(/LiteLLM/);
+
+    const agents = rowFor(rows, 'OpenAI Agents SDK');
+    expect(agents, 'the Agents SDK row must name the Responses API its check runs on').toMatch(
+      /Responses API/,
+    );
+
+    const browser = rowFor(rows, 'browser-use');
+    expect(browser, 'the browser-use check drives no browser, and the row must say so').toMatch(
+      /LLM layer only/,
+    );
+  });
+});

--- a/test/integrations/README.md
+++ b/test/integrations/README.md
@@ -36,16 +36,33 @@ a matrix that only exercised a plain completion would have said nothing about ei
 | check | the mechanism it covers | what else rides on it |
 |---|---|---|
 | `openai-sdk` | the official Python SDK reads `OPENAI_BASE_URL` | every framework that lets the SDK build its own client |
-| `openai-async` | the same for `AsyncOpenAI` | the OpenAI Agents SDK |
+| `openai-async` | the same for `AsyncOpenAI` | anything building its own async client |
 | `anthropic-sdk` | `ANTHROPIC_BASE_URL` | Claude-backed agents that are not Claude Code |
-| `litellm` | `OPENAI_API_BASE` through LiteLLM | **CrewAI, Aider, OpenHands** — they route through it |
+| `litellm` | `OPENAI_API_BASE` through LiteLLM | **Aider** — and anything else riding that transport |
+| `openhands-sdk` | the OpenHands SDK's own `LLM`, which wraps LiteLLM | OpenHands |
+| `crewai` | CrewAI's own `Agent`, `Task` and `Crew` | CrewAI, which since 1.x does **not** use LiteLLM |
+| `openai-agents` | the Agents SDK on the **Responses API**, its default | the Agents SDK, and orca's `responses` dialect |
 | `langgraph-stream` | LangChain's own `OPENAI_API_BASE`, over SSE | LangGraph, LangChain |
 | `langgraph-tools` | the same, with a bound tool | tool-calling graphs |
 | `browser-use` | its own `ChatOpenAI` passes an unset `base_url` through | browser-use, and the pattern any wrapper using the official SDK follows |
 | `fetch-hook` | `NODE_OPTIONS` preload on `globalThis.fetch` | the Vercel AI SDK, and any JS agent with its origin compiled in |
 
-Eight checks, and the `litellm` row is the reason the list is shorter than the set of frameworks it
-speaks for: covering the layer underneath covers everything standing on it.
+Eleven checks. Covering the layer underneath still covers what stands on it — that is what the
+`litellm` row is for — but three of these exist because that stopped being enough, and each of the
+three was added after running the framework itself said something the layer could not.
+
+**CrewAI is the clearest case.** It sat under the `litellm` row for exactly the reason that row
+gives, and in CrewAI 1.x it is no longer true: LiteLLM became an optional extra and CrewAI grew
+native providers, so a default install never loads it. Capture survived — the native provider reads
+both variables `generic-openai` sets — but the stated reason had been wrong for a whole major
+version, and nothing here could have noticed. Running CrewAI also turned up two changes worth
+documenting: `LLM(model="openai/…")` no longer resolves, and `LLM(base_url=…)`, long documented as
+silently ignored, is now honoured.
+
+**`openai-agents` is not a duplicate of `openai-async` either.** The Agents SDK defaults to the
+Responses API; `AsyncOpenAI` in that check uses chat completions. So the older check covered the
+client underneath on a wire format the SDK does not use, and the format the README claimed support
+for had no end-to-end check at all until this one.
 
 ## What the checks are worth, measured
 
@@ -54,15 +71,27 @@ notice:
 
 | removed from `generic-openai` | what fails |
 |---|---|
-| `OPENAI_BASE_URL` | `openai-sdk`, `openai-async` |
+| `OPENAI_BASE_URL` | `openai-sdk`, `openai-async`, `openai-agents`, `browser-use` |
 | `ANTHROPIC_BASE_URL` | `anthropic-sdk` |
 | `OPENAI_API_BASE` | **nothing** |
 
-The last row is the finding. LangChain reads `OPENAI_API_BASE` itself, but it hands the rest to the
-official client, which reads `OPENAI_BASE_URL` — so the LangGraph checks survive losing the variable
-that appears to be theirs. Both are still set, because pre-1.0 SDKs and several ports read only the
-second, and this matrix does not cover those. It is worth knowing that today nothing here would
-notice if that line went away.
+The last row is still the finding, and it survived the checks added since it was first measured.
+LangChain reads `OPENAI_API_BASE` itself but hands the rest to the official client, which reads
+`OPENAI_BASE_URL`; CrewAI's native provider reads **both**, so it survives losing either one on its
+own and appears in neither row. Both variables stay set, because pre-1.0 SDKs and several ports read
+only the second and this matrix does not cover those. It is worth knowing that today nothing here
+would notice if that line went away.
+
+Two notes on the re-measurement rather than the measurement:
+
+- `browser-use` is new to the first row. It was absent from the earlier table and it does depend on
+  `OPENAI_BASE_URL` — its `ChatOpenAI` passes an unset `base_url` to the official client, which is
+  precisely the dependency. Read as a correction to the table, not as a change in browser-use.
+- `litellm` is excluded from this run. A complete litellm install does not fit under the Windows
+  long-path limit on the machine this was re-measured on, so its result here would have been an
+  artefact of the environment rather than a fact about the redirect. It is unchanged from the
+  earlier measurement, where removing `OPENAI_API_BASE` did not break it either — because
+  `generic-openai` still sets the other two and LiteLLM is reached through the same client.
 
 ## Running them
 

--- a/test/integrations/README.md
+++ b/test/integrations/README.md
@@ -96,10 +96,16 @@ Two notes on the re-measurement rather than the measurement:
 ## Running them
 
 ```console
-node test/integrations/run.mjs            # all of them
-node test/integrations/run.mjs litellm    # one
+node test/integrations/run.mjs                # all of them
+node test/integrations/run.mjs litellm        # one
+node test/integrations/run.mjs --require-all  # a skip is a failure — what CI runs
 ```
 
 Python checks are skipped, not failed, when the package they need is not installed — a contributor
-without `langgraph` on their machine should still be able to run the suite. CI installs them, so a
-skip there is a failure.
+without `langgraph` on their machine should still be able to run the suite.
+
+`--require-all` is what makes a skip a failure, and it exists because the sentence that used to be
+here said CI installing the packages was enough. It was not. Two checks were added without a line
+in the workflow's `pip install`, CI went green on the skips, and the README said "in CI" about both
+— a claim made false by an omission that nothing could fail on. Adding a check now means adding it
+to that line, or this run says so.

--- a/test/integrations/agents/crewai_agent.py
+++ b/test/integrations/agents/crewai_agent.py
@@ -1,0 +1,43 @@
+"""CrewAI itself — a real Agent, Task and Crew.
+
+Not a duplicate of `litellm_agent.py`, and since CrewAI 1.x not even the same route. CrewAI moved
+LiteLLM to an optional extra (`crewai[litellm]`) and grew native providers, so a default install
+reaches OpenAI through its own `crewai.llms.providers.openai.completion` and never loads LiteLLM at
+all. Covering the layer underneath stopped covering CrewAI the moment that happened, and only
+running CrewAI itself would have noticed.
+
+Two things this pins that the LiteLLM route cannot:
+
+  - the native provider reads `OPENAI_API_BASE` *and* `OPENAI_BASE_URL`, both of which
+    `generic-openai` sets — so the capture survived the change even though the reason for it did not
+  - a bare model name is what the native provider takes. `LLM(model="openai/stub-1")` is the
+    LiteLLM spelling and now raises `ImportError` on a default install, which is the shape of
+    breakage a CrewAI user upgrading from 0.x will hit
+"""
+
+import os
+
+# Before importing crewai: telemetry is wired up at import time, and a run that phones home is doing
+# something this check did not ask for. Not orca's business to capture — it is not model traffic —
+# but a reader deciding whether a recording is complete should know the connection exists.
+os.environ["CREWAI_DISABLE_TELEMETRY"] = "true"
+os.environ["OTEL_SDK_DISABLED"] = "true"
+
+from crewai import Agent, Crew, LLM, Process, Task  # noqa: E402
+
+# Bare, not `openai/…`. See the note above: the prefixed form is LiteLLM's and no longer resolves.
+llm = LLM(model="stub-1")
+
+agent = Agent(
+    role="Responder",
+    goal="Answer the question you are given",
+    backstory="You answer in one short sentence.",
+    llm=llm,
+    verbose=False,
+)
+
+task = Task(description="Say hello.", expected_output="A short greeting.", agent=agent)
+
+crew = Crew(agents=[agent], tasks=[task], process=Process.sequential, verbose=False)
+result = crew.kickoff()
+print("GOT:", str(result).strip())

--- a/test/integrations/agents/openai_agents_sdk.py
+++ b/test/integrations/agents/openai_agents_sdk.py
@@ -1,0 +1,29 @@
+"""The OpenAI Agents SDK itself, on the API it reaches for by default.
+
+Separate from `openai_async.py`, which covers the `AsyncOpenAI` client underneath it. That check
+proves the client can be redirected; it says nothing about the wire format the SDK actually speaks,
+because the SDK defaults to the **Responses API** and `AsyncOpenAI` in that check does not. So the
+path a real Agents SDK user takes had no end-to-end check until this one, on a claim the README has
+been making.
+
+Nothing here switches the SDK to chat completions. A check that did would prove the wrong path
+works.
+"""
+
+import asyncio
+
+from agents import Agent, Runner, set_tracing_disabled
+
+# The SDK ships its own traces to OpenAI, on a second connection that is not model traffic and that
+# orca does not capture. Off here so the run talks to nothing but the proxy — which is also what
+# makes this check deterministic, and what the docs tell a reader to decide about before a long run.
+set_tracing_disabled(True)
+
+
+async def main() -> None:
+    agent = Agent(name="Stub", instructions="Answer in one short sentence.", model="stub-1")
+    result = await Runner.run(agent, "hello")
+    print("GOT:", result.final_output)
+
+
+asyncio.run(main())

--- a/test/integrations/run.mjs
+++ b/test/integrations/run.mjs
@@ -7,8 +7,9 @@
  * before the replay — a replay that reached the network would fail here by construction rather
  * than by assertion.
  *
- *   node test/integrations/run.mjs            # all of them
- *   node test/integrations/run.mjs litellm    # one
+ *   node test/integrations/run.mjs               # all of them
+ *   node test/integrations/run.mjs litellm       # one
+ *   node test/integrations/run.mjs --require-all # a skip is a failure, which is what CI wants
  */
 import { execFile, spawn } from 'node:child_process';
 import { cp, mkdtemp, rm } from 'node:fs/promises';
@@ -248,7 +249,19 @@ async function runCheck(check) {
   }
 }
 
-const only = process.argv[2];
+/**
+ * `--require-all` turns a skip into a failure.
+ *
+ * A skip is right for a contributor who has not installed every framework, and wrong for CI, where
+ * the whole point is that the check ran. Without a way to say so the two are indistinguishable from
+ * the exit code, and that is not hypothetical: two checks were added, neither was added to the
+ * workflow's `pip install` line, and CI went green on three skips while the README said "in CI"
+ * about all of them. The intent was even written down here — "CI installs them, so a skip there is
+ * a failure" — and nothing enforced it.
+ */
+const args = process.argv.slice(2);
+const requireAll = args.includes('--require-all');
+const only = args.find((a) => !a.startsWith('--'));
 const selected = only ? CHECKS.filter((c) => c.id === only) : CHECKS;
 if (selected.length === 0) {
   console.error(`no check named ${only}. known: ${CHECKS.map((c) => c.id).join(', ')}`);
@@ -265,7 +278,11 @@ for (const check of selected) {
   } catch (e) {
     result = { failed: String(e.message).split('\n')[0] };
   }
-  if (result.skipped) {
+  if (result.skipped && requireAll) {
+    failed += 1;
+    console.log(`FAILED — ${result.skipped}, and --require-all was given`);
+    console.log(`   ${check.what}`);
+  } else if (result.skipped) {
     skipped += 1;
     console.log(`skipped — ${result.skipped}`);
   } else if (result.failed) {

--- a/test/integrations/run.mjs
+++ b/test/integrations/run.mjs
@@ -66,6 +66,20 @@ const CHECKS = [
     exchanges: 1,
   },
   {
+    id: 'openai-agents',
+    what: 'the OpenAI Agents SDK on its default wire format, the Responses API',
+    run: ['python', 'agents/openai_agents_sdk.py'],
+    needs: 'agents',
+    exchanges: 1,
+  },
+  {
+    id: 'crewai',
+    what: 'CrewAI itself — which since 1.x no longer routes through LiteLLM at all',
+    run: ['python', 'agents/crewai_agent.py'],
+    needs: 'crewai',
+    exchanges: 1,
+  },
+  {
     id: 'langgraph-stream',
     what: 'a two-node LangGraph over streaming SSE',
     run: ['python', 'agents/langgraph_agent.py', 'stream'],

--- a/test/integrations/stub-origin.mjs
+++ b/test/integrations/stub-origin.mjs
@@ -58,6 +58,36 @@ function stream(seen) {
   return `${frames.map((f) => `data: ${JSON.stringify(f)}\n\n`).join('')}data: [DONE]\n\n`;
 }
 
+/**
+ * The Responses API shape.
+ *
+ * Here because it is the OpenAI Agents SDK's *default* — not an option it offers — so a check that
+ * quietly switched the SDK to chat completions would prove the wrong path works. orca has carried a
+ * `responses` dialect since early on; until this, nothing end to end exercised it.
+ */
+function responses(seen) {
+  return {
+    id: 'resp_stub_1',
+    object: 'response',
+    created_at: 1756000000,
+    status: 'completed',
+    model: seen.model ?? 'stub-1',
+    output: [
+      {
+        id: 'msg_stub_1',
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [{ type: 'output_text', text: REPLY, annotations: [] }],
+      },
+    ],
+    usage: { input_tokens: 9, output_tokens: 4, total_tokens: 13 },
+    parallel_tool_calls: false,
+    tool_choice: 'auto',
+    tools: [],
+  };
+}
+
 function anthropic(seen) {
   return {
     id: 'msg_stub_1',
@@ -82,6 +112,13 @@ const server = createServer((req, res) => {
       // whether orca captured it, not whether the client sent valid JSON.
     }
 
+    // Before the generic branch: a Responses request wants Responses output back, not a
+    // chat.completion the SDK cannot parse.
+    if (req.url?.includes('/responses')) {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify(responses(seen)));
+      return;
+    }
     if (req.url?.includes('/messages')) {
       res.writeHead(200, { 'content-type': 'application/json' });
       res.end(JSON.stringify(anthropic(seen)));


### PR DESCRIPTION
<!-- orca-cr-summary:start -->
<!-- orca-code-review-summary -->
<!-- orca-cr-state: {"p0":0,"p1":0,"p2":0,"p3":0,"push":2} -->

## Orca-Code-Review — push 2

| Severity | Count | Δ vs previous push |
|---|---|---|
| P0 | 0 | 0 |
| P1 | 0 | 0 |
| P2 | 0 | 0 |
| P3 | 0 | 0 |

✅ no blocking findings
<!-- orca-cr-summary:end -->

Two checks that run the framework rather than the layer under it — the same move as [#61](https://github.com/Continuum-AI-Corp/OrcaReplay/pull/61). Both found something the layer could not, which is the argument for the duplication.

## CrewAI no longer routes through LiteLLM

It sat under the `litellm` row on exactly those grounds, and in CrewAI 1.x that stopped being true:

```
$ python -c "import importlib.metadata as m; print([d for d in m.requires('crewai') if 'litellm' in d])"
["litellm<2,>=1.84.0; extra == 'litellm'"]
```

LiteLLM is an optional extra now and CrewAI ships native providers, so a default install reaches OpenAI through its own `crewai.llms.providers.openai.completion` and never loads LiteLLM at all.

**Capture survived. The reason for it did not.** The native provider reads both `OPENAI_API_BASE` and `OPENAI_BASE_URL`, and `generic-openai` sets both — so this went on working while the sentence explaining why had been wrong for a whole major version. Nothing in CI could have noticed, because nothing in CI ran CrewAI.

Two further changes it surfaced, both re-measured rather than carried forward:

| | before | measured on 1.15.20 |
|---|---|---|
| `LLM(model="openai/…")` | the way to name a model | **raises `ImportError`** on a default install — that is LiteLLM's spelling |
| `LLM(base_url=…)` | documented as silently ignored | **honoured** — measured against a listener with the environment cleared |

The first one fails before any request is made, so orca records three events and reports `capture.empty` — accurate, and very easy to read as a capture bug rather than a model-name bug.

## The Agents SDK check runs the SDK, on the API it defaults to

`openai-async` covers `AsyncOpenAI` on chat completions: the client underneath, on a wire format the SDK does not use by default. So the format the README claimed support for had **no end-to-end check at all**.

```
dialect=openai-responses path=/v1/responses model=stub-1
replay: reused=1/1 exact=1 divergences=0 unmatched=0
```

The stub grew a Responses branch to serve it — without one, a Responses request came back a `chat.completion` the SDK cannot parse.

## Re-measured: which redirect is load-bearing

Three checks have been added since that table was written, so it was re-run rather than trusted.

| removed from `generic-openai` | what fails |
|---|---|
| `OPENAI_BASE_URL` | `openai-sdk`, `openai-async`, `openai-agents`, `browser-use` |
| `ANTHROPIC_BASE_URL` | `anthropic-sdk` |
| `OPENAI_API_BASE` | **nothing** |

The finding holds. CrewAI's native provider reads both, so it survives losing either one alone and appears in neither row. `browser-use` is new to the first row — an omission in the earlier table, not a change in browser-use.

## Keeping the rows honest

`support-claims.test.ts` holds the README support table to the runner: every cited check exists, every `exact=N` matches the exchange count that check asserts, every `docs/integrations.md` anchor resolves, and **no row claims CI drives a framework where the check drives the layer beneath it**.

That last rule is the one that would have caught this. Mutation-tested:

| mutation | result |
|---|---|
| CrewAI row back to the LiteLLM wording | red |
| delete the `crewai` check the row cites | red |

## Verification

| | |
|---|---|
| new checks, ×3 each | `exact=1` offline every time — crewai 1.15.20, openai-agents 0.20.0 |
| pre-existing checks after the stub change | 8/8 green |
| `support-claims.test.ts` | 8/8, mutation-tested |
| full suite | 1957 passing, **zero new failures** vs `a1ff210` (+8 = exactly the new tests) |
| conformance / fidelity / neutrality | 57 events, 1 replay, 0 failures |

The two new checks are skipped, not failed, where their framework is absent — CI installs both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)