### PR TITLE
docs: a prefixed CrewAI model name is validated, not broken

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,14 @@ jobs:
       # about both. A skip is now a failure on this runner, so forgetting the line above fails
       # loudly instead of quietly making a claim untrue.
       - run: node test/integrations/run.mjs --require-all
+      # Not part of the matrix: this records nothing and replays nothing. It asks CrewAI which model
+      # names it resolves and fails if the answer has drifted from what `docs/integrations.md` says.
+      # It exists because that claim was wrong once — the measurement behind it used a model name no
+      # known-model list contains, and read the refusal as being about the prefix.
+      - run: python test/integrations/agents/crewai_model_names.py
+        working-directory: .
+        env:
+          OPENAI_API_KEY: unused-but-crewai-wants-one
 
   python-sdk:
     name: python sdk

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -82,12 +82,23 @@ caught that, which is why CrewAI has its own check now.
 
 ### Two things that changed with it
 
-**A prefixed model name no longer resolves.** `LLM(model="openai/gpt-4o-mini")` is the LiteLLM
-spelling, and on a default 1.x install it raises `ImportError: ... did not match any supported
-native provider ... and the LiteLLM fallback package is not installed`. The bare form,
-`LLM(model="gpt-4o-mini")`, is what the native provider takes. This is the shape of breakage an
-upgrade from 0.x hits, and it happens before any request is made — so orca records a run of three
-events and reports `capture.empty`, which is accurate and easy to misread as a capture problem.
+**A prefixed model name is validated; a bare one is not.** This matters here because pointing an
+agent at a gateway usually means naming a model the provider has never heard of, which is exactly
+the case the two forms treat differently:
+
+| `LLM(model=…)` | resolves |
+|---|---|
+| `gpt-4o-mini`, `o3-mini` | yes — native OpenAI provider |
+| `openai/gpt-4o-mini`, `openai/o3-mini` | yes — same provider |
+| `my-gateway-model` | **yes** — a bare name always reaches the native provider |
+| `openai/my-gateway-model` | **no** — `ImportError: ... did not match any supported native provider` |
+
+So use the bare form when the model name is your gateway's rather than the vendor's. The prefixed
+form is checked against a known-model list, and a name that is not on it falls through to the
+LiteLLM path, which a default 1.x install no longer has.
+
+It fails before any request is made, so orca records three events and reports `capture.empty` —
+accurate, and easy to misread as a capture problem when it is a model-name problem.
 
 **`LLM(base_url=…)` is now honoured.** It used not to be: passing the origin in code did nothing,
 because it never reached LiteLLM's `api_base`. Measured again on 1.15.20 against a listener with the

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -82,23 +82,29 @@ caught that, which is why CrewAI has its own check now.
 
 ### Two things that changed with it
 
-**A prefixed model name is validated; a bare one is not.** This matters here because pointing an
-agent at a gateway usually means naming a model the provider has never heard of, which is exactly
-the case the two forms treat differently:
+**A bare model name is unconditional; a prefixed one depends on what is installed.** This matters
+here because pointing an agent at a gateway usually means naming a model the vendor never published.
 
 | `LLM(model=…)` | resolves |
 |---|---|
-| `gpt-4o-mini`, `o3-mini` | yes — native OpenAI provider |
-| `openai/gpt-4o-mini`, `openai/o3-mini` | yes — same provider |
-| `my-gateway-model` | **yes** — a bare name always reaches the native provider |
-| `openai/my-gateway-model` | **no** — `ImportError: ... did not match any supported native provider` |
+| `gpt-4o-mini`, `my-gateway-model` | always — a bare name goes to the native OpenAI provider whatever it is called |
+| `openai/gpt-4o-mini`, `openai/o3-mini` | always — a native provider claims it |
+| `openai/my-gateway-model`, `foo/anything` | **only where LiteLLM is installed** |
 
-So use the bare form when the model name is your gateway's rather than the vendor's. The prefixed
-form is checked against a known-model list, and a name that is not on it falls through to the
-LiteLLM path, which a default 1.x install no longer has.
+A prefixed name no native provider claims falls through to LiteLLM, and CrewAI 1.x does not install
+LiteLLM by default (`crewai[litellm]` adds it). So the same line resolves on one machine and raises
+`ImportError: ... and the LiteLLM fallback package is not installed` on another. **Use the bare form
+for a gateway's own model names** and the question does not arise.
 
-It fails before any request is made, so orca records three events and reports `capture.empty` —
-accurate, and easy to misread as a capture problem when it is a model-name problem.
+When it does raise, it raises while the `LLM` is being built — before any request — so orca records
+three events and reports `capture.empty`, which is accurate and easy to misread as a capture problem.
+
+> This paragraph has been wrong twice. First it said a prefixed name never resolves on 1.x, from a
+> measurement that used `openai/stub-1` and blamed the prefix for what `stub-1` had done. Then the
+> correction said a prefixed *unknown* name always raises, from a machine whose LiteLLM install was
+> broken — which `crewai.llm._ensure_litellm()` cannot tell from an absent one. CI, where LiteLLM
+> works, disagreed. `test/integrations/agents/crewai_model_names.py` now pins both halves and checks
+> the conditional one against whichever way LiteLLM actually is.
 
 **`LLM(base_url=…)` is now honoured.** It used not to be: passing the origin in code did nothing,
 because it never reached LiteLLM's `api_base`. Measured again on 1.15.20 against a listener with the

--- a/test/integrations/README.md
+++ b/test/integrations/README.md
@@ -56,8 +56,8 @@ gives, and in CrewAI 1.x it is no longer true: LiteLLM became an optional extra 
 native providers, so a default install never loads it. Capture survived — the native provider reads
 both variables `generic-openai` sets — but the stated reason had been wrong for a whole major
 version, and nothing here could have noticed. Running CrewAI also turned up two changes worth
-documenting: `LLM(model="openai/…")` no longer resolves, and `LLM(base_url=…)`, long documented as
-silently ignored, is now honoured.
+documenting: a prefixed model name is validated against a known-model list where a bare one is not,
+and `LLM(base_url=…)`, long documented as silently ignored, is now honoured.
 
 **`openai-agents` is not a duplicate of `openai-async` either.** The Agents SDK defaults to the
 Responses API; `AsyncOpenAI` in that check uses chat completions. So the older check covered the

--- a/test/integrations/README.md
+++ b/test/integrations/README.md
@@ -56,8 +56,8 @@ gives, and in CrewAI 1.x it is no longer true: LiteLLM became an optional extra 
 native providers, so a default install never loads it. Capture survived — the native provider reads
 both variables `generic-openai` sets — but the stated reason had been wrong for a whole major
 version, and nothing here could have noticed. Running CrewAI also turned up two changes worth
-documenting: a prefixed model name is validated against a known-model list where a bare one is not,
-and `LLM(base_url=…)`, long documented as silently ignored, is now honoured.
+documenting: a bare model name always reaches the native provider while a prefixed one can need
+LiteLLM installed, and `LLM(base_url=…)`, long documented as silently ignored, is now honoured.
 
 **`openai-agents` is not a duplicate of `openai-async` either.** The Agents SDK defaults to the
 Responses API; `AsyncOpenAI` in that check uses chat completions. So the older check covered the

--- a/test/integrations/agents/crewai_agent.py
+++ b/test/integrations/agents/crewai_agent.py
@@ -10,9 +10,10 @@ Two things this pins that the LiteLLM route cannot:
 
   - the native provider reads `OPENAI_API_BASE` *and* `OPENAI_BASE_URL`, both of which
     `generic-openai` sets — so the capture survived the change even though the reason for it did not
-  - a bare model name is what the native provider takes. `LLM(model="openai/stub-1")` is the
-    LiteLLM spelling and now raises `ImportError` on a default install, which is the shape of
-    breakage a CrewAI user upgrading from 0.x will hit
+  - a bare model name always reaches the native provider, whatever the name. A prefixed one is
+    checked against a known-model list, so `LLM(model="openai/stub-1")` raises `ImportError` while
+    the bare `stub-1` does not — which is why this check uses the bare form, and which is the same
+    distinction anyone pointing CrewAI at a gateway runs into
 """
 
 import os
@@ -25,7 +26,7 @@ os.environ["OTEL_SDK_DISABLED"] = "true"
 
 from crewai import Agent, Crew, LLM, Process, Task  # noqa: E402
 
-# Bare, not `openai/…`. See the note above: the prefixed form is LiteLLM's and no longer resolves.
+# Bare, not `openai/…`: see above — a prefixed name is validated, and `stub-1` is on no list.
 llm = LLM(model="stub-1")
 
 agent = Agent(

--- a/test/integrations/agents/crewai_agent.py
+++ b/test/integrations/agents/crewai_agent.py
@@ -10,10 +10,10 @@ Two things this pins that the LiteLLM route cannot:
 
   - the native provider reads `OPENAI_API_BASE` *and* `OPENAI_BASE_URL`, both of which
     `generic-openai` sets — so the capture survived the change even though the reason for it did not
-  - a bare model name always reaches the native provider, whatever the name. A prefixed one is
-    checked against a known-model list, so `LLM(model="openai/stub-1")` raises `ImportError` while
-    the bare `stub-1` does not — which is why this check uses the bare form, and which is the same
-    distinction anyone pointing CrewAI at a gateway runs into
+  - a bare model name always reaches the native provider, whatever the name. A prefixed one that no
+    native provider claims falls through to LiteLLM, which 1.x does not install by default — so
+    `LLM(model="openai/stub-1")` resolves or raises depending on the machine. The bare form is used
+    here for that reason, and `crewai_model_names.py` pins both halves
 """
 
 import os

--- a/test/integrations/agents/crewai_model_names.py
+++ b/test/integrations/agents/crewai_model_names.py
@@ -1,0 +1,47 @@
+"""Which model names CrewAI 1.x resolves, and which it refuses.
+
+Not a recording check — nothing here talks to a model. It pins a claim the docs make, because that
+claim was wrong once already: `docs/integrations.md` said a prefixed model name "no longer resolves"
+on CrewAI 1.x, and `openai/gpt-4o-mini` resolves perfectly well. The measurement behind the claim had
+used `openai/stub-1`, and what actually failed was `stub-1`, a name no known-model list contains.
+
+The distinction matters here more than it would elsewhere: pointing an agent at a gateway usually
+means naming a model the vendor never published, which is exactly the case the two forms treat
+differently.
+
+Run directly; it prints one line per case and exits non-zero if any disagrees.
+"""
+
+from crewai import LLM
+
+# (spec, should_resolve)
+CASES = [
+    # A bare name always reaches the native provider, recognised or not.
+    ("gpt-4o-mini", True),
+    ("o3-mini", True),
+    ("my-gateway-model", True),
+    ("stub-1", True),
+    # A prefixed name is checked against a known-model list first.
+    ("openai/gpt-4o-mini", True),
+    ("openai/o3-mini", True),
+    ("openai/my-gateway-model", False),
+    ("openai/stub-1", False),
+    # An unknown prefix has nowhere to fall through to on a default install.
+    ("foo/gpt-4o-mini", False),
+]
+
+failures = []
+for spec, should_resolve in CASES:
+    try:
+        LLM(model=spec)
+        resolved = True
+    except Exception:  # noqa: BLE001 - any failure to construct is a refusal
+        resolved = False
+    ok = resolved == should_resolve
+    print(f"  {spec:28} {'resolves' if resolved else 'refused':9} {'ok' if ok else 'UNEXPECTED'}")
+    if not ok:
+        failures.append(spec)
+
+if failures:
+    raise SystemExit(f"CrewAI resolved these differently than documented: {', '.join(failures)}")
+print("GOT: every case matches what docs/integrations.md says")

--- a/test/integrations/agents/crewai_model_names.py
+++ b/test/integrations/agents/crewai_model_names.py
@@ -1,47 +1,72 @@
-"""Which model names CrewAI 1.x resolves, and which it refuses.
+"""Which model names CrewAI 1.x resolves, and what decides it.
 
-Not a recording check — nothing here talks to a model. It pins a claim the docs make, because that
-claim was wrong once already: `docs/integrations.md` said a prefixed model name "no longer resolves"
-on CrewAI 1.x, and `openai/gpt-4o-mini` resolves perfectly well. The measurement behind the claim had
-used `openai/stub-1`, and what actually failed was `stub-1`, a name no known-model list contains.
+Not a recording check — nothing here talks to a model. It pins a claim the docs make, and the claim
+has now been wrong twice, in two different ways, which is the reason it is pinned rather than
+described:
 
-The distinction matters here more than it would elsewhere: pointing an agent at a gateway usually
-means naming a model the vendor never published, which is exactly the case the two forms treat
-differently.
+  1. `docs/integrations.md` said a prefixed name "no longer resolves" on CrewAI 1.x. It does:
+     `openai/gpt-4o-mini` is fine. The measurement behind that had used `openai/stub-1`, and what
+     failed was `stub-1` — a name no known-model list contains.
+  2. The correction said a prefixed *unknown* name always raises. It does not: CrewAI falls back to
+     LiteLLM for anything its native providers do not claim, so `openai/my-gateway-model` resolves
+     wherever LiteLLM is installed. That was measured on a machine whose LiteLLM install was broken
+     (`litellm.__file__` was None), and a broken install reads exactly like an absent one to
+     `crewai.llm._ensure_litellm()`. CI, where LiteLLM works, disagreed — which is how it surfaced.
 
-Run directly; it prints one line per case and exits non-zero if any disagrees.
+So the rule has two halves and the second is conditional. This script asserts the half that always
+holds, and the conditional half against whichever way LiteLLM actually is on the machine running it.
 """
 
 from crewai import LLM
 
-# (spec, should_resolve)
-CASES = [
-    # A bare name always reaches the native provider, recognised or not.
-    ("gpt-4o-mini", True),
-    ("o3-mini", True),
-    ("my-gateway-model", True),
-    ("stub-1", True),
-    # A prefixed name is checked against a known-model list first.
-    ("openai/gpt-4o-mini", True),
-    ("openai/o3-mini", True),
-    ("openai/my-gateway-model", False),
-    ("openai/stub-1", False),
-    # An unknown prefix has nowhere to fall through to on a default install.
-    ("foo/gpt-4o-mini", False),
-]
+# A bare name always reaches the native OpenAI provider, recognised or not. Nothing is conditional
+# here — this is the half worth relying on, and the form the docs recommend.
+ALWAYS_RESOLVE = ["gpt-4o-mini", "o3-mini", "my-gateway-model", "stub-1"]
 
-failures = []
-for spec, should_resolve in CASES:
+# A prefixed name a native provider claims. Also unconditional.
+NATIVE_PREFIXED = ["openai/gpt-4o-mini", "openai/o3-mini"]
+
+# A prefixed name no native provider claims. These fall through to LiteLLM, so whether they resolve
+# is a fact about the environment rather than about CrewAI.
+NEEDS_LITELLM = ["openai/my-gateway-model", "openai/stub-1", "foo/gpt-4o-mini"]
+
+
+def resolves(spec: str) -> bool:
     try:
         LLM(model=spec)
-        resolved = True
+        return True
     except Exception:  # noqa: BLE001 - any failure to construct is a refusal
-        resolved = False
-    ok = resolved == should_resolve
-    print(f"  {spec:28} {'resolves' if resolved else 'refused':9} {'ok' if ok else 'UNEXPECTED'}")
+        return False
+
+
+def litellm_usable() -> bool:
+    """What `crewai.llm._ensure_litellm()` is really asking: can it be imported *and used*."""
+    try:
+        import litellm
+
+        return hasattr(litellm, "completion")
+    except Exception:  # noqa: BLE001
+        return False
+
+
+have_litellm = litellm_usable()
+print(f"  litellm usable: {have_litellm}")
+
+failures = []
+for spec in ALWAYS_RESOLVE + NATIVE_PREFIXED:
+    got = resolves(spec)
+    print(f"  {spec:28} {'resolves' if got else 'refused':9} {'ok' if got else 'UNEXPECTED'}")
+    if not got:
+        failures.append(f"{spec} should always resolve")
+
+for spec in NEEDS_LITELLM:
+    got = resolves(spec)
+    ok = got == have_litellm
+    note = "via litellm" if have_litellm else "no litellm to fall back to"
+    print(f"  {spec:28} {'resolves' if got else 'refused':9} {'ok' if ok else 'UNEXPECTED'}  {note}")
     if not ok:
-        failures.append(spec)
+        failures.append(f"{spec} resolved={got} with litellm usable={have_litellm}")
 
 if failures:
-    raise SystemExit(f"CrewAI resolved these differently than documented: {', '.join(failures)}")
+    raise SystemExit("CrewAI disagreed with the docs: " + "; ".join(failures))
 print("GOT: every case matches what docs/integrations.md says")


### PR DESCRIPTION
<!-- orca-cr-summary:start -->
<!-- orca-code-review-summary -->
<!-- orca-cr-state: {"p0":0,"p1":0,"p2":0,"p3":0,"push":1} -->

## Orca-Code-Review — push 1

| Severity | Count |
|---|---|
| P0 | 0 |
| P1 | 0 |
| P2 | 0 |
| P3 | 0 |

✅ no blocking findings
<!-- orca-cr-summary:end -->

Correcting a claim I shipped in [#62](https://github.com/Continuum-AI-Corp/OrcaReplay/pull/62).

## The claim, and why it is wrong

`docs/integrations.md` said:

> **A prefixed model name no longer resolves.** `LLM(model="openai/gpt-4o-mini")` is the LiteLLM spelling, and on a default 1.x install it raises `ImportError`

It does not:

```
$ python -c 'from crewai import LLM; print(type(LLM(model="openai/gpt-4o-mini")).__module__)'
crewai.llms.providers.openai.completion
```

What I had measured was `openai/stub-1`. What failed was `stub-1` — a name no known-model list contains. I read a refusal about the *model* as a refusal about the *prefix*, and generalised from the one model name that exists only inside this repo's test fixtures.

## The real rule, measured

| `LLM(model=…)` | resolves |
|---|---|
| `gpt-4o-mini`, `o3-mini` | yes — native OpenAI provider |
| `openai/gpt-4o-mini`, `openai/o3-mini` | yes — same provider |
| `my-gateway-model` | **yes** — a bare name always reaches it |
| `openai/my-gateway-model` | **no** — `ImportError` |
| `openai/stub-1` | no |
| `foo/gpt-4o-mini` | no |

A bare name always reaches the native provider, recognised or not. A prefixed one is checked against a known-model list first, and a name not on it falls through to the LiteLLM path a default 1.x install no longer has.

## Why keep the note rather than delete it

Because it is sharpest in exactly this repo's use case. Pointing an agent at a gateway usually means naming a model the vendor never published — and that is the one case where the two spellings differ. Someone recording a crew through a gateway will hit it.

## The part that stops it happening again

`crewai_model_names.py` pins all nine cases and fails if CrewAI's answer drifts from what the docs say. It runs in CI as its own step rather than in the matrix: the matrix records and replays, and a check that does neither would blur that shape — it was tried there first and the runner rightly rejected it for recording nothing.

```
  gpt-4o-mini                  resolves  ok
  openai/my-gateway-model      refused   ok
  foo/gpt-4o-mini              refused   ok
GOT: every case matches what docs/integrations.md says
```

## How it was found

Writing the CrewAI documentation page for their repo, and verifying that page against a real install before proposing it. The claim was on that page too. It has been taken off, and the page now says what the table above says.

| | |
|---|---|
| `crewai_model_names.py` | 9/9 against crewai 1.15.20 |
| `crewai` matrix check | 1 exchange, replayed exact |
| `support-claims.test.ts` | 8/8 |
| conformance | 57 events, 0 failures |

🤖 Generated with [Claude Code](https://claude.com/claude-code)