### PR TITLE
resolve the upstream before any command creates a run

### DIFF
--- a/packages/cli/src/commands/attach.ts
+++ b/packages/cli/src/commands/attach.ts
@@ -141,6 +141,11 @@ async function runAttached(
   // — so the next command someone types operates on the session that never happened.
   planTlsCapture(args, replaying?.hosts);
 
+  // Before the run directory exists, because this refuses an upstream that is not an origin: resolved after it, a
+  // typo in `--upstream-*` left an empty run behind for `orca list` to show. It depends on nothing
+  // but the arguments and the environment, so there is no reason for it to run any later.
+  const plan = await upstreamPlan(args);
+
   const dir = await ensureRunsDir(cwd);
   const writer = await TraceWriter.create(dir, {
     adapter: { id: adapter.id, version: ORCA_VERSION, harness_version: adapter.harnessVersions },
@@ -154,7 +159,6 @@ async function runAttached(
   let unmatched = 0;
 
   const writes = new SerialQueue();
-  const plan = await upstreamPlan(args);
   const tls = await setupTlsCapture({
     args,
     out,

--- a/packages/cli/src/commands/attach.ts
+++ b/packages/cli/src/commands/attach.ts
@@ -138,8 +138,10 @@ async function runAttached(
 
   // The last thing that can refuse the run, and it runs before the trace exists: a writer created
   // first and abandoned by a throw leaves an unsealed run directory behind, which then wins `last`
-  // — so the next command someone types operates on the session that never happened.
-  planTlsCapture(args, replaying?.hosts);
+  // — so the next command someone types operates on the session that never happened. Awaited
+  // since it grew the one refusal that needs the disk, an `ORCA_TLS_UPSTREAM_CA` that cannot be
+  // read; the guarantee here is unchanged, it just covers one more way to fail.
+  await planTlsCapture(args, replaying?.hosts);
 
   // Before the run directory exists, because this refuses an upstream that is not an origin: resolved after it, a
   // typo in `--upstream-*` left an empty run behind for `orca list` to show. It depends on nothing

--- a/packages/cli/src/commands/record.ts
+++ b/packages/cli/src/commands/record.ts
@@ -20,7 +20,7 @@ import { SerialQueue } from '../serial.js';
 import { appendSnapshot } from '../fs-events.js';
 import type { Output } from '../out.js';
 import type { ParsedArgs } from '../args.js';
-import { persistNetExchange, setupTlsCapture, trustRunCa } from '../tls-capture.js';
+import { persistNetExchange, planTlsCapture, setupTlsCapture, trustRunCa } from '../tls-capture.js';
 import { upstreamPlan } from '../upstream.js';
 import { ORCA_VERSION } from '../version.js';
 
@@ -118,10 +118,15 @@ async function runRecording(
     out.info('adapter.detected', { id: adapter.id });
   }
 
-  // Before the run directory exists, because this refuses an upstream that is not an origin: resolved after it, a
-  // typo in `--upstream-*` left an empty run behind for `orca list` to show. It depends on nothing
-  // but the arguments and the environment, so there is no reason for it to run any later.
+  // Before the run directory exists, because both of these refuse: `upstreamPlan` an upstream that
+  // is not an origin, `planTlsCapture` a `--tls-hosts` list that names `*` or contradicts itself
+  // and an `ORCA_TLS_UPSTREAM_CA` that cannot be read. Resolved after it, a typo in any of them
+  // left an empty run behind for `orca list` to show. Neither depends on more than the arguments,
+  // the environment and a file the run was going to read anyway, so there is no reason for either
+  // to run later — and `planTlsCapture` is the refusing half of `setupTlsCapture` alone, so the
+  // certificate authority is still minted below, once the run has a directory to mint it into.
   const plan = await upstreamPlan(args);
+  await planTlsCapture(args);
 
   const dir = await ensureRunsDir(cwd);
 

--- a/packages/cli/src/commands/record.ts
+++ b/packages/cli/src/commands/record.ts
@@ -118,6 +118,11 @@ async function runRecording(
     out.info('adapter.detected', { id: adapter.id });
   }
 
+  // Before the run directory exists, because this refuses an upstream that is not an origin: resolved after it, a
+  // typo in `--upstream-*` left an empty run behind for `orca list` to show. It depends on nothing
+  // but the arguments and the environment, so there is no reason for it to run any later.
+  const plan = await upstreamPlan(args);
+
   const dir = await ensureRunsDir(cwd);
 
   const writer = await TraceWriter.create(dir, {
@@ -187,8 +192,6 @@ async function runRecording(
   // Serial, not parallel: each persist snapshots the workspace, and two overlapping `git add`
   // calls collide on index.lock. It also keeps seq in the order exchanges actually happened.
   const writes = new SerialQueue();
-
-  const plan = await upstreamPlan(args);
 
   /**
    * TLS interception, off unless the flag is present.

--- a/packages/cli/src/commands/replay.ts
+++ b/packages/cli/src/commands/replay.ts
@@ -642,6 +642,11 @@ async function replayFork(
   // requests happened at or before the checkpoint.
   const forkAt = ctx.exchanges.filter((e) => e.seq <= checkpoint.seq).length;
 
+  // Before the worktree and the fork's own run directory, because this refuses an upstream that
+  // is not an origin: resolved after them, a typo in `--upstream-*` left a restored temp tree in
+  // `$TMPDIR` and an empty fork in `orca list`, reading `FROM <parent>@<n>` as though it had run.
+  const plan = await upstreamPlan(args);
+
   const worktree = await mkdtemp(join(tmpdir(), `orca-${checkpoint.seq}-`));
   if (checkpoint.fsTree) {
     // Restore from the ORIGINAL run's shadow store: that is the only place the tree object
@@ -699,8 +704,6 @@ async function replayFork(
       out.warn('fs.unavailable', { reason: String(err) });
     }
   }
-
-  const plan = await upstreamPlan(args);
 
   // A fork runs a real agent live, so it has exactly the same blind spot `orca record` does: a
   // harness that talks to its own backend over TLS reads no base-URL variable and is invisible

--- a/packages/cli/src/commands/replay.ts
+++ b/packages/cli/src/commands/replay.ts
@@ -12,7 +12,7 @@ import {
   TraceWriter,
 } from '@orcareplay/core';
 import { FsCapture } from '@orcareplay/fs-capture';
-import { createProxy, defaultDialects, type RecordedExchange } from '@orcareplay/proxy';
+import { createProxy, defaultDialects, type RecordedExchange, type RunCa } from '@orcareplay/proxy';
 import { defaultAdapters, resolveLaunch } from '@orcareplay/adapters';
 import { serveViewer } from '@orcareplay/viewer';
 import { isBlobRef, type TraceEvent } from '@orcareplay/schema';
@@ -315,19 +315,21 @@ async function replayExact(args: ParsedArgs, out: Output, ctx: Ctx): Promise<Rep
   const interceptedHosts = recordedTlsHosts(ctx.events);
   await planTlsCapture(args, interceptedHosts);
 
+  // Armed on the line after the call, which is only sound because `replayWorkspace` owns its own
+  // destructive step: it either returns with the tree replaced and a `release` that undoes that,
+  // or it throws having already put the tree back. Arming here without that guarantee would have
+  // read as covering the restore while missing it entirely — the restore is inside the call, so a
+  // `materialize` that failed part-way rejected before `workspace` was ever assigned.
   const workspace = await replayWorkspace(args, out, ctx);
   try {
     return await replayRestored(args, out, ctx, { plan, interceptedHosts, workspace });
   } finally {
-    // The safety net behind both refusals above, and behind every one nobody has enumerated. The
-    // list of things that can throw between the restore and the child's launch is not closed:
-    // `createProxy` binds a socket, `RunCa.create` writes a key, `adapter.prepare` runs a
-    // harness's own setup, `mcpForReplay` rewrites a config — and each one of them would
-    // otherwise end with a recording's files in someone's checkout. Enumerating refusals is what
-    // failed twice already, and hoisting them is only ever as complete as the list; this is the
-    // half that does not depend on the list being right. `release` is idempotent, so the one at
-    // the child's launch still owns the ordinary path and still puts the tree back before the
-    // run reports itself done.
+    // The outermost of three, and the one that needs no list to be right. Hoisting a refusal is
+    // only ever as complete as the list of refusals somebody thought of, and that list has been
+    // wrong twice; `replayRestored` has its own `finally` for the span it owns; this covers what
+    // is left, which is `openReplayTrace` throwing before that span begins. `release` is
+    // idempotent, so the ordinary path still puts the tree back where it always did — before the
+    // run reports itself done — and this is a no-op behind it.
     await workspace.release();
   }
 }
@@ -356,184 +358,30 @@ async function replayRestored(
   // handler, and two overlapping appends would interleave lines in events.jsonl.
   const writes = new SerialQueue();
 
-  // A subscription-backed harness does not use the ordinary base URL, so exact replay needs the
-  // same per-run CA and HTTPS proxy as recording. The proxy's TLS hook then answers Codex's model
-  // request from the trace before it can open an origin connection.
-  // The hosts were resolved before the workspace was restored, where anything refusable about
-  // them was refused; this is the half that mints.
-  const tls = await setupTlsCapture({
-    args,
-    out,
-    ...(interceptedHosts ? { recordedHosts: interceptedHosts } : {}),
-    writer: trace,
-    runDir: ctx.runDir,
-    writes,
-    turn: () => 0,
-  });
+  /**
+   * The two things a failed replay would otherwise leave running or on disk.
+   *
+   * Filled as each is built, because what needs cleaning up depends on how far the run got:
+   * `createProxy` throwing has a key to remove and no socket, and everything after it has both.
+   */
+  let mintedCa: RunCa | undefined;
+  let openProxy: { close: () => Promise<void> } | undefined;
 
-  const proxy = await createProxy({
-    mode: 'replay',
-    exchanges: ctx.exchanges,
-    loose: args.bool('loose'),
-    upstream: plan.upstream,
-    upstreamHeaders: plan.headers,
-    upstreamHeadersOrigin: plan.headersOrigin,
-    ...tls.proxyOptions,
-    onDivergence: (d) => {
-      divergences.push(d);
-      if (!trace) return;
-      writes.push(async () => {
-        await trace.append({
-          type: 'divergence',
-          actor: 'orca',
-          // Turn 0 for everything in this trace, and deliberately not a running count. An exact
-          // match produces no callback, so a counter here would number the third divergence as
-          // turn 1 and claim a position in the conversation that it does not have. `source_seq`
-          // is the honest coordinate: it points straight at the parent's own event.
-          turn: 0,
-          attrs: { level: d.level, rung: d.rung, detail: d.detail, source_seq: d.seq },
-        });
-      });
-    },
-    // Printed as it happens rather than tallied at the end. A halted replay stops the agent, so
-    // the count in `replay.done` arrives after the operator has already seen the run die — and a
-    // bare `unmatched=1` with no reason is indistinguishable from a bug in orca itself.
-    //
-    // The two directories are on the line because a distance in the hundreds of thousands is true
-    // and unactionable. Harnesses put absolute paths in their tool calls, so a replay running
-    // anywhere but the recording's own directory gets a permission refusal where the recording has
-    // file contents — by far the most common cause of a halt, and invisible from the number alone.
-    onUnmatched: (u) => {
-      unmatched.push(u);
-      // A halt inside a delegation is not a corrupt trace and not a bug, and looks like both. The
-      // harness writes the delegate's prompt itself, fresh on every run, so the request really is
-      // a different question — which is exactly what the matcher refuses to serve from a
-      // recording. Without this the operator sees `distance 54` and goes looking for the fault.
-      const delegation = enclosingDelegation(ctx.events, u.seq);
-      out.warn('replay.unmatched', {
-        seq: u.seq,
-        index: u.index,
-        reason: u.reason,
-        ...(delegation === undefined
-          ? {}
-          : {
-              inside: `${delegation.subagent} delegated at seq ${delegation.seq}`,
-              why: 'the harness writes a delegate prompt of its own each run, so this request is a different question rather than a drifted one',
-            }),
-        recorded_in: ctx.manifest.cwd,
-        replayed_in: workspace.dir,
-        next:
-          workspace.dir === ctx.manifest.cwd
-            ? 'orca replay <run> --loose'
-            : `cd ${ctx.manifest.cwd} && orca replay <run> --in-place   # or --loose to continue live`,
-      });
-      if (!trace) return;
-      // `error`, not `divergence`: nothing was served and the run is over, so calling it an
-      // inexact match would put a rung on a ladder the request never climbed. It is also the one
-      // finding here that exists nowhere else — a matched exchange is already in the parent, but
-      // "the agent asked for something this recording cannot answer" is new, and until now it
-      // lived only in the operator's scrollback.
-      writes.push(async () => {
-        await trace.append({
-          type: 'error',
-          actor: 'orca',
-          turn: 0,
-          attrs: {
-            rule: 'replay_unmatched',
-            rung: 4,
-            reason: u.reason,
-            index: u.index,
-            source_seq: u.seq,
-            recorded_in: ctx.manifest.cwd,
-            replayed_in: workspace.dir,
-          },
-        });
-      });
-    },
-  });
-
-  await trace?.append({
-    type: 'run.start',
-    actor: 'orca',
-    turn: 0,
-    attrs: {
-      adapter: ctx.manifest.adapter.id,
-      cwd: workspace.dir,
-      proxy: proxy.url,
-      mode: 'replay',
-      // Also on the manifest, which is what an out-of-process reader sees first. Here as well
-      // because a trace read on its own should say what it is a replay of.
-      parent_run: ctx.manifest.run_id,
-      exchanges: ctx.exchanges.length,
-    },
-  });
-
-  out.phase('replaying', {
-    run: ctx.manifest.run_id,
-    exchanges: ctx.exchanges.length,
-    // Read from the flag, because `--loose` is exactly the run where it is not blocked. It was a
-    // literal, so `orca replay <run> --loose` announced `egress=blocked` and then answered the
-    // first unmatched request from the provider — the one line a reader checks to know whether a
-    // run can spend money, saying the opposite of what the run was about to do. Worse than an
-    // inaccuracy, because `replay halted` recommends `--loose` by name: the reader is following
-    // orca's own advice when the label stops being true.
-    egress: args.bool('loose') ? 'live-on-unmatched' : 'blocked',
-    proxy: proxy.url,
-    cwd: workspace.dir,
-  });
-
-  // The agent runs live for everything that is not a model call, MCP included. Without a config it
-  // talks to servers orca cannot see — or, for a harness that requires the variable, does not start
-  // at all, which is how a replay of a working recording exits non-zero for a reason that has
-  // nothing to do with the recording.
-  const mcp =
-    trace === undefined
-      ? undefined
-      : await mcpForReplay(args, ctx.events, trace, out, join(ctx.runDir, 'mcp-frames.jsonl'));
-
-  const adapter = defaultAdapters().get(ctx.manifest.adapter.id);
-  const launch = await adapter.prepare({
-    runId: ctx.manifest.run_id,
-    cwd: workspace.dir,
-    proxyUrl: proxy.url,
-    runDir: ctx.runDir,
-    userArgs: driveArgs(adapter, ctx, out),
-    env: process.env,
-  });
-  // Replaying must not introduce a catalog request before the capture plugin is installed.
-  if (adapter.id === 'opencode') launch.env.OPENCODE_DISABLE_MODELS_FETCH = '1';
-  if (proxy.tls) await trustRunCa(trace, proxy.tls, proxy.url, launch.env, out);
-  if (mcp) {
-    pointAtMcpConfig(launch.env, mcp.configPath);
-    // Same as record: the path has to reach the harness the way the harness actually reads it, or
-    // a replay re-instruments a config nothing opens and every recorded MCP call goes unmatched.
-    const mcpArgs = adapter.mcpConfigArgs?.(mcp.configPath);
-    if (mcpArgs !== undefined) launch.args = [...mcpArgs, ...launch.args];
-  }
-
-  let exitCode: number;
-  try {
-    exitCode = await runChild(
-      launch.command,
-      launch.args,
-      { ...process.env, ...launch.env },
-      workspace.dir,
-      agentStdoutFor(args),
-    );
-  } catch (err) {
-    // A listening proxy keeps node's event loop alive, so a throw here printed the error and then
-    // hung forever. The agent that was recorded is not always installed where the recording is
-    // replayed — that is half the point of a trace — and `spawn <agent> ENOENT` is what that looks
-    // like from in here.
-    //
-    // The fork path below already does this, and `orca record` does it too. This was the third of
-    // the three and the one still missing it, which is visible from the outside as `orca replay`
-    // being the one command of the three that has to be killed.
-    //
-    // The replay's own trace is sealed rather than abandoned, for the reason the fork gives: a run
-    // that failed to launch is still a run someone will want to read, and an unsealed trace has no
-    // `ended_at` or `integrity`, so `verifyIntegrity` calls it tampered with rather than unfinished.
-    await proxy.close().catch(() => undefined);
+  /**
+   * Give up on a replay that has already built something, then re-throw. `orca record`'s
+   * `abandon` is the same function for the same two reasons.
+   *
+   * A listening proxy keeps Node's event loop alive, so a throw printed the error and then hung
+   * forever — `orca replay` was the one command of the three that had to be killed. And an
+   * unsealed trace has no `ended_at` or `integrity`, so `verifyIntegrity` reports the run as
+   * *tampered* rather than as unfinished.
+   *
+   * Sealing rather than discarding, for the reason the fork gives: a run that failed to launch is
+   * still a run someone will want to read. The CA is not disposed here because the `finally`
+   * below does it on both paths.
+   */
+  async function abandon(err: unknown): Promise<never> {
+    await openProxy?.close().catch(() => undefined);
     await writes.drain().catch(() => undefined);
     if (trace) {
       await trace
@@ -542,71 +390,268 @@ async function replayRestored(
       await trace.close().catch(() => undefined);
     }
     throw err;
-  } finally {
-    // In a finally because the whole justification for restoring over the working tree is that it
-    // is put back — a throw between here and there would leave someone's checkout holding a
-    // recorded run's files.
-    await workspace.release();
-    await tls.ca?.dispose();
   }
 
-  await writes.drain();
-  const stats = proxy.stats();
-  await proxy.close();
+  /*
+   * Everything from here to the child's exit mints a key and then opens a socket, so everything
+   * from here to the child's exit has to come back through `abandon` — the rule `orca record`
+   * states in the same words, having learned it the same way.
+   *
+   * The guard used to start at the spawn, which covered the failure it was written for and missed
+   * the four that happen first. `RunCa.create` writes `tls/ca.key`; `createProxy` binds; then
+   * `mcpForReplay` rewrites a config and `adapter.prepare` runs a harness's own validation, which
+   * is where `orca replay` on a trace naming an adapter this build does not have ended up — the
+   * right error message, printed, and then a process that never exited with a private key left
+   * behind in the run directory.
+   */
+  try {
+    // A subscription-backed harness does not use the ordinary base URL, so exact replay needs the
+    // same per-run CA and HTTPS proxy as recording. The proxy's TLS hook then answers Codex's
+    // model request from the trace before it can open an origin connection.
+    // The hosts were resolved before the workspace was restored, where anything refusable about
+    // them was refused; this is the half that mints.
+    const tls = await setupTlsCapture({
+      args,
+      out,
+      ...(interceptedHosts ? { recordedHosts: interceptedHosts } : {}),
+      writer: trace,
+      runDir: ctx.runDir,
+      writes,
+      turn: () => 0,
+    });
+    // Handed to `abandon` the moment it exists, not once the run is under way: `createProxy` on
+    // the next line is one of the throws this key has to survive being disposed by.
+    mintedCa = tls.ca;
 
-  for (const d of divergences) {
-    out.warn('divergence', { seq: d.seq, level: d.level, detail: d.detail });
-  }
+    const proxy = await createProxy({
+      mode: 'replay',
+      exchanges: ctx.exchanges,
+      loose: args.bool('loose'),
+      upstream: plan.upstream,
+      upstreamHeaders: plan.headers,
+      upstreamHeadersOrigin: plan.headersOrigin,
+      ...tls.proxyOptions,
+      onDivergence: (d) => {
+        divergences.push(d);
+        if (!trace) return;
+        writes.push(async () => {
+          await trace.append({
+            type: 'divergence',
+            actor: 'orca',
+            // Turn 0 for everything in this trace, and deliberately not a running count. An exact
+            // match produces no callback, so a counter here would number the third divergence as
+            // turn 1 and claim a position in the conversation that it does not have. `source_seq`
+            // is the honest coordinate: it points straight at the parent's own event.
+            turn: 0,
+            attrs: { level: d.level, rung: d.rung, detail: d.detail, source_seq: d.seq },
+          });
+        });
+      },
+      // Printed as it happens rather than tallied at the end. A halted replay stops the agent, so
+      // the count in `replay.done` arrives after the operator has already seen the run die — and a
+      // bare `unmatched=1` with no reason is indistinguishable from a bug in orca itself.
+      //
+      // The two directories are on the line because a distance in the hundreds of thousands is true
+      // and unactionable. Harnesses put absolute paths in their tool calls, so a replay running
+      // anywhere but the recording's own directory gets a permission refusal where the recording has
+      // file contents — by far the most common cause of a halt, and invisible from the number alone.
+      onUnmatched: (u) => {
+        unmatched.push(u);
+        // A halt inside a delegation is not a corrupt trace and not a bug, and looks like both. The
+        // harness writes the delegate's prompt itself, fresh on every run, so the request really is
+        // a different question — which is exactly what the matcher refuses to serve from a
+        // recording. Without this the operator sees `distance 54` and goes looking for the fault.
+        const delegation = enclosingDelegation(ctx.events, u.seq);
+        out.warn('replay.unmatched', {
+          seq: u.seq,
+          index: u.index,
+          reason: u.reason,
+          ...(delegation === undefined
+            ? {}
+            : {
+                inside: `${delegation.subagent} delegated at seq ${delegation.seq}`,
+                why: 'the harness writes a delegate prompt of its own each run, so this request is a different question rather than a drifted one',
+              }),
+          recorded_in: ctx.manifest.cwd,
+          replayed_in: workspace.dir,
+          next:
+            workspace.dir === ctx.manifest.cwd
+              ? 'orca replay <run> --loose'
+              : `cd ${ctx.manifest.cwd} && orca replay <run> --in-place   # or --loose to continue live`,
+        });
+        if (!trace) return;
+        // `error`, not `divergence`: nothing was served and the run is over, so calling it an
+        // inexact match would put a rung on a ladder the request never climbed. It is also the one
+        // finding here that exists nowhere else — a matched exchange is already in the parent, but
+        // "the agent asked for something this recording cannot answer" is new, and until now it
+        // lived only in the operator's scrollback.
+        writes.push(async () => {
+          await trace.append({
+            type: 'error',
+            actor: 'orca',
+            turn: 0,
+            attrs: {
+              rule: 'replay_unmatched',
+              rung: 4,
+              reason: u.reason,
+              index: u.index,
+              source_seq: u.seq,
+              recorded_in: ctx.manifest.cwd,
+              replayed_in: workspace.dir,
+            },
+          });
+        });
+      },
+    });
+    // Listening from here on, so from here on a throw that does not close it is a process that
+    // does not exit.
+    openProxy = proxy;
 
-  // A halted replay is a failed replay even if the harness chose to exit 0 on the error. The exit
-  // code is what a script reads, so it has to reflect what happened rather than what the agent
-  // decided to do about it — and the trace records the same verdict for the same reason.
-  const verdict = exitCode === 0 && unmatched.length > 0 ? 1 : exitCode;
-
-  if (trace) {
-    // What the replay discovered rather than repeated: these calls really happened just now, and
-    // exist nowhere in the parent.
-    if (mcp) await drainMcpFrames(mcp, trace, () => 0, 0);
-    await trace.append({
-      type: 'run.end',
+    await trace?.append({
+      type: 'run.start',
       actor: 'orca',
       turn: 0,
       attrs: {
-        exit_code: verdict,
-        agent_exit_code: exitCode,
-        matched: stats.matchedExact,
-        divergences: stats.divergences,
-        unmatched: stats.unmatched,
+        adapter: ctx.manifest.adapter.id,
+        cwd: workspace.dir,
+        proxy: proxy.url,
+        mode: 'replay',
+        // Also on the manifest, which is what an out-of-process reader sees first. Here as well
+        // because a trace read on its own should say what it is a replay of.
+        parent_run: ctx.manifest.run_id,
+        exchanges: ctx.exchanges.length,
       },
     });
-    await trace.close(verdict);
+
+    out.phase('replaying', {
+      run: ctx.manifest.run_id,
+      exchanges: ctx.exchanges.length,
+      // Read from the flag, because `--loose` is exactly the run where it is not blocked. It was a
+      // literal, so `orca replay <run> --loose` announced `egress=blocked` and then answered the
+      // first unmatched request from the provider — the one line a reader checks to know whether a
+      // run can spend money, saying the opposite of what the run was about to do. Worse than an
+      // inaccuracy, because `replay halted` recommends `--loose` by name: the reader is following
+      // orca's own advice when the label stops being true.
+      egress: args.bool('loose') ? 'live-on-unmatched' : 'blocked',
+      proxy: proxy.url,
+      cwd: workspace.dir,
+    });
+
+    // The agent runs live for everything that is not a model call, MCP included. Without a config it
+    // talks to servers orca cannot see — or, for a harness that requires the variable, does not start
+    // at all, which is how a replay of a working recording exits non-zero for a reason that has
+    // nothing to do with the recording.
+    const mcp =
+      trace === undefined
+        ? undefined
+        : await mcpForReplay(args, ctx.events, trace, out, join(ctx.runDir, 'mcp-frames.jsonl'));
+
+    const adapter = defaultAdapters().get(ctx.manifest.adapter.id);
+    const launch = await adapter.prepare({
+      runId: ctx.manifest.run_id,
+      cwd: workspace.dir,
+      proxyUrl: proxy.url,
+      runDir: ctx.runDir,
+      userArgs: driveArgs(adapter, ctx, out),
+      env: process.env,
+    });
+    // Replaying must not introduce a catalog request before the capture plugin is installed.
+    if (adapter.id === 'opencode') launch.env.OPENCODE_DISABLE_MODELS_FETCH = '1';
+    if (proxy.tls) await trustRunCa(trace, proxy.tls, proxy.url, launch.env, out);
+    if (mcp) {
+      pointAtMcpConfig(launch.env, mcp.configPath);
+      // Same as record: the path has to reach the harness the way the harness actually reads it, or
+      // a replay re-instruments a config nothing opens and every recorded MCP call goes unmatched.
+      const mcpArgs = adapter.mcpConfigArgs?.(mcp.configPath);
+      if (mcpArgs !== undefined) launch.args = [...mcpArgs, ...launch.args];
+    }
+
+    const exitCode = await runChild(
+      launch.command,
+      launch.args,
+      { ...process.env, ...launch.env },
+      workspace.dir,
+      agentStdoutFor(args),
+    );
+
+    await writes.drain();
+    const stats = proxy.stats();
+    await proxy.close();
+
+    for (const d of divergences) {
+      out.warn('divergence', { seq: d.seq, level: d.level, detail: d.detail });
+    }
+
+    // A halted replay is a failed replay even if the harness chose to exit 0 on the error. The exit
+    // code is what a script reads, so it has to reflect what happened rather than what the agent
+    // decided to do about it — and the trace records the same verdict for the same reason.
+    const verdict = exitCode === 0 && unmatched.length > 0 ? 1 : exitCode;
+
+    if (trace) {
+      // What the replay discovered rather than repeated: these calls really happened just now, and
+      // exist nowhere in the parent.
+      if (mcp) await drainMcpFrames(mcp, trace, () => 0, 0);
+      await trace.append({
+        type: 'run.end',
+        actor: 'orca',
+        turn: 0,
+        attrs: {
+          exit_code: verdict,
+          agent_exit_code: exitCode,
+          matched: stats.matchedExact,
+          divergences: stats.divergences,
+          unmatched: stats.unmatched,
+        },
+      });
+      await trace.close(verdict);
+    }
+
+    out.phase('replay.done', {
+      // `matched=1 total=13` was the old shape, and on a healthy replay of a real harness it read as
+      // a failure: rung 1 is only reachable when nothing in the request was redacted, so a run whose
+      // every request was served from disk still reported one match. What someone wants to know here
+      // is how much of the recording was reused, and how much of that reuse was exact.
+      reused: `${stats.matchedExact + stats.matchedInexact}/${ctx.exchanges.length}`,
+      exact: stats.matchedExact,
+      divergences: stats.divergences,
+      unmatched: stats.unmatched,
+      exit: exitCode,
+      // Omitted entirely under --no-trace: `Output` drops undefined fields, so the line stays the
+      // shape it has always been for anyone who opted out.
+      trace: trace?.runId,
+    });
+
+    return {
+      runId: ctx.manifest.run_id,
+      mode: 'exact',
+      ...(trace === undefined ? {} : { traceRunId: trace.runId }),
+      matchedExact: stats.matchedExact,
+      divergences: stats.divergences,
+      unmatched: stats.unmatched,
+      liveCalls: stats.liveCalls,
+      exitCode: verdict,
+    };
+  } catch (err) {
+    // `return await`, not the bare `return abandon(err)` that `orca record` can afford. The
+    // difference is the `finally` below: a promise returned out of a `catch` is not adopted by
+    // the caller until the `finally` has finished, and this one awaits real I/O, so the
+    // rejection sits with no handler attached for as long as that takes. Node reports it as an
+    // unhandled rejection and kills the process on the spot — the operator got a raw stack trace
+    // where `orca replay` had always printed `error replay.failed`, and `main`'s catch never ran
+    // at all. Awaiting here turns it back into a throw *inside* the catch, before the finally,
+    // which is what every frame above expects.
+    return await abandon(err);
+  } finally {
+    // Both paths, which is why these two are here and the proxy is not: a replay that ran
+    // closes its own proxy after reading `stats()`, and one that did not comes through
+    // `abandon`. These do not divide that way. The whole justification for restoring over
+    // the working tree is that it is put back, and `tls-capture.ts` asks the caller to own
+    // the run CA on every exit path — `replayCommand` had no equivalent of the `minted`
+    // wrapper `recordCommand` and `attachCommand` use, so a key outlived every failure
+    // between the mint and the launch.
+    await workspace.release();
+    await mintedCa?.dispose();
   }
-
-  out.phase('replay.done', {
-    // `matched=1 total=13` was the old shape, and on a healthy replay of a real harness it read as
-    // a failure: rung 1 is only reachable when nothing in the request was redacted, so a run whose
-    // every request was served from disk still reported one match. What someone wants to know here
-    // is how much of the recording was reused, and how much of that reuse was exact.
-    reused: `${stats.matchedExact + stats.matchedInexact}/${ctx.exchanges.length}`,
-    exact: stats.matchedExact,
-    divergences: stats.divergences,
-    unmatched: stats.unmatched,
-    exit: exitCode,
-    // Omitted entirely under --no-trace: `Output` drops undefined fields, so the line stays the
-    // shape it has always been for anyone who opted out.
-    trace: trace?.runId,
-  });
-
-  return {
-    runId: ctx.manifest.run_id,
-    mode: 'exact',
-    ...(trace === undefined ? {} : { traceRunId: trace.runId }),
-    matchedExact: stats.matchedExact,
-    divergences: stats.divergences,
-    unmatched: stats.unmatched,
-    liveCalls: stats.liveCalls,
-    exitCode: verdict,
-  };
 }
 
 /**
@@ -761,6 +806,33 @@ async function replayFork(
   // half — the operator believes they captured that traffic.
   // Same for a fork: it continues a recorded conversation, so its prefix is replayed and the
   // requests carrying it arrive by the same intercepted transport they were recorded on.
+
+  /** Filled as each is built; see the exact path's pair, which this mirrors. */
+  let mintedCa: RunCa | undefined;
+  let openProxy: { close: () => Promise<void> } | undefined;
+
+  /**
+   * The same two failures `orca record` had. A listening proxy keeps Node's event loop alive, so
+   * a throw printed the error and then hung; and a fork that mints a certificate authority must
+   * not leave the private key on disk when it dies. The trace is sealed either way, because a
+   * fork that failed to launch is still a fork someone will want to read.
+   *
+   * This used to guard the spawn alone, which is one throw out of five: `RunCa.create` writes the
+   * key, `mcpForReplay` rewrites a config, `createProxy` binds, and `adapter.prepare` runs a
+   * harness's own validation — all of them before the child, all of them leaving the key, the
+   * socket, or both.
+   */
+  async function abandon(err: unknown): Promise<never> {
+    await openProxy?.close().catch(() => undefined);
+    await writes.drain().catch(() => undefined);
+    await mintedCa?.dispose().catch(() => undefined);
+    await writer
+      .append({ type: 'run.end', actor: 'orca', turn, attrs: { error: String(err) } })
+      .catch(() => undefined);
+    await writer.close().catch(() => undefined);
+    throw err;
+  }
+
   const tls = await setupTlsCapture({
     args,
     out,
@@ -768,11 +840,12 @@ async function replayFork(
     writer,
     writes,
     turn: () => turn,
-  });
+  }).catch(abandon);
+  mintedCa = tls.ca;
 
   // A fork continues the run live past the checkpoint, so its MCP traffic is new and belongs in the
   // fork's own trace. Without this the layer simply stopped at the fork point.
-  const mcp = await mcpForReplay(args, ctx.events, writer, out);
+  const mcp = await mcpForReplay(args, ctx.events, writer, out).catch(abandon);
 
   const proxy = await createProxy({
     mode: 'hybrid',
@@ -813,6 +886,8 @@ async function replayFork(
       });
     },
   });
+  // Listening from here on — see the exact path.
+  openProxy = proxy;
 
   await writer.append({
     type: 'fork',
@@ -838,50 +913,41 @@ async function replayFork(
     worktree,
   });
 
-  const adapter = defaultAdapters().get(ctx.manifest.adapter.id);
-  const launch = await adapter.prepare({
-    runId: writer.runId,
-    cwd: worktree,
-    proxyUrl: proxy.url,
-    runDir: writer.runDir,
-    userArgs: driveArgs(adapter, ctx, out),
-    env: process.env,
-  });
+  // `defaultAdapters().get` refuses a manifest naming an adapter this build does not have, which
+  // is what replaying a newer orca's recording looks like from here, and `prepare` is where a
+  // harness validates its own invocation. Both are throws with the proxy already listening.
+  const launch = await (async () => {
+    const adapter = defaultAdapters().get(ctx.manifest.adapter.id);
+    const prepared = await adapter.prepare({
+      runId: writer.runId,
+      cwd: worktree,
+      proxyUrl: proxy.url,
+      runDir: writer.runDir,
+      userArgs: driveArgs(adapter, ctx, out),
+      env: process.env,
+    });
 
-  if (proxy.tls) {
-    await trustRunCa(writer, proxy.tls, proxy.url, launch.env, out);
-  }
-  if (mcp) {
-    pointAtMcpConfig(launch.env, mcp.configPath);
-    // Same as record: the path has to reach the harness the way the harness actually reads it, or
-    // a replay re-instruments a config nothing opens and every recorded MCP call goes unmatched.
-    const mcpArgs = adapter.mcpConfigArgs?.(mcp.configPath);
-    if (mcpArgs !== undefined) launch.args = [...mcpArgs, ...launch.args];
-  }
+    if (proxy.tls) {
+      await trustRunCa(writer, proxy.tls, proxy.url, prepared.env, out);
+    }
+    if (mcp) {
+      pointAtMcpConfig(prepared.env, mcp.configPath);
+      // Same as record: the path has to reach the harness the way the harness actually reads it,
+      // or a replay re-instruments a config nothing opens and every recorded MCP call goes
+      // unmatched.
+      const mcpArgs = adapter.mcpConfigArgs?.(mcp.configPath);
+      if (mcpArgs !== undefined) prepared.args = [...mcpArgs, ...prepared.args];
+    }
+    return prepared;
+  })().catch(abandon);
 
-  let exitCode: number;
-  try {
-    exitCode = await runChild(
-      launch.command,
-      launch.args,
-      { ...process.env, ...launch.env },
-      worktree,
-      agentStdoutFor(args),
-    );
-  } catch (err) {
-    // The same two failures `orca record` had. A listening proxy keeps Node's event loop alive, so
-    // a throw here printed the error and then hung; and a fork that mints a certificate authority
-    // must not leave the private key on disk when it dies. The trace is sealed either way, because
-    // a fork that failed to launch is still a fork someone will want to read.
-    await proxy.close().catch(() => undefined);
-    await writes.drain().catch(() => undefined);
-    await tls.ca?.dispose().catch(() => undefined);
-    await writer
-      .append({ type: 'run.end', actor: 'orca', turn, attrs: { error: String(err) } })
-      .catch(() => undefined);
-    await writer.close().catch(() => undefined);
-    throw err;
-  }
+  const exitCode = await runChild(
+    launch.command,
+    launch.args,
+    { ...process.env, ...launch.env },
+    worktree,
+    agentStdoutFor(args),
+  ).catch(abandon);
   await writes.drain();
   if (mcp) await drainMcpFrames(mcp, writer, turnAtFork, turn);
 
@@ -993,30 +1059,46 @@ async function replayWorkspace(args: ParsedArgs, out: Output, ctx: Ctx): Promise
     note: 'your files are restored when the replay ends',
   });
 
-  await recorded.restore(initial.fsTree, ctx.cwd);
-
   // Two callers, on purpose — see `Workspace.release`. Restoring twice would be wrong rather than
   // merely wasteful: the second pass would write the pre-replay tree back over whatever the
   // caller has done since, and the `rm` would take the scratch with it.
   let released = false;
-  return {
-    dir: ctx.cwd,
-    release: async () => {
-      if (released) return;
-      released = true;
-      await safety.restore(before.tree, ctx.cwd);
-      // Only after the restore succeeded. This store holds the only copy of your working tree as
-      // it was before the replay overwrote it, so removing it on the failure path would delete the
-      // thing the failure means you still need — better a directory to clean up by hand than the
-      // one that had your uncommitted work in it.
-      //
-      // Left behind on every run until now: a whole workspace per `orca replay`, in a directory
-      // `orca gc` deliberately will not touch because it only reclaims scratch worktrees belonging
-      // to forks. Owning its lifetime here is the fix; teaching gc to delete unknown temp
-      // directories is how gc ends up removing someone's work.
-      await rm(scratch, { recursive: true, force: true });
-    },
+  const release = async (): Promise<void> => {
+    if (released) return;
+    released = true;
+    await safety.restore(before.tree, ctx.cwd);
+    // Only after the restore succeeded. This store holds the only copy of your working tree as
+    // it was before the replay overwrote it, so removing it on the failure path would delete the
+    // thing the failure means you still need — better a directory to clean up by hand than the
+    // one that had your uncommitted work in it.
+    //
+    // Left behind on every run until now: a whole workspace per `orca replay`, in a directory
+    // `orca gc` deliberately will not touch because it only reclaims scratch worktrees belonging
+    // to forks. Owning its lifetime here is the fix; teaching gc to delete unknown temp
+    // directories is how gc ends up removing someone's work.
+    await rm(scratch, { recursive: true, force: true });
   };
+
+  // The destructive step, inside the thing that undoes it.
+  //
+  // A caller cannot guard this one: it happens here, and the `release` that undoes it does not
+  // exist outside this function until this function returns. So a `materialize` that failed
+  // part-way — it is `read-tree` + `checkout-index -a -f` with no rollback of its own, and a
+  // path conflict, EACCES or ENOSPC stops it mid-tree — left the operator holding a mixture of
+  // their files and the recording's, with the only copy of the original in a scratch directory
+  // whose path nothing prints, and no release attempted anywhere.
+  //
+  // With this, the function has one postcondition either way: it returns with the tree replaced
+  // and a `release` that puts it back, or it throws with the tree as it found it. That is what
+  // lets the caller arm its own guard on the line after the call rather than before it.
+  try {
+    await recorded.restore(initial.fsTree, ctx.cwd);
+  } catch (err) {
+    await release();
+    throw err;
+  }
+
+  return { dir: ctx.cwd, release };
 }
 
 /** Where the replayed agent's own stdout should go, given the flags. */

--- a/packages/cli/src/commands/replay.ts
+++ b/packages/cli/src/commands/replay.ts
@@ -22,8 +22,8 @@ import type { ParsedArgs } from '../args.js';
 import { SerialQueue } from '../serial.js';
 import { appendSnapshot } from '../fs-events.js';
 import { drainMcpFrames, mcpForReplay, pointAtMcpConfig } from '../mcp.js';
-import { recordedTlsHosts, setupTlsCapture, trustRunCa } from '../tls-capture.js';
-import { upstreamPlan } from '../upstream.js';
+import { planTlsCapture, recordedTlsHosts, setupTlsCapture, trustRunCa } from '../tls-capture.js';
+import { upstreamPlan, type UpstreamPlan } from '../upstream.js';
 import { ORCA_VERSION } from '../version.js';
 
 export interface ReplayResult {
@@ -296,17 +296,61 @@ interface Ctx {
  * rather than letting the agent edit it a second time.
  */
 async function replayExact(args: ParsedArgs, out: Output, ctx: Ctx): Promise<ReplayResult> {
+  // Before `replayWorkspace`, because these refuse and `replayWorkspace` replaces the working
+  // tree. Resolved after it, a refusal threw with the checkout holding the recorded run's files
+  // and the operator's own tree left behind in an `orca-safety-*` scratch whose path nothing
+  // prints — the outcome the release exists to prevent, escaping it because it only ran at the
+  // child's launch. An invocation that cannot work should decide so before it touches anything,
+  // which is the rule `attach` already follows where it resolves the advertised URL before making
+  // a run directory.
+  //
+  // Two refusals, not one. `upstreamPlan` rejects an upstream that is not an origin;
+  // `planTlsCapture` rejects a `--tls-hosts` list that names `*` or contradicts itself, and an
+  // `ORCA_TLS_UPSTREAM_CA` that cannot be read. It is the refusing half of `setupTlsCapture` on
+  // its own — it mints nothing, so the certificate authority is still created down where the run
+  // is, after the workspace exists.
+  const plan = await upstreamPlan(args);
+  // A run recorded through interception is reproduced through it, without the operator having to
+  // remember which hosts they named. See `setupTlsCapture`.
+  const interceptedHosts = recordedTlsHosts(ctx.events);
+  await planTlsCapture(args, interceptedHosts);
+
+  const workspace = await replayWorkspace(args, out, ctx);
+  try {
+    return await replayRestored(args, out, ctx, { plan, interceptedHosts, workspace });
+  } finally {
+    // The safety net behind both refusals above, and behind every one nobody has enumerated. The
+    // list of things that can throw between the restore and the child's launch is not closed:
+    // `createProxy` binds a socket, `RunCa.create` writes a key, `adapter.prepare` runs a
+    // harness's own setup, `mcpForReplay` rewrites a config — and each one of them would
+    // otherwise end with a recording's files in someone's checkout. Enumerating refusals is what
+    // failed twice already, and hoisting them is only ever as complete as the list; this is the
+    // half that does not depend on the list being right. `release` is idempotent, so the one at
+    // the child's launch still owns the ordinary path and still puts the tree back before the
+    // run reports itself done.
+    await workspace.release();
+  }
+}
+
+/**
+ * The replay itself, once the filesystem it needs is in place.
+ *
+ * Split from `replayExact` for one reason: everything in here happens with the recording's files
+ * over the operator's checkout, so it has to run inside something that puts them back.
+ */
+async function replayRestored(
+  args: ParsedArgs,
+  out: Output,
+  ctx: Ctx,
+  prepared: {
+    plan: UpstreamPlan;
+    interceptedHosts: readonly string[] | undefined;
+    workspace: Workspace;
+  },
+): Promise<ReplayResult> {
+  const { plan, interceptedHosts, workspace } = prepared;
   const divergences: { level: string; detail: string; seq: number }[] = [];
   const unmatched: { seq: number; reason: string }[] = [];
-  // Before `replayWorkspace`, because this refuses an upstream that is not an origin and
-  // `replayWorkspace` replaces the working tree. Resolved after it, a refusal threw with the
-  // checkout holding the recorded run's files and the operator's own tree left behind in an
-  // `orca-safety-*` scratch — the outcome the `finally` below exists to prevent, escaping it
-  // because that `finally` only begins at the child's launch. An invocation that cannot work
-  // should decide so before it touches anything, which is the rule `attach` already follows where
-  // it resolves the advertised URL before making a run directory.
-  const plan = await upstreamPlan(args);
-  const workspace = await replayWorkspace(args, out, ctx);
   const trace = await openReplayTrace(args, ctx, workspace.dir);
   // Serial for the same reason the recorder's is: the callbacks fire from the proxy's request
   // handler, and two overlapping appends would interleave lines in events.jsonl.
@@ -315,9 +359,8 @@ async function replayExact(args: ParsedArgs, out: Output, ctx: Ctx): Promise<Rep
   // A subscription-backed harness does not use the ordinary base URL, so exact replay needs the
   // same per-run CA and HTTPS proxy as recording. The proxy's TLS hook then answers Codex's model
   // request from the trace before it can open an origin connection.
-  // A run recorded through interception is reproduced through it, without the operator having to
-  // remember which hosts they named. See `setupTlsCapture`.
-  const interceptedHosts = recordedTlsHosts(ctx.events);
+  // The hosts were resolved before the workspace was restored, where anything refusable about
+  // them was refused; this is the half that mints.
   const tls = await setupTlsCapture({
     args,
     out,
@@ -642,10 +685,17 @@ async function replayFork(
   // requests happened at or before the checkpoint.
   const forkAt = ctx.exchanges.filter((e) => e.seq <= checkpoint.seq).length;
 
-  // Before the worktree and the fork's own run directory, because this refuses an upstream that
-  // is not an origin: resolved after them, a typo in `--upstream-*` left a restored temp tree in
-  // `$TMPDIR` and an empty fork in `orca list`, reading `FROM <parent>@<n>` as though it had run.
+  // Before the worktree and the fork's own run directory, because both of these refuse:
+  // `upstreamPlan` an upstream that is not an origin, `planTlsCapture` a `--tls-hosts` list that
+  // names `*` or contradicts itself and an `ORCA_TLS_UPSTREAM_CA` that cannot be read. Resolved
+  // after them, a typo in any of them left a restored temp tree in `$TMPDIR` that `orca gc` will
+  // not reclaim — no manifest points at it — and an empty fork in `orca list`, reading
+  // `FROM <parent>@<n>` as though it had run.
   const plan = await upstreamPlan(args);
+  // A fork continues a recorded conversation, so it is intercepted on the same terms the
+  // recording was; see `setupTlsCapture` below, which this is the refusing half of.
+  const forkInterceptedHosts = recordedTlsHosts(ctx.events);
+  await planTlsCapture(args, forkInterceptedHosts);
 
   const worktree = await mkdtemp(join(tmpdir(), `orca-${checkpoint.seq}-`));
   if (checkpoint.fsTree) {
@@ -711,7 +761,6 @@ async function replayFork(
   // half — the operator believes they captured that traffic.
   // Same for a fork: it continues a recorded conversation, so its prefix is replayed and the
   // requests carrying it arrive by the same intercepted transport they were recorded on.
-  const forkInterceptedHosts = recordedTlsHosts(ctx.events);
   const tls = await setupTlsCapture({
     args,
     out,
@@ -868,6 +917,12 @@ async function replayFork(
 /** Where an exact replay runs, and how to put the directory back afterwards. */
 interface Workspace {
   dir: string;
+  /**
+   * Put the working tree back. Idempotent, and called from two places for that reason: once at
+   * the child's launch, where it belongs on the ordinary path, and once from a `finally` around
+   * the whole restored span, which is what makes the guarantee hold for a throw that never
+   * reaches the launch at all.
+   */
   release: () => Promise<void>;
 }
 
@@ -940,9 +995,15 @@ async function replayWorkspace(args: ParsedArgs, out: Output, ctx: Ctx): Promise
 
   await recorded.restore(initial.fsTree, ctx.cwd);
 
+  // Two callers, on purpose — see `Workspace.release`. Restoring twice would be wrong rather than
+  // merely wasteful: the second pass would write the pre-replay tree back over whatever the
+  // caller has done since, and the `rm` would take the scratch with it.
+  let released = false;
   return {
     dir: ctx.cwd,
     release: async () => {
+      if (released) return;
+      released = true;
       await safety.restore(before.tree, ctx.cwd);
       // Only after the restore succeeded. This store holds the only copy of your working tree as
       // it was before the replay overwrote it, so removing it on the failure path would delete the

--- a/packages/cli/src/tls-capture.ts
+++ b/packages/cli/src/tls-capture.ts
@@ -62,11 +62,23 @@ export interface TlsCapture {
  * Everything `setupTlsCapture` can refuse, without creating anything.
  *
  * A caller that has a trace directory to lose needs the refusal to happen first: a run abandoned
- * by a throw leaves an unsealed directory behind, and an unsealed directory wins `last`.
+ * by a throw leaves an unsealed directory behind, and an unsealed directory wins `last`. An exact
+ * replay has more than that to lose — it calls this before `replayWorkspace`, which writes the
+ * recording over the operator's checkout.
+ *
+ * `extraOriginRoots` is here for the second reason and not the first. It reads files, so it was
+ * left out of a function whose whole point was to decide from the arguments alone — but that made
+ * this only *most* of what `setupTlsCapture` refuses, and an unreadable `ORCA_TLS_UPSTREAM_CA`
+ * went on failing late, past the restore. The roots are read again below, microseconds later and
+ * on a path the run was going to read anyway.
  */
-export function planTlsCapture(args: ParsedArgs, recordedHosts?: readonly string[]): void {
+export async function planTlsCapture(
+  args: ParsedArgs,
+  recordedHosts?: readonly string[],
+): Promise<void> {
   if (!interceptionRequested(args, recordedHosts)) return;
   HostPolicy.from([...resolveTlsHosts(args.list('tls-hosts'), recordedHosts)]);
+  await extraOriginRoots();
 }
 
 /**

--- a/packages/cli/test/e2e.test.ts
+++ b/packages/cli/test/e2e.test.ts
@@ -25,6 +25,34 @@ const here = dirname(fileURLToPath(import.meta.url));
 const FAKE_AGENT = join(here, 'fixtures', 'fake-agent.mjs');
 
 /**
+ * Run `body` with the temp directory pointed somewhere only this test can reach, and hand back
+ * what was left in it.
+ *
+ * A replay's safety scratch goes to `os.tmpdir()`, so asserting on what it leaves there means
+ * asserting on a directory the whole machine shares — the other suites replay too, and a test
+ * that diffed the real `$TMPDIR` failed under `vitest run` while passing on its own. Moving the
+ * directory for the duration makes "nothing was left behind" a statement about this replay.
+ */
+async function withIsolatedTmp<T>(
+  body: () => Promise<T>,
+): Promise<{ result: T; leftBehind: string[] }> {
+  const isolated = await mkdtemp(join(tmpdir(), 'orca-tmproot-'));
+  const saved = { TMPDIR: process.env.TMPDIR, TMP: process.env.TMP, TEMP: process.env.TEMP };
+  process.env.TMPDIR = isolated;
+  process.env.TMP = isolated;
+  process.env.TEMP = isolated;
+  try {
+    const result = await body();
+    return { result, leftBehind: await readdir(isolated) };
+  } finally {
+    for (const [key, value] of Object.entries(saved)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+}
+
+/**
  * The acceptance test for the whole project.
  *
  *   orca record <agent>
@@ -435,6 +463,83 @@ describe('end to end: record → replay → fork', () => {
     expect((await listRuns(workspace)).length, 'a refused fork must not have created a run').toBe(
       afterGood,
     );
+  });
+
+  /**
+   * The restore is inside the thing that undoes it, so the caller cannot guard it.
+   *
+   * `replayWorkspace` snapshots the checkout, then overwrites it, then returns the `release` that
+   * puts it back — so a `materialize` that fails rejects before its caller has anything to call.
+   * The guard in `replayExact` is armed on the next line and never ran; the scratch holding the
+   * only copy of the operator's tree was abandoned in `$TMPDIR` with nothing printing its path.
+   *
+   * The store is emptied of its objects rather than deleted, so `FsCapture.start` still opens it
+   * and the failure lands where it matters: on `read-tree`, inside the restore. `orca gc` on a
+   * half-copied trace gets there the same way.
+   */
+  it('puts the working tree back when the restore itself fails', async () => {
+    const recorded = await record();
+    await writeFile(join(workspace, 'auth.ts'), 'MY UNCOMMITTED WORK\n');
+
+    // A shadow store that opens and holds nothing: every loose-object directory removed.
+    const objects = join(recorded.runDir, 'fs', 'objects');
+    for (const entry of await readdir(objects)) {
+      if (/^[0-9a-f]{2}$/.test(entry)) await rm(join(objects, entry), { recursive: true });
+    }
+
+    const { leftBehind } = await withIsolatedTmp(async () => {
+      await expect(replayCommand(parseArgs(['replay', 'last']), out, workspace)).rejects.toThrow();
+    });
+
+    expect(
+      await readFile(join(workspace, 'auth.ts'), 'utf8'),
+      'a replay whose restore failed must not have kept the operator out of their own tree',
+    ).toBe('MY UNCOMMITTED WORK\n');
+    // The release ran, which is the whole assertion: it is the only thing that removes the
+    // scratch, and it removes it only once the tree is back.
+    expect(leftBehind, 'nor left the only copy of it in a temp directory nothing names').toEqual(
+      [],
+    );
+  });
+
+  /**
+   * A replay that dies after minting a certificate authority must take the key with it.
+   *
+   * `tls-capture.ts` puts it in writing — "the caller owns the CA's lifetime and must dispose it
+   * on every exit path" — and `replayCommand` had no equivalent of the `minted` wrapper that
+   * `recordCommand` and `attachCommand` use. Between `RunCa.create` and the child's launch sit
+   * `createProxy`, `mcpForReplay` and `adapter.prepare`, and a throw from any of them left
+   * `tls/ca.key` on disk.
+   *
+   * The throw here is a trace naming an adapter this build does not have, which is what replaying
+   * a newer orca's recording looks like. It also pins the other half: the proxy is listening by
+   * then, and a proxy that is not closed keeps Node's event loop alive — so a regression shows up
+   * as this test timing out rather than as a hang nobody notices until a user reports it.
+   */
+  it('takes the run CA with it when the replay dies after minting one', async () => {
+    const recorded = await record();
+    const manifestPath = join(recorded.runDir, 'manifest.json');
+    const manifest = JSON.parse(await readFile(manifestPath, 'utf8')) as {
+      adapter: { id: string };
+    };
+    manifest.adapter.id = 'agent-from-the-future';
+    await writeFile(manifestPath, JSON.stringify(manifest));
+
+    await expect(
+      replayCommand(
+        parseArgs(['replay', 'last', '--tls-intercept', '--tls-hosts', 'api.openai.com']),
+        out,
+        workspace,
+      ),
+    ).rejects.toThrow(/unknown adapter/);
+
+    const withKey: string[] = [];
+    const runsRoot = join(workspace, '.orca', 'runs');
+    for (const run of await readdir(runsRoot)) {
+      const entries = await readdir(join(runsRoot, run)).catch(() => [] as string[]);
+      if (entries.includes('tls')) withKey.push(run);
+    }
+    expect(withKey, 'a replay that refused after minting must not leave the key').toEqual([]);
   });
 
   /**

--- a/packages/cli/test/e2e.test.ts
+++ b/packages/cli/test/e2e.test.ts
@@ -313,6 +313,131 @@ describe('end to end: record → replay → fork', () => {
   });
 
   /**
+   * The same rule, for the other refusal in the same window.
+   *
+   * `--tls-hosts` is refused by `resolveTlsHosts`/`HostPolicy.from`, and that happened inside
+   * `setupTlsCapture` — reached after `replayWorkspace` had already written the recording over the
+   * checkout, and after the replay's own run directory existed. The throw escaped the `finally`
+   * that puts the tree back for the same reason the upstream one did: that `finally` only begins
+   * at the child's launch. So the operator was left holding the recording's files, with their own
+   * work in an `orca-safety-*` scratch whose path nothing prints.
+   *
+   * `planTlsCapture` is the refusing half on its own and mints nothing; `attach` already calls it
+   * before its run directory for exactly this reason.
+   */
+  it('leaves the working tree alone when it refuses the tls host list', async () => {
+    await record();
+    await writeFile(join(workspace, 'auth.ts'), 'MY UNCOMMITTED WORK\n');
+    const before = (await listRuns(workspace)).length;
+
+    await expect(
+      replayCommand(
+        parseArgs(['replay', 'last', '--tls-intercept', '--tls-hosts', '*']),
+        out,
+        workspace,
+      ),
+    ).rejects.toThrow(/would intercept every host/);
+
+    expect(
+      await readFile(join(workspace, 'auth.ts'), 'utf8'),
+      'a refused replay must not have touched the checkout',
+    ).toBe('MY UNCOMMITTED WORK\n');
+    // And it never claimed to have: the restore line belongs to a replay that got that far.
+    expect(lines.join('\n')).not.toContain('replay.restored');
+    expect((await listRuns(workspace)).length, 'nor created a run for it').toBe(before);
+  });
+
+  /**
+   * The refusal that hoisting alone would still have missed.
+   *
+   * `ORCA_TLS_UPSTREAM_CA` is read from disk, so it cannot be decided from the arguments the way
+   * a host list can — `setupTlsCapture` opens it, past the restore. Two things now stand between
+   * that and the operator's checkout: `planTlsCapture` reads the roots too, so the refusal
+   * happens before `replayWorkspace`; and the release is armed for the whole restored span, so a
+   * throw that gets past the first still puts the tree back.
+   *
+   * Worth its own test because it is the one that proves the rule generalises. `createProxy`,
+   * `RunCa.create` and `adapter.prepare` all sit in the same window and are not on any list.
+   */
+  it('leaves the working tree alone when the upstream CA cannot be read', async () => {
+    await record();
+    await writeFile(join(workspace, 'auth.ts'), 'MY UNCOMMITTED WORK\n');
+
+    process.env.ORCA_TLS_UPSTREAM_CA = join(workspace, 'no-such-root.pem');
+    try {
+      await expect(
+        replayCommand(
+          parseArgs(['replay', 'last', '--tls-intercept', '--tls-hosts', 'api.openai.com']),
+          out,
+          workspace,
+        ),
+      ).rejects.toThrow(/ENOENT|no such file/);
+    } finally {
+      delete process.env.ORCA_TLS_UPSTREAM_CA;
+    }
+
+    expect(
+      await readFile(join(workspace, 'auth.ts'), 'utf8'),
+      'a refused replay must not have touched the checkout',
+    ).toBe('MY UNCOMMITTED WORK\n');
+    expect(lines.join('\n')).not.toContain('replay.restored');
+  });
+
+  /**
+   * And the same on the two paths where only scratch is at stake.
+   *
+   * A fork restores its checkpoint into a temp worktree and opens its own run before it reaches
+   * `setupTlsCapture`, and `record` opens its run first too — so a refused host list left an empty
+   * run for `orca list` to show, plus a worktree in `$TMPDIR` that `orca gc` will not reclaim
+   * because no manifest points at it. Cheaper than the checkout, the same rule.
+   */
+  it('leaves no run behind when it refuses the tls host list', async () => {
+    const before = (await listRuns(workspace)).length;
+    await expect(
+      recordCommand(
+        parseArgs([
+          'record',
+          'generic-openai',
+          '--tls-intercept',
+          '--tls-hosts',
+          '*',
+          '--',
+          'node',
+          FAKE_AGENT,
+        ]),
+        out,
+        workspace,
+      ),
+    ).rejects.toThrow(/would intercept every host/);
+    expect((await listRuns(workspace)).length, 'a refused record must not have created a run').toBe(
+      before,
+    );
+
+    await record();
+    const afterGood = (await listRuns(workspace)).length;
+    await expect(
+      replayCommand(
+        parseArgs([
+          'replay',
+          'last',
+          '--from',
+          '1',
+          '--model',
+          'gpt-5.2',
+          '--tls-intercept',
+          '--tls-hosts',
+          '*',
+        ]),
+        out,
+        workspace,
+      ),
+    ).rejects.toThrow(/would intercept every host/);
+    expect((await listRuns(workspace)).length, 'a refused fork must not have created a run').toBe(
+      afterGood,
+    );
+  });
+
+  /**
    * The one line a reader checks to know whether a run can spend money.
    *
    * `egress` was a literal, so `--loose` — which answers an unmatched request from the provider —

--- a/packages/cli/test/e2e.test.ts
+++ b/packages/cli/test/e2e.test.ts
@@ -262,6 +262,57 @@ describe('end to end: record → replay → fork', () => {
   });
 
   /**
+   * Nor may a refusal leave a run behind.
+   *
+   * The same misordering as above, in its quiet form. `upstreamPlan` throws for an upstream that is
+   * not an origin, and every command resolved it *after* creating the run directory — `record`,
+   * `attach`, and the fork path, which also restores a temp worktree first. So a typo in
+   * `--upstream-*` left an empty run for `orca list` to show, reading `FROM <parent>@<n>` on a fork
+   * as though it had run, plus a restored tree abandoned in `$TMPDIR`. Nothing was lost, which is
+   * why it went unnoticed; it is the same rule, and the rule is that an invocation which cannot
+   * work decides so before it touches anything.
+   */
+  it('leaves no run behind when it refuses the upstream', async () => {
+    const BAD = 'myuser:PASSWORD@gw.example/v1';
+
+    const before = (await listRuns(workspace)).length;
+    await expect(
+      recordCommand(
+        parseArgs(['record', 'generic-openai', '--upstream-openai', BAD, '--', 'node', FAKE_AGENT]),
+        out,
+        workspace,
+      ),
+    ).rejects.toThrow(/is not an origin orca can use/);
+    expect((await listRuns(workspace)).length, 'a refused record must not have created a run').toBe(
+      before,
+    );
+
+    // The fork path gets there by a different route: a checkpoint restored into a temp worktree and
+    // a second run directory, both made before the upstream was ever looked at.
+    await record();
+    const afterGood = (await listRuns(workspace)).length;
+    await expect(
+      replayCommand(
+        parseArgs([
+          'replay',
+          'last',
+          '--from',
+          '1',
+          '--model',
+          'gpt-5.2',
+          '--upstream-openai',
+          BAD,
+        ]),
+        out,
+        workspace,
+      ),
+    ).rejects.toThrow(/is not an origin orca can use/);
+    expect((await listRuns(workspace)).length, 'a refused fork must not have created a run').toBe(
+      afterGood,
+    );
+  });
+
+  /**
    * The one line a reader checks to know whether a run can spend money.
    *
    * `egress` was a literal, so `--loose` — which answers an unmatched request from the provider —

--- a/packages/cli/test/tls-intercept.test.ts
+++ b/packages/cli/test/tls-intercept.test.ts
@@ -6,7 +6,7 @@ import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { TraceReader } from '@orcareplay/core';
+import { TraceReader, listRuns } from '@orcareplay/core';
 import { RunCa } from '@orcareplay/proxy';
 import { validateEvent } from '@orcareplay/schema';
 import { parseArgs } from '../src/args.js';
@@ -230,6 +230,12 @@ describe('orca record --tls-intercept', () => {
     // Rejected before `RunCa.create`, so the run that is not going to happen leaves no private key
     // anywhere under the runs root — the same guarantee `--tls-hosts '*'` already has.
     expect(await grepRunDir(join(workspace, '.orca'), 'PRIVATE KEY')).toEqual([]);
+    // And before `ensureRunsDir`, so there is no runs root either. The key was the urgent half;
+    // this is the rest of it — a refused host list used to leave an empty run for `orca list` to
+    // show, the same way a refused upstream did.
+    expect(await listRuns(workspace), 'a refused host list must not have created a run').toEqual(
+      [],
+    );
   });
 
   /**
@@ -495,11 +501,19 @@ describe('orca record --tls-intercept', () => {
   });
 });
 
-/** Every file under a run directory that contains `needle`. */
+/**
+ * Every file under a run directory that contains `needle`.
+ *
+ * A directory that is not there holds no files, and answering `[]` for it is the honest reading
+ * rather than a convenience: the callers ask whether a refused run left a key behind, and a runs
+ * root that was never created is the strongest possible no. It used to throw ENOENT instead, so
+ * moving the refusal ahead of `ensureRunsDir` failed the very test that asked for it.
+ */
 async function grepRunDir(runDir: string, needle: string): Promise<string[]> {
   const hits: string[] = [];
   const walk = async (dir: string): Promise<void> => {
-    for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const entries = await readdir(dir, { withFileTypes: true }).catch(() => []);
+    for (const entry of entries) {
       const full = join(dir, entry.name);
       if (entry.isDirectory()) {
         await walk(full);


### PR DESCRIPTION
<!-- orca-cr-summary:start -->
<!-- orca-code-review-summary -->
<!-- orca-cr-state: {"p0":0,"p1":0,"p2":0,"p3":0,"push":3} -->

## Orca-Code-Review — push 3

| Severity | Count | Δ vs previous push |
|---|---|---|
| P0 | 0 | 0 |
| P1 | 0 | -2 |
| P2 | 0 | 0 |
| P3 | 0 | 0 |

✅ no blocking findings
<!-- orca-cr-summary:end -->

Follow-up to #58. The guard added there (`upstreamPlan` throws for an upstream that is not an origin) was resolved *after* the run directory already existed in `record`, `attach` and the fork path — the fork after restoring a checkpoint into a temp worktree as well. #58 fixed the severe member of this family, where `orca replay` had already replaced the working tree; these are the quiet ones.

So a typo in `--upstream-*` left an empty run for `orca list` to show, reading `FROM <parent>@<n>` on a fork as though it had run, plus a restored tree abandoned in `$TMPDIR`.

Measured on the built CLI, before and after:

| command with a refused upstream | before | after |
|---|---|---|
| `orca record --upstream-openai myuser:PASSWORD@gw/v1` | 1 run, 5 files, 0 events | nothing |
| `orca replay last --model gpt-5.2 --upstream-openai …` | 1 run, 0 events + a temp worktree | nothing |

Both still refuse, with the same message.

`upstreamPlan` reads only the arguments and the environment, so there was never a reason for it to run later.

Both halves of the new test were mutated independently — moving either call back down fails it, on its own assertion.

---

## Push 2 — the sibling refusal review found (P1)

Review was right, and the finding reproduces. `--tls-hosts` is refused by `resolveTlsHosts`/`HostPolicy.from`, both inside `setupTlsCapture` — which an exact replay reaches *after* `replayWorkspace` has written the recording over the working tree. Measured on the built CLI at this PR's first commit:

```
$ orca replay last --tls-intercept --tls-hosts '*'
info  replay.restored … note="your files are restored when the replay ends"
error replay.failed
      "*" would intercept every host the agent talks to.

working tree   "export const fixed = false;\n"   ← was "MY UNCOMMITTED WORK"
runs           1 → 2
scratch        orca-safety-5HLeC0 abandoned in $TMPDIR
```

The restore only began at the child's launch, so the throw escaped it, and nothing prints the scratch path — `replay.restored` reports a tree id, not a directory.

**Two halves, because hoisting is only ever as complete as the list of things somebody thought of.**

`planTlsCapture` now runs before `replayWorkspace`, and before the run directory in `record` and in the fork — the same three places the first commit fixed for the upstream, plus the checkout. It also reads `ORCA_TLS_UPSTREAM_CA` now: that one needs the disk, so it had been left out of a function meant to decide from the arguments alone, and being left out is exactly why it went on failing late.

And the release is armed for the whole restored span rather than from the child's launch, with a `released` flag so the ordinary path puts the tree back where it always did. Nothing else in that window is on any list — `createProxy` binds a socket, `RunCa.create` writes a key, `adapter.prepare` runs a harness's own setup.

Measured on the built CLI, before and after. Every row still refuses, with the same message and the same exit code:

| refused invocation | before | after |
|---|---|---|
| `replay last --tls-intercept --tls-hosts '*'` | checkout replaced, 1 run, `orca-safety-*` left | nothing |
| `record … --tls-intercept --tls-hosts '*'` | 1 run | nothing |
| `replay last --from 1 --model … --tls-hosts '*'` | 1 run + a temp worktree | nothing |
| `replay last --tls-intercept`, unreadable upstream CA | checkout replaced, 1 run, `orca-safety-*` left | nothing |

The span guard was measured on its own, by injecting a throw after `openReplayTrace` into the built CLI: without it the checkout holds the recording and the scratch is abandoned; with it the tree comes back and the scratch is removed. Each new test was mutated — moving a hoisted call back below the thing it guards fails it, on its own assertion.

One test helper changed: `grepRunDir` threw ENOENT for a runs root that was never created, which failed the very test asking for the refusal to come first. A directory that is not there holds no files.

### Not fixed here

A throw in that same window **past `createProxy`** leaves the proxy listening, so orca prints the error and then hangs until it is killed. Reproduced with a trace naming an adapter this build does not have. The `catch` that closes the proxy begins at the child's launch, the same way the release did — pre-existing, unchanged by this PR (before: hangs *and* clobbers; after: hangs, tree intact), and worth its own commit.

---

Full suite 2012 passed / 23 failed, the failure set identical to main's own baseline on this machine (Windows: POSIX modes, SIGTERM, symlinks); conformance 57 events 0 failures; fidelity 0 regressions; plugin neutrality 0; integrations 9 checked, 0 failed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
