### PR TITLE
publish main to npm, on a channel nobody is opted in to

### DIFF
--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -1,0 +1,118 @@
+# Publish main to npm under the `next` tag, so what is on main is always installable.
+#
+#     npm i orcareplay          # latest — a tagged release, unchanged by this workflow
+#     npm i orcareplay@next     # whatever main is right now
+#
+# Every version published here is a prerelease — `0.2.4-main.<sha>`. npm excludes a prerelease from
+# `npm install <pkg>` even though it sorts above `0.2.3`, so nothing here can reach someone who did
+# not ask for it by name, and `--tag next` never moves `latest`. That is what makes publishing on
+# every merge safe: main is always available, and no user is opted in to it.
+#
+# The version is derived from the commit, never committed back. Bumping a version in main to publish
+# from main would mean a bot with write access to the default branch and a push race between two
+# merges a minute apart; a `<next-patch>-main.<sha>` needs neither, and is unique by construction —
+# which matters because npm never allows re-publishing a version.
+name: Publish next
+
+# After CI, not on the push itself.
+#
+# CI already runs fmt, tsc, the suite on node 20 and 22, conformance, the framework integrations,
+# the Python SDK and plugin neutrality on every push to main. Re-running that here would double it
+# on a repository that merges several pull requests a day, and a second copy of the gate is a second
+# thing to keep in step. `workflow_run` also makes the rule structural rather than remembered:
+# nothing is published unless the checks for that exact commit went green.
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Pack and verify without publishing'
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  id-token: write # npm provenance: proves the tarball came from this workflow, from this commit
+
+# Queued, never cancelled. Twelve packages are published one at a time in dependency order, so
+# cancelling half way leaves some of them on the registry at a version the rest do not name — and
+# npm will not let that version be re-published to fix it. A burst of merges therefore publishes a
+# prerelease each, in order, rather than racing.
+concurrency:
+  group: publish-next
+  cancel-in-progress: false
+
+jobs:
+  next:
+    # A failed or cancelled CI run must publish nothing. `workflow_run` fires for those too.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      # The commit CI passed on, not whatever main has moved to since. `workflow_run` checks out
+      # the default branch by default, which would publish code the green tick did not cover.
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: npm ci
+      # The published tarballs contain `dist/`, which is not committed.
+      - run: npx tsc --build
+
+      - name: Work out the prerelease version
+        id: version
+        run: |
+          set -euo pipefail
+          sha="${{ github.event.workflow_run.head_sha || github.sha }}"
+          # The next patch, so a prerelease always sorts *above* the release it follows: main is
+          # ahead of `latest`, and `0.2.3-main.x` would sort below `0.2.3` and say the opposite.
+          base=$(node -p "require('./packages/cli/package.json').version.split('-')[0]")
+          next=$(node -p "const v='$base'.split('.'); v[2]=Number(v[2])+1; v.join('.')")
+          version="$next-main.${sha:0:7}"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "publishing $version from ${sha:0:7}"
+
+      - name: Set it across every workspace
+        run: node scripts/set-version.mjs "${{ steps.version.outputs.version }}"
+
+      # The same gate the tagged release runs: it recomputes the publish order and fails if an
+      # internal pin was left naming the old version, which is the one way `set-version.mjs` could
+      # be wrong in a way npm cannot undo.
+      - run: node scripts/publish-order.mjs
+
+      - name: Publish in dependency order
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          DRY_RUN: ${{ github.event.inputs.dry-run }}
+        run: |
+          set -euo pipefail
+          node scripts/publish-order.mjs | while read -r dir; do
+            if [ "${DRY_RUN:-false}" = "true" ]; then
+              echo "── dry run: $dir"
+              ( cd "$dir" && npm publish --dry-run --provenance --access public --tag next )
+            else
+              echo "── publishing: $dir"
+              ( cd "$dir" && npm publish --provenance --access public --tag next )
+            fi
+          done
+
+      - name: Say what to install
+        if: ${{ github.event.inputs.dry-run != 'true' }}
+        run: |
+          echo "### \`orcareplay@next\` is now ${{ steps.version.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
+          echo '' >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          echo 'npm i orcareplay@next' >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          echo '' >> "$GITHUB_STEP_SUMMARY"
+          echo '`latest` is unchanged — it only moves on a tagged release.' >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -3,14 +3,14 @@
 #     npm i orcareplay          # latest — a tagged release, unchanged by this workflow
 #     npm i orcareplay@next     # whatever main is right now
 #
-# Every version published here is a prerelease — `0.2.4-main.<sha>`. npm excludes a prerelease from
+# Every version published here is a prerelease — `0.2.4-main.g<sha>`. npm excludes a prerelease from
 # `npm install <pkg>` even though it sorts above `0.2.3`, so nothing here can reach someone who did
 # not ask for it by name, and `--tag next` never moves `latest`. That is what makes publishing from
 # main safe at all: main is always available, and no user is opted in to it.
 #
 # The version is derived from the commit, never committed back. Bumping a version in main to publish
 # from main would mean a bot with write access to the default branch and a push race between two
-# merges a minute apart; a `<next-patch>-main.<sha>` needs neither, and is unique by construction —
+# merges a minute apart; a `<next-patch>-main.g<sha>` needs neither, and is unique by construction —
 # which matters because npm never allows re-publishing a version.
 name: Publish next
 
@@ -40,9 +40,13 @@ on:
         type: boolean
         default: true
 
-permissions:
-  contents: read
-  id-token: write # npm provenance: proves the tarball came from this workflow, from this commit
+# Declared per job rather than here, because `permissions:` is not additive: "if you specify the
+# access for any of these permissions, all of those that are not specified are set to `none`". So a
+# block naming only `contents` and `id-token` gives `pick` `actions: none`, and its `gh run list`
+# call — `GET /repos/{owner}/{repo}/actions/runs` — comes back 403. Under `set -euo pipefail` that
+# fails `pick`, and `next` needs it, so nothing would ever reach the `next` tag. Running the same
+# shell locally cannot catch this: a developer's `gh auth` token is full-scope.
+permissions: {}
 
 # Queued, never cancelled. Twelve packages are published one at a time in dependency order, so
 # cancelling half way leaves some of them on the registry at a version the rest do not name — and
@@ -62,6 +66,9 @@ jobs:
   # number is exactly the version-count cost this schedule exists to avoid.
   pick:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # checkout main, and read its history for the ancestry check
+      actions: read # `gh run list`, to find the newest commit on main that CI passed
     outputs:
       sha: ${{ steps.pick.outputs.sha }}
       version: ${{ steps.pick.outputs.version }}
@@ -113,7 +120,16 @@ jobs:
           base=$(git show "$sha:packages/cli/package.json" | node -p \
                    "JSON.parse(require('fs').readFileSync(0,'utf8')).version.split('-')[0]")
           next=$(node -p "const v='$base'.split('.'); v[2]=Number(v[2])+1; v.join('.')")
-          version="$next-main.${sha:0:7}"
+          # `g` before the sha, git-describe style, so the identifier always contains a letter.
+          #
+          # A prerelease identifier that is all digits may not have a leading zero, and about one
+          # commit in 270 has a short sha like `0123456`. `npm publish` does not refuse that
+          # version: it rewrites it to `0.2.4-main.123456` with a warning and leaves every
+          # dependency pin naming `0.2.4-main.0123456`, so twelve packages go out declaring a
+          # version that does not exist — permanently, because npm never replaces a version.
+          # `set-version.mjs` and `publish-order.mjs` now refuse it too, but refusing would only
+          # turn the daily run red; the prefix is what stops it arising.
+          version="$next-main.g${sha:0:7}"
 
           echo "sha=$sha" >> "$GITHUB_OUTPUT"
           echo "version=$version" >> "$GITHUB_OUTPUT"
@@ -138,6 +154,9 @@ jobs:
     needs: pick
     if: needs.pick.outputs.publish == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # npm provenance: proves the tarball came from this workflow, from this commit
     steps:
       # The commit CI passed on, not whatever main has moved to since.
       - uses: actions/checkout@v4

--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -5,8 +5,8 @@
 #
 # Every version published here is a prerelease — `0.2.4-main.<sha>`. npm excludes a prerelease from
 # `npm install <pkg>` even though it sorts above `0.2.3`, so nothing here can reach someone who did
-# not ask for it by name, and `--tag next` never moves `latest`. That is what makes publishing on
-# every merge safe: main is always available, and no user is opted in to it.
+# not ask for it by name, and `--tag next` never moves `latest`. That is what makes publishing from
+# main safe at all: main is always available, and no user is opted in to it.
 #
 # The version is derived from the commit, never committed back. Bumping a version in main to publish
 # from main would mean a bot with write access to the default branch and a push race between two
@@ -14,18 +14,25 @@
 # which matters because npm never allows re-publishing a version.
 name: Publish next
 
-# After CI, not on the push itself.
+# Once a day, not once a merge.
 #
-# CI already runs fmt, tsc, the suite on node 20 and 22, conformance, the framework integrations,
-# the Python SDK and plugin neutrality on every push to main. Re-running that here would double it
-# on a repository that merges several pull requests a day, and a second copy of the gate is a second
-# thing to keep in step. `workflow_run` also makes the rule structural rather than remembered:
-# nothing is published unless the checks for that exact commit went green.
+# A version is not free: npm serves a *packument* — the metadata document for every version of a
+# package — on every install, and it grows with the version count. `orcareplay` is 20 KB at seven
+# versions; `typescript` is 15.6 MB at 3820, which is roughly 4 KB each and is a real install-time
+# cost paid by everyone, including people who only ever ask for `latest`. Publishing on every merge
+# at eight pull requests a day would add ~2900 versions a year and put this package in that
+# territory inside twelve months. Daily is an eighth of that, and it is what `typescript` itself
+# does for its own `-dev` builds.
+#
+# The cost is that `next` can be up to a day behind main. `workflow_dispatch` covers the case where
+# that is not good enough: run it by hand and main is on npm in a couple of minutes.
+#
+# 04:00 UTC is noon in Beijing. GitHub's cron is UTC only, and it is best-effort — a scheduled run
+# is commonly minutes late and can be dropped under load, so treat this as "some time after noon"
+# rather than as a clock. For noon UTC instead, this is `0 12 * * *`.
 on:
-  workflow_run:
-    workflows: [CI]
-    types: [completed]
-    branches: [main]
+  schedule:
+    - cron: '0 4 * * *'
   workflow_dispatch:
     inputs:
       dry-run:
@@ -39,25 +46,78 @@ permissions:
 
 # Queued, never cancelled. Twelve packages are published one at a time in dependency order, so
 # cancelling half way leaves some of them on the registry at a version the rest do not name — and
-# npm will not let that version be re-published to fix it. A burst of merges therefore publishes a
-# prerelease each, in order, rather than racing.
+# npm will not let that version be re-published to fix it. A hand-run that overlaps the schedule
+# therefore waits rather than racing it.
 concurrency:
   group: publish-next
   cancel-in-progress: false
 
 jobs:
-  next:
-    # A failed or cancelled CI run must publish nothing. `workflow_run` fires for those too.
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success'
+  # Which commit, and whether it is worth publishing at all.
+  #
+  # A schedule knows neither, and both matter. `main` at 04:00 may be a commit whose checks are
+  # still running or already red, so this asks for the newest commit on main that CI actually
+  # passed — the guarantee `workflow_run` would have given for free. And on a day when nothing
+  # merged, that commit is the one already on `next`: republishing an identical tree under a new
+  # number is exactly the version-count cost this schedule exists to avoid.
+  pick:
     runs-on: ubuntu-latest
+    outputs:
+      sha: ${{ steps.pick.outputs.sha }}
+      version: ${{ steps.pick.outputs.version }}
+      publish: ${{ steps.pick.outputs.publish }}
     steps:
-      # The commit CI passed on, not whatever main has moved to since. `workflow_run` checks out
-      # the default branch by default, which would publish code the green tick did not cover.
+      # Full history: the newest green commit is usually main's tip but need not be, and a shallow
+      # clone would not contain it for the `git show` below.
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          ref: main
+          fetch-depth: 0
+
+      - id: pick
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # Newest first, so the first success is the newest one.
+          sha=$(gh run list --workflow=CI --branch=main --status=success \
+                  --limit 20 --json headSha --jq '.[0].headSha // empty')
+          if [ -z "$sha" ]; then
+            echo "no successful CI run on main to publish" >&2
+            exit 1
+          fi
+
+          # The next patch, so a prerelease sorts *above* the release it follows: main is ahead of
+          # `latest`, and `0.2.3-main.x` would sort below `0.2.3` and say the opposite.
+          base=$(git show "$sha:packages/cli/package.json" | node -p \
+                   "JSON.parse(require('fs').readFileSync(0,'utf8')).version.split('-')[0]")
+          next=$(node -p "const v='$base'.split('.'); v[2]=Number(v[2])+1; v.join('.')")
+          version="$next-main.${sha:0:7}"
+
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+          # Asking npm rather than tracking state: it is the thing that would reject a duplicate,
+          # and it stays right across a re-run, a hand-run minutes after the schedule, and a day
+          # with no merges.
+          if npm view "orcareplay@$version" version >/dev/null 2>&1; then
+            echo "orcareplay@$version is already published — nothing new on main"
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "publishing $version from ${sha:0:7}"
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  next:
+    needs: pick
+    if: needs.pick.outputs.publish == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      # The commit CI passed on, not whatever main has moved to since.
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.pick.outputs.sha }}
 
       - uses: actions/setup-node@v4
         with:
@@ -69,21 +129,8 @@ jobs:
       # The published tarballs contain `dist/`, which is not committed.
       - run: npx tsc --build
 
-      - name: Work out the prerelease version
-        id: version
-        run: |
-          set -euo pipefail
-          sha="${{ github.event.workflow_run.head_sha || github.sha }}"
-          # The next patch, so a prerelease always sorts *above* the release it follows: main is
-          # ahead of `latest`, and `0.2.3-main.x` would sort below `0.2.3` and say the opposite.
-          base=$(node -p "require('./packages/cli/package.json').version.split('-')[0]")
-          next=$(node -p "const v='$base'.split('.'); v[2]=Number(v[2])+1; v.join('.')")
-          version="$next-main.${sha:0:7}"
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "publishing $version from ${sha:0:7}"
-
-      - name: Set it across every workspace
-        run: node scripts/set-version.mjs "${{ steps.version.outputs.version }}"
+      - name: Set the version across every workspace
+        run: node scripts/set-version.mjs "${{ needs.pick.outputs.version }}"
 
       # The same gate the tagged release runs: it recomputes the publish order and fails if an
       # internal pin was left naming the old version, which is the one way `set-version.mjs` could
@@ -109,7 +156,7 @@ jobs:
       - name: Say what to install
         if: ${{ github.event.inputs.dry-run != 'true' }}
         run: |
-          echo "### \`orcareplay@next\` is now ${{ steps.version.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "### \`orcareplay@next\` is now ${{ needs.pick.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
           echo '' >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
           echo 'npm i orcareplay@next' >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -80,11 +80,31 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Newest first, so the first success is the newest one.
-          sha=$(gh run list --workflow=CI --branch=main --status=success \
+          # `--event=push`, and then checked again against main's history.
+          #
+          # `--branch` filters on a run's *head branch*, which for a pull request is the branch the
+          # PR came from — a fork's branch, named whatever its author chose. `ci.yml` runs on
+          # `pull_request`, so a fork PR from a branch called `main` produces a successful CI run
+          # whose head branch is `main`, and `--branch=main --status=success` would return it. This
+          # job would then publish a contributor's unmerged tree to `next` with `NPM_TOKEN` and
+          # provenance, and `npm i orcareplay@next` — which RELEASING.md tells people to use —
+          # would install it.
+          #
+          # `--event=push` is what makes the selection right: CI's push trigger is
+          # `branches: [main]`, and only this repository can push to it. `gh run list` cannot
+          # filter on the head repository (it does not expose the field), so the ancestry check
+          # below is the one that does not depend on reading GitHub's event semantics correctly.
+          sha=$(gh run list --workflow=CI --branch=main --event=push --status=success \
                   --limit 20 --json headSha --jq '.[0].headSha // empty')
           if [ -z "$sha" ]; then
             echo "no successful CI run on main to publish" >&2
+            exit 1
+          fi
+
+          # HEAD is main, checked out above with full history. A commit that is not in main's
+          # history is not main, whatever any filter said about it.
+          if ! git merge-base --is-ancestor "$sha" HEAD; then
+            echo "$sha is not an ancestor of main — refusing to publish it" >&2
             exit 1
           fi
 

--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -118,9 +118,14 @@ jobs:
           echo "sha=$sha" >> "$GITHUB_OUTPUT"
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
-          # Asking npm rather than tracking state: it is the thing that would reject a duplicate,
-          # and it stays right across a re-run, a hand-run minutes after the schedule, and a day
-          # with no merges.
+          # `orcareplay` is published *last*, so its presence means the previous run got all the
+          # way through: this is a completion check, not a progress one. An unfinished run looks
+          # identical to one that never started, which is fine here and is why the publish step
+          # asks about each package for itself.
+          #
+          # Asking npm rather than keeping state, because npm is the thing that would reject a
+          # duplicate — so the answer stays right across a re-run, a hand-run minutes after the
+          # schedule, and a day on which nothing merged.
           if npm view "orcareplay@$version" version >/dev/null 2>&1; then
             echo "orcareplay@$version is already published — nothing new on main"
             echo "publish=false" >> "$GITHUB_OUTPUT"
@@ -157,20 +162,40 @@ jobs:
       # be wrong in a way npm cannot undo.
       - run: node scripts/publish-order.mjs
 
+      # Resumable, because a partial publish cannot be undone.
+      #
+      # Twelve packages go one at a time and the loop stops where it fails, so a transient npm 5xx
+      # at package five leaves five versions on the registry permanently. Restarting from the top
+      # then dies immediately on E403 — npm refuses to replace a version, which is the property this
+      # whole design leans on — and every later run fails the same way, so that commit never reaches
+      # `next` at all. `pick` cannot see it either: it asks about `orcareplay`, which is published
+      # *last*, so any unfinished run looks exactly like one that never started.
+      #
+      # Asking per package makes a retry publish only what is missing. `--names` rather than
+      # deriving the name in the shell: that means interpolating a path into a `require`, which is a
+      # string escape on Windows and something this script already knows the answer to.
+      #
+      # A dry run skips the probe entirely and packs all twelve, because validating the tarballs is
+      # the whole point of one.
       - name: Publish in dependency order
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           DRY_RUN: ${{ github.event.inputs.dry-run }}
+          VERSION: ${{ needs.pick.outputs.version }}
         run: |
           set -euo pipefail
-          node scripts/publish-order.mjs | while read -r dir; do
+          node scripts/publish-order.mjs --names | while IFS="$(printf '\t')" read -r name dir; do
             if [ "${DRY_RUN:-false}" = "true" ]; then
-              echo "── dry run: $dir"
+              echo "── dry run: $name"
               ( cd "$dir" && npm publish --dry-run --provenance --access public --tag next )
-            else
-              echo "── publishing: $dir"
-              ( cd "$dir" && npm publish --provenance --access public --tag next )
+              continue
             fi
+            if npm view "$name@$VERSION" version >/dev/null 2>&1; then
+              echo "── already on npm, skipping: $name@$VERSION"
+              continue
+            fi
+            echo "── publishing: $name@$VERSION"
+            ( cd "$dir" && npm publish --provenance --access public --tag next )
           done
 
       - name: Say what to install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,8 +151,31 @@ jobs:
               ( cd "$dir" && npm publish --dry-run --provenance --access public )
               continue
             fi
-            if npm view "$name@$VERSION" version >/dev/null 2>&1; then
-              echo "── already on npm, skipping: $name@$VERSION"
+            # Skip only what this commit already published.
+            #
+            # The probe in `publish-next.yml` can skip on the version alone, because there the
+            # version *is* the tree — `0.2.4-main.g<sha>`. A release version is a number a human
+            # chose, and main can carry it across many commits, so "0.3.0 exists on npm" does not
+            # mean this commit produced it.
+            #
+            # What that allows, without this check: the bump to 0.3.0 merges, the loop publishes
+            # packages 1-5 and dies, no tag is created, so main still looks unreleased. Someone
+            # pushes the fix for that failure — same version, still untagged — and this workflow
+            # runs again: 1-5 are skipped because they are on npm from the *older* commit, 6-12 are
+            # published from the new one, and the tag step then tags the new commit. `orcareplay@0.3.0`
+            # is permanently a mixture of two trees that no commit corresponds to.
+            #
+            # `gitHead` is what npm records at publish time; it is present on the existing releases
+            # (0.2.3 carries 2a1311c, the commit `v0.2.3` points at). If it is missing, this falls
+            # through and publishes, which is the loud E403 that used to be the only behaviour.
+            head=$(npm view "$name@$VERSION" gitHead 2>/dev/null) || head=
+            if [ -n "$head" ]; then
+              if [ "$head" != "$GITHUB_SHA" ]; then
+                echo "$name@$VERSION was published from $head, not $GITHUB_SHA." >&2
+                echo "A version cannot be replaced on npm — bump the version instead." >&2
+                exit 1
+              fi
+              echo "── already on npm from this commit, skipping: $name@$VERSION"
               continue
             fi
             echo "── publishing: $name@$VERSION"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,6 +134,10 @@ jobs:
           VERSION: ${{ needs.decide.outputs.version }}
         run: |
           set -euo pipefail
+          # The commit that is about to be packed, which is also what npm will write as `gitHead`.
+          PUBLISHING=$(git rev-parse HEAD)
+          echo "publishing $VERSION from $PUBLISHING"
+
           # Computed, never hardcoded: internal deps are pinned to an exact version, so publishing
           # the CLI before the core it names would fail on a version the registry does not have.
           #
@@ -165,13 +169,22 @@ jobs:
             # published from the new one, and the tag step then tags the new commit. `orcareplay@0.3.0`
             # is permanently a mixture of two trees that no commit corresponds to.
             #
-            # `gitHead` is what npm records at publish time; it is present on the existing releases
-            # (0.2.3 carries 2a1311c, the commit `v0.2.3` points at). If it is missing, this falls
-            # through and publishes, which is the loud E403 that used to be the only behaviour.
+            # `gitHead` is what npm records at publish time, read out of the checkout's own `.git`;
+            # it is present on the existing releases (0.2.3 carries 2a1311c, the commit `v0.2.3`
+            # points at). If it is missing, this falls through and publishes, which is the loud E403
+            # that used to be the only behaviour.
+            #
+            # Compared against `git rev-parse HEAD` rather than `$GITHUB_SHA`, so both sides come
+            # from the same place: the commit that is checked out and about to be packed. They agree
+            # today even for an annotated tag — all six releases in this repository were annotated
+            # tags and GitHub reported the *commit* as the event sha in every one — but that is a
+            # property of GitHub's event payload, and if it ever reported the tag object instead,
+            # every probe would mismatch and a tag-triggered release that died half way could never
+            # be resumed. Asking git costs nothing and does not depend on knowing that.
             head=$(npm view "$name@$VERSION" gitHead 2>/dev/null) || head=
             if [ -n "$head" ]; then
-              if [ "$head" != "$GITHUB_SHA" ]; then
-                echo "$name@$VERSION was published from $head, not $GITHUB_SHA." >&2
+              if [ "$head" != "$PUBLISHING" ]; then
+                echo "$name@$VERSION was published from $head, not $PUBLISHING." >&2
                 echo "A version cannot be replaced on npm — bump the version instead." >&2
                 exit 1
               fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,22 @@
-# Publish every workspace to npm, in dependency order, from a tag.
+# Publish every workspace to npm, in dependency order, as `latest`.
 #
-# Nothing here runs on a push to a branch: it fires on a `v*` tag, or by hand. Publishing is
-# irreversible — npm allows an unpublish only briefly and never a re-publish of the same version —
-# so the whole test suite gates it, and a dry run is available that proves the tarballs are right
-# without sending anything.
+# Two ways in, and a human decides the version in both. A `v*` tag still works. The other is a
+# version bump reaching main: when `packages/cli/package.json` names a version that has no tag yet,
+# that merge *is* the release, and this workflow publishes it and creates the tag. `set-version.mjs`
+# makes the bump one command instead of thirteen hand-edited manifests, so the whole ceremony is a
+# pull request that changes a version number.
+#
+# What this deliberately does not do is publish on every merge. Publishing is irreversible — npm
+# allows an unpublish only briefly and never a re-publish of the same version — so the whole test
+# suite gates it, and a dry run is available that proves the tarballs are right without sending
+# anything. Main is still installable between releases: `publish-next.yml` puts every green commit
+# on the `next` tag, where nobody is opted in by accident.
 name: Release
 
 on:
   push:
     tags: ['v*']
+    branches: [main]
   workflow_dispatch:
     inputs:
       dry-run:
@@ -28,9 +36,55 @@ permissions:
   contents: read
   id-token: write # npm provenance: proves the tarball came from this workflow, from this commit
 
+# One release at a time. The publish loop walks twelve packages in dependency order, and two runs
+# interleaving would put a version on the registry that the rest do not name — which npm will not
+# let anyone re-publish over.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 jobs:
-  release:
+  # Cheap, so an ordinary merge does not run the whole suite to discover there is nothing to do.
+  # Several pull requests land here a day and almost none of them change a version.
+  decide:
     runs-on: ubuntu-latest
+    outputs:
+      publish: ${{ steps.check.outputs.publish }}
+      version: ${{ steps.check.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # the tags are the state this reads
+      - id: check
+        run: |
+          set -euo pipefail
+          version=$(node -p "require('./packages/cli/package.json').version")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+          # A tag push or a hand-run is already someone asking for a release.
+          if [ "${{ github.ref_type }}" != "branch" ]; then
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # From main, the tag is the record of what has been released. Asking git rather than
+          # diffing the previous commit means this is idempotent and survives a squash merge, a
+          # direct push, or a re-run: if `v$version` exists, that version is out.
+          if git rev-parse -q --verify "refs/tags/v$version" >/dev/null; then
+            echo "main is at $version, which is already tagged — nothing to release"
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "main is at $version and v$version does not exist yet — releasing it"
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  release:
+    needs: decide
+    if: needs.decide.outputs.publish == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # only to create the tag for a release that came from main
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -77,6 +131,22 @@ jobs:
               ( cd "$dir" && npm publish --provenance --access public )
             fi
           done
+
+      # Created after the publish, not before it, so the tag means "this went out" rather than
+      # "this was attempted". A release that came in as a `v*` tag already has one.
+      #
+      # It is also what stops the next merge re-releasing the same version: `decide` reads these
+      # tags, so until this exists, main looks unreleased.
+      - name: Tag the release that came from main
+        if: ${{ github.ref_type == 'branch' && github.event.inputs.dry-run != 'true' }}
+        env:
+          VERSION: ${{ needs.decide.outputs.version }}
+        run: |
+          set -euo pipefail
+          git -c user.name='github-actions[bot]' \
+              -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
+              tag -a "v$VERSION" -m "release $VERSION"
+          git push origin "v$VERSION"
 
       # The npm packages are the artefact; this makes them findable. Ownership is proved twice at
       # once: `mcpName` in packages/cli/package.json must equal the name in server.json, and GitHub

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,8 +61,21 @@ jobs:
           version=$(node -p "require('./packages/cli/package.json').version")
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
-          # A tag push or a hand-run is already someone asking for a release.
-          if [ "${{ github.ref_type }}" != "branch" ]; then
+          # A tag push or a hand-run is already someone asking for a release, so the tag rule below
+          # applies to a `push` and nothing else.
+          #
+          # `github.ref_type` is not the test for that: a `workflow_dispatch` is run *from a ref*,
+          # and from main that ref is a branch — so keying on it alone sent every hand-run into the
+          # tag check, where a version that is already tagged means `publish=false` and the release
+          # job is skipped. The workflow would then report success having published nothing.
+          #
+          # That is the one path this must not swallow. `registry-only` exists because the MCP
+          # Registry step can fail *after* npm has gone out — v0.2.2 and v0.2.3 both did — and by
+          # then the tag is on the remote, so the documented retry is a hand-run against an
+          # already-tagged version. The `dry run` rehearsal RELEASING.md describes is the same
+          # shape, and main is normally at a tagged version, which is when it would break.
+          if [ "${{ github.event_name }}" != "push" ] || [ "${{ github.ref_type }}" != "branch" ]; then
+            echo "${{ github.event_name }} from ${{ github.ref_type }} — an explicit request, releasing"
             echo "publish=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -137,12 +150,23 @@ jobs:
       #
       # It is also what stops the next merge re-releasing the same version: `decide` reads these
       # tags, so until this exists, main looks unreleased.
+      # Only a merge creates a tag, and only if there is not one already.
+      #
+      # `push` and not merely "a branch ref", because a hand-run from main is now allowed through
+      # `decide` — and the reason it is allowed is the `registry-only` retry, which runs against a
+      # version whose tag already exists. `git tag -a` on an existing tag is a fatal error, so
+      # under `set -e` that retry would have died here instead of reaching the registry step it was
+      # dispatched for. Checked as well as scoped: a re-run of the same merge must not fail either.
       - name: Tag the release that came from main
-        if: ${{ github.ref_type == 'branch' && github.event.inputs.dry-run != 'true' }}
+        if: ${{ github.event_name == 'push' && github.ref_type == 'branch' && github.event.inputs.dry-run != 'true' }}
         env:
           VERSION: ${{ needs.decide.outputs.version }}
         run: |
           set -euo pipefail
+          if git rev-parse -q --verify "refs/tags/v$VERSION" >/dev/null; then
+            echo "v$VERSION already exists — leaving it alone"
+            exit 0
+          fi
           git -c user.name='github-actions[bot]' \
               -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
               tag -a "v$VERSION" -m "release $VERSION"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,18 +131,32 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           DRY_RUN: ${{ github.event.inputs.dry-run }}
+          VERSION: ${{ needs.decide.outputs.version }}
         run: |
           set -euo pipefail
           # Computed, never hardcoded: internal deps are pinned to an exact version, so publishing
           # the CLI before the core it names would fail on a version the registry does not have.
-          node scripts/publish-order.mjs | while read -r dir; do
+          #
+          # Resumable for the same reason `publish-next.yml` is, and it matters more here. The loop
+          # stops where it fails, so a transient npm 5xx at package five leaves five versions of a
+          # *release* on the registry permanently — and npm refuses to replace a version, so a
+          # re-run from the top dies on E403 and the only way forward would be to abandon that
+          # version number half-published and bump again. Asking per package makes the retry publish
+          # exactly what is missing.
+          #
+          # A dry run skips the probe and packs all twelve: validating the tarballs is the point.
+          node scripts/publish-order.mjs --names | while IFS="$(printf '\t')" read -r name dir; do
             if [ "${DRY_RUN:-false}" = "true" ]; then
-              echo "── dry run: $dir"
+              echo "── dry run: $name"
               ( cd "$dir" && npm publish --dry-run --provenance --access public )
-            else
-              echo "── publishing: $dir"
-              ( cd "$dir" && npm publish --provenance --access public )
+              continue
             fi
+            if npm view "$name@$VERSION" version >/dev/null 2>&1; then
+              echo "── already on npm, skipping: $name@$VERSION"
+              continue
+            fi
+            echo "── publishing: $name@$VERSION"
+            ( cd "$dir" && npm publish --provenance --access public )
           done
 
       # Created after the publish, not before it, so the tag means "this went out" rather than

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -10,44 +10,60 @@ sequence of `npm publish` calls run by hand at the end of a long day.
   `@orcareplay` scope. An automation token, not a personal one.
 - **Actions enabled** for the repository, and Actions billing active on the org.
 
+## Two channels
+
+| | what it is | who gets it |
+| --- | --- | --- |
+| `latest` | a version someone decided to release | `npm i orcareplay` |
+| `next` | every green commit on main, as `0.2.4-main.<sha>` | `npm i orcareplay@next` |
+
+`next` is published by `.github/workflows/publish-next.yml` after CI passes on main, and needs
+nothing from you. Every version on it is a **prerelease**, which npm excludes from
+`npm i orcareplay` even though `0.2.4-main.abc1234` sorts above `0.2.3` — so main is always
+installable and nobody is opted in to it by accident. `--tag next` never moves `latest`.
+
+That is what keeps the rest of this page short: releasing is no longer the only way to get main
+into someone's hands, so it can stay deliberate.
+
 ## Every release
 
+A release is a pull request that changes a version number. Merging it publishes `latest` and
+creates the tag.
+
 ```console
-npm version 0.3.0 --workspaces --include-workspace-root --no-git-tag-version
-
-# `npm version` bumps each package's own version and nothing else: the internal pins
-# ("@orcareplay/core": "0.2.0") are left naming the previous release. Move them too,
-# before anything installs. By this point the only "0.2.0" left in these files IS a pin.
-sed -i 's/"0\.2\.0"/"0.3.0"/g' packages/*/package.json
-
-node scripts/publish-order.mjs      # sanity: prints the order, fails if versions disagree
-
-# `npm version` already rewrote package-lock.json — while the pins were still stale. Throw that
-# write away and re-resolve from the last committed lockfile, which is clean.
-git checkout package-lock.json
-rm -rf node_modules packages/*/node_modules && npm install   # one clean re-resolve
-grep -c 'registry.npmjs.org/@orcareplay' package-lock.json   # must be 0: every one is a link
-npm run check                       # what the workflow will run anyway, but faster to find here
-git commit -am "release 0.3.0"
-# -a, not a lightweight tag: `--follow-tags` pushes only annotated ones, and a tag that
-# stays local fires nothing.
-git tag -a v0.3.0 -m "0.3.0" && git push --follow-tags
+node scripts/set-version.mjs 0.3.0 --lock   # 13 manifests, every internal pin, and the lockfile
+node scripts/publish-order.mjs              # sanity: prints the order, fails if versions disagree
+npm run check                               # what the workflow runs anyway, faster to find here
+git commit -am "release 0.3.0" && git push  # open a PR, merge it
 ```
 
-> **Why both the sed and the `git checkout`.** When a workspace sits at the new version and its
+Merging that into main fires `.github/workflows/release.yml`, which sees a version with no tag,
+runs the full gate, publishes, and creates `v0.3.0` itself. Nothing else lands a release: every
+other merge leaves the version alone, and the workflow's `decide` job costs seconds to say so.
+
+A `v*` tag pushed by hand still works and does the same thing, for a release made from somewhere
+other than main.
+
+> **Why there is a script for what looks like one edit.** Twelve packages name each other by exact
+> version, so a bump is thirty-eight fields across thirteen manifests — and `npm version
+> --workspaces` moves each package's own `version` while leaving its dependants naming the previous
+> release. Publish that and `orcareplay@0.3.0` depends on `@orcareplay/core@0.2.0`, which npm will
+> never let you replace.
+>
+> **And why `--lock` rather than `npm version`.** When a workspace sits at the new version and its
 > dependants still name the old one, npm stops treating them as satisfiable workspace links and
 > resolves the *published* old version instead, into `packages/<name>/node_modules/`. Those copies
 > shadow the source, `tsc` then checks the CLI against last release's `.d.ts`, and the errors it
-> reports name symbols that plainly do exist.
+> reports name symbols that plainly do exist. `npm version` writes `package-lock.json` itself at
+> exactly that moment, so the bad resolution is recorded before the pins can be fixed — 0.2.1
+> shipped with correct manifests and two poisoned lockfile entries, and every later `npm ci`
+> honoured them. `set-version.mjs` moves the pins first and reconciles the lockfile after, so the
+> window does not exist.
 >
-> The sed alone does not prevent it, because **`npm version` writes `package-lock.json` itself**,
-> at the one moment when the versions have moved and the pins have not. So the bad resolution is
-> already recorded before you get a chance to fix the pins, and the next `npm install` honours it
-> — as does any later `npm ci`. 0.2.1 hit this with correct manifests and two poisoned lockfile
-> entries. Discarding npm's write and re-resolving from the committed lockfile is what clears it.
->
-> `scripts/publish-order.mjs` catches the manifest mismatch, and the `grep` catches the lockfile
-> one; the manifests can be perfectly consistent while the lockfile is not, so check both.
+> Both halves are still checked rather than trusted: `publish-order.mjs` catches a manifest
+> mismatch, and `scripts/set-version.test.ts` asserts the committed lockfile links every
+> `@orcareplay/*` instead of fetching it. The manifests can be perfectly consistent while the
+> lockfile is not.
 
 > **The registry step waits for npm, and has to.** The MCP Registry validates that the npm version
 > it is being told about exists, and npm's own publish output says a tarball "may take a few minutes
@@ -56,12 +72,20 @@ git tag -a v0.3.0 -m "0.3.0" && git push --follow-tags
 > re-running the whole workflow was not an option. The step now polls `npm view` for up to five
 > minutes before publishing. `registry-only` exists for the case where it still needs a retry.
 
-The tag fires `.github/workflows/release.yml`, which:
+`.github/workflows/release.yml`, however it was triggered:
 
-1. runs the full gate — format, build, 1000+ tests, conformance, neutrality;
-2. checks the tag matches `packages/cli`'s version, so a published version always has a tag
-   pointing at it;
-3. publishes every workspace **in dependency order**, with npm provenance.
+1. decides whether there is anything to release — from main, a version that already has a tag is
+   not one, which is what makes an ordinary merge cost seconds instead of the whole suite;
+2. runs the full gate — format, build, 1000+ tests, conformance, neutrality;
+3. for a `v*` tag, checks it matches `packages/cli`'s version, so a published version always has a
+   tag pointing at it;
+4. publishes every workspace **in dependency order**, with npm provenance;
+5. creates the tag, when the release came from main — *after* the publish, so a tag means "this
+   went out" rather than "this was attempted", and so the next merge does not try again.
+
+Both publishing workflows are `concurrency`-grouped and queue rather than cancel. The publish loop
+walks twelve packages one at a time, and a run cancelled half way leaves some of them on the
+registry at a version the rest do not name — which is the one state npm will not let anyone fix.
 
 To rehearse without sending anything: **Actions → Release → Run workflow**, leaving *dry run*
 checked. It packs and validates every tarball and publishes nothing.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -15,11 +15,11 @@ sequence of `npm publish` calls run by hand at the end of a long day.
 | | what it is | who gets it |
 | --- | --- | --- |
 | `latest` | a version someone decided to release | `npm i orcareplay` |
-| `next` | main, once a day, as `0.2.4-main.<sha>` | `npm i orcareplay@next` |
+| `next` | main, once a day, as `0.2.4-main.g<sha>` | `npm i orcareplay@next` |
 
 `next` is published by `.github/workflows/publish-next.yml` on a daily schedule — 04:00 UTC, which
 is noon in Beijing — and needs nothing from you. Every version on it is a **prerelease**, which npm
-excludes from `npm i orcareplay` even though `0.2.4-main.abc1234` sorts above `0.2.3`, so main is
+excludes from `npm i orcareplay` even though `0.2.4-main.gabc1234` sorts above `0.2.3`, so main is
 always installable and nobody is opted in to it by accident. `--tag next` never moves `latest`.
 
 It publishes **the newest commit on main that CI passed**, not whatever main happens to be at
@@ -95,9 +95,18 @@ other than main.
 2. runs the full gate — format, build, 1000+ tests, conformance, neutrality;
 3. for a `v*` tag, checks it matches `packages/cli`'s version, so a published version always has a
    tag pointing at it;
-4. publishes every workspace **in dependency order**, with npm provenance;
+4. publishes every workspace **in dependency order**, with npm provenance — skipping any package
+   already on npm at that version *from this commit*, so a run that died half way can be retried;
 5. creates the tag, when the release came from main — *after* the publish, so a tag means "this
    went out" rather than "this was attempted", and so the next merge does not try again.
+
+> **A retry may resume, but only from the same commit.** A release version is a number a human
+> chose, and main can carry it across several commits, so "0.3.0 is on npm" does not mean this
+> commit put it there. If the loop dies at package five and someone then pushes the fix to main —
+> same version, still untagged — resuming would publish 6-12 from the new tree and leave 1-5 from
+> the old one, making `orcareplay@0.3.0` a mixture no commit corresponds to, permanently. So the
+> skip compares npm's recorded `gitHead` with the commit being published and stops the release when
+> they disagree: bump the version instead.
 
 Both publishing workflows are `concurrency`-grouped and queue rather than cancel. The publish loop
 walks twelve packages one at a time, and a run cancelled half way leaves some of them on the

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -15,12 +15,28 @@ sequence of `npm publish` calls run by hand at the end of a long day.
 | | what it is | who gets it |
 | --- | --- | --- |
 | `latest` | a version someone decided to release | `npm i orcareplay` |
-| `next` | every green commit on main, as `0.2.4-main.<sha>` | `npm i orcareplay@next` |
+| `next` | main, once a day, as `0.2.4-main.<sha>` | `npm i orcareplay@next` |
 
-`next` is published by `.github/workflows/publish-next.yml` after CI passes on main, and needs
-nothing from you. Every version on it is a **prerelease**, which npm excludes from
-`npm i orcareplay` even though `0.2.4-main.abc1234` sorts above `0.2.3` — so main is always
-installable and nobody is opted in to it by accident. `--tag next` never moves `latest`.
+`next` is published by `.github/workflows/publish-next.yml` on a daily schedule — 04:00 UTC, which
+is noon in Beijing — and needs nothing from you. Every version on it is a **prerelease**, which npm
+excludes from `npm i orcareplay` even though `0.2.4-main.abc1234` sorts above `0.2.3`, so main is
+always installable and nobody is opted in to it by accident. `--tag next` never moves `latest`.
+
+It publishes **the newest commit on main that CI passed**, not whatever main happens to be at
+04:00, and it skips a day on which nothing merged — the version it would publish is already on the
+registry, and it asks npm rather than keeping state. Needing main on npm sooner than tomorrow is
+what **Actions → Publish next → Run workflow** is for; uncheck *dry run*.
+
+> **Why daily rather than on every merge.** A version is not free. npm serves a *packument* — the
+> metadata for every version of a package — on each install, and it grows with the version count:
+> `orcareplay` is 20 KB at seven versions, `typescript` is 15.6 MB at 3820. That is roughly 4 KB
+> each, paid by everyone who installs, including people who only ever ask for `latest`. Publishing
+> per merge at this repository's rate would add ~2900 versions a year and land in that territory
+> inside twelve months. Daily is an eighth of it, and it is what `typescript` does for its own
+> `-dev` builds.
+>
+> GitHub's cron is UTC only and best-effort — a scheduled run is commonly minutes late and can be
+> dropped under load — so read the schedule as "some time after noon", not as a clock.
 
 That is what keeps the rest of this page short: releasing is no longer the only way to get main
 into someone's hands, so it can stay deliberate.

--- a/scripts/publish-order.mjs
+++ b/scripts/publish-order.mjs
@@ -77,6 +77,12 @@ if (problems.length > 0) {
 
 if (process.argv.includes('--json')) {
   console.log(JSON.stringify(order.map((n) => packages.get(n).dir)));
+} else if (process.argv.includes('--names')) {
+  // `name<TAB>dir`, because a publisher that needs to ask the registry about a package needs its
+  // name, and building one in the shell means interpolating a path into a `require` — which is a
+  // string escape on Windows (`packages\node-instrument` becomes a newline). This script already
+  // parsed every manifest, so it can just say.
+  for (const name of order) console.log(`${name}\t${packages.get(name).dir}`);
 } else {
   for (const name of order) console.log(packages.get(name).dir);
 }

--- a/scripts/publish-order.mjs
+++ b/scripts/publish-order.mjs
@@ -58,7 +58,12 @@ for (const [name, p] of packages) {
     const range = p.ranges[dep];
     // A range resolves to whatever is latest on the registry, so a 0.1.0 CLI would install a
     // 0.9.0 core — and on a first publish it resolves to nothing at all.
-    if (!/^\d+\.\d+\.\d+$/.test(range)) {
+    //
+    // A prerelease is allowed because it is still exactly one version: the `next` channel
+    // publishes `0.2.4-main.<sha>`, and this check exists to forbid a *range*, not a suffix.
+    // Build metadata (`+…`) stays forbidden — npm ignores it when comparing, so two different
+    // manifests could name the same version to the registry, which a publish cannot undo.
+    if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(range)) {
       problems.push(`${name} depends on ${dep} as "${range}" — must be an exact version`);
     } else if (target.version !== range) {
       problems.push(`${name} names ${dep}@${range}, but ${dep} is at ${target.version}`);

--- a/scripts/publish-order.mjs
+++ b/scripts/publish-order.mjs
@@ -60,10 +60,18 @@ for (const [name, p] of packages) {
     // 0.9.0 core — and on a first publish it resolves to nothing at all.
     //
     // A prerelease is allowed because it is still exactly one version: the `next` channel
-    // publishes `0.2.4-main.<sha>`, and this check exists to forbid a *range*, not a suffix.
-    // Build metadata (`+…`) stays forbidden — npm ignores it when comparing, so two different
-    // manifests could name the same version to the registry, which a publish cannot undo.
-    if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(range)) {
+    // publishes `0.2.4-main.g<sha>`, and this check exists to forbid a *range*, not a suffix.
+    //
+    // semver.org's grammar, not a loose `[0-9A-Za-z.-]+`. A numeric prerelease identifier may not
+    // have a leading zero, and `npm publish` does not refuse one: it rewrites the version and
+    // leaves the pins, so twelve packages go out naming a version that does not exist. Build
+    // metadata (`+…`) stays forbidden — npm ignores it when comparing, so two different manifests
+    // could name the same version to the registry, which a publish cannot undo.
+    if (
+      !/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?$/.test(
+        range,
+      )
+    ) {
       problems.push(`${name} depends on ${dep} as "${range}" — must be an exact version`);
     } else if (target.version !== range) {
       problems.push(`${name} names ${dep}@${range}, but ${dep} is at ${target.version}`);

--- a/scripts/set-version.mjs
+++ b/scripts/set-version.mjs
@@ -30,15 +30,32 @@ import { fileURLToPath } from 'node:url';
 const root = fileURLToPath(new URL('..', import.meta.url));
 
 /**
- * Accepts a prerelease, because that is what the `next` channel publishes.
+ * Accepts a prerelease, because that is what the `next` channel publishes — but only a *legal* one.
  *
- * `0.2.4-main.90fc463` is a legal semver version and npm treats it specially: it is excluded from
+ * `0.2.4-main.g90fc463` is a legal semver version and npm treats it specially: it is excluded from
  * `npm install <pkg>` even though it sorts above `0.2.3`, so a prerelease cannot reach someone who
- * did not ask for it by name. Build metadata (`+…`) is rejected instead of allowed — npm ignores it
- * when comparing versions, so two builds could differ in the manifest and be the same version to
- * the registry, which is the one failure mode a publish cannot recover from.
+ * did not ask for it by name.
+ *
+ * This is semver.org's own grammar rather than a loose `[0-9A-Za-z.-]+`, because the loose form
+ * accepts something npm will not publish as written and does not refuse either. A numeric
+ * prerelease identifier may not have a leading zero, so `0.2.4-main.0123456` is invalid — and
+ * `npm publish` does not fail on it. It runs the manifest through `@npmcli/package-json`'s `fix()`,
+ * which *rewrites* the version to `0.2.4-main.123456` with only a warning, and leaves every
+ * dependency pin naming `0.2.4-main.0123456`. Measured with npm's own library:
+ *
+ *     fix() version : 0.2.4-main.123456
+ *     fix() dep pin : 0.2.4-main.0123456
+ *
+ * Twelve packages would go out at one version while declaring dependencies on another that does not
+ * exist, and npm never lets a version be replaced. The `next` channel would be permanently
+ * unresolvable. A short sha triggers it whenever its first seven characters are all digits and
+ * start with a zero — about one commit in 270.
+ *
+ * Build metadata (`+…`) is left out of the grammar on purpose rather than allowed: npm ignores it
+ * when comparing versions, so two different trees could claim the same version to the registry.
  */
-const VERSION = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/;
+const VERSION =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?$/;
 
 const DEP_FIELDS = ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies'];
 

--- a/scripts/set-version.mjs
+++ b/scripts/set-version.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+/**
+ * Set one version across every workspace, and rewrite the internal pins that name it.
+ *
+ * Twelve packages depend on each other by *exact* version — `"@orcareplay/core": "0.2.3"`, never a
+ * range — for the reason `publish-order.mjs` gives: a range resolves to whatever is latest, so a
+ * 0.1.0 CLI would install a 0.9.0 core. The cost is that a version bump is not one edit but
+ * thirteen manifests plus every pin inside them, and `npm version --workspaces` does not touch the
+ * pins: it moves each package's own `version` and leaves its dependents naming the old one, which
+ * `publish-order.mjs` then rejects. Every release so far was therefore a hand-written commit
+ * touching thirteen files, which is exactly the kind of thing that goes wrong once and is
+ * irreversible on npm.
+ *
+ *     node scripts/set-version.mjs 0.2.4            # manifests only
+ *     node scripts/set-version.mjs 0.2.4 --lock     # and reconcile package-lock.json
+ *     node scripts/set-version.mjs 0.2.4 --check    # say what would change, write nothing
+ *
+ * `--lock` is what a bump you intend to *commit* needs, because `npm ci` fails on a lockfile that
+ * disagrees with the manifests. A publish does not read the lockfile, so the release workflows that
+ * set a version in the runner and never commit it can skip the slow half.
+ *
+ * Verified by `scripts/set-version.test.ts`, and by `publish-order.mjs`, which every release runs
+ * and which fails loudly if a pin was left behind.
+ */
+import { execFileSync } from 'node:child_process';
+import { readdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = fileURLToPath(new URL('..', import.meta.url));
+
+/**
+ * Accepts a prerelease, because that is what the `next` channel publishes.
+ *
+ * `0.2.4-main.90fc463` is a legal semver version and npm treats it specially: it is excluded from
+ * `npm install <pkg>` even though it sorts above `0.2.3`, so a prerelease cannot reach someone who
+ * did not ask for it by name. Build metadata (`+…`) is rejected instead of allowed — npm ignores it
+ * when comparing versions, so two builds could differ in the manifest and be the same version to
+ * the registry, which is the one failure mode a publish cannot recover from.
+ */
+const VERSION = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/;
+
+const DEP_FIELDS = ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies'];
+
+/** Every workspace manifest, plus the root, which carries a version of its own. */
+async function manifests() {
+  const found = [join(root, 'package.json')];
+  const dir = join(root, 'packages');
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    found.push(join(dir, entry.name, 'package.json'));
+  }
+  return found;
+}
+
+/** The names this repository publishes, so a pin on someone else's package is left alone. */
+async function internalNames(paths) {
+  const names = new Set();
+  for (const path of paths) {
+    const pkg = JSON.parse(await readFile(path, 'utf8').catch(() => '{}'));
+    if (typeof pkg.name === 'string' && pkg.name.startsWith('@orcareplay/')) names.add(pkg.name);
+  }
+  return names;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const version = args.find((a) => !a.startsWith('--'));
+  const check = args.includes('--check');
+  const lock = args.includes('--lock');
+
+  if (version === undefined) {
+    console.error('usage: node scripts/set-version.mjs <version> [--lock] [--check]');
+    process.exit(2);
+  }
+  if (!VERSION.test(version)) {
+    console.error(
+      `"${version}" is not a version this can set — expected 1.2.3 or 1.2.3-main.abc1234`,
+    );
+    process.exit(2);
+  }
+
+  const paths = await manifests();
+  const internal = await internalNames(paths);
+  const changes = [];
+
+  for (const path of paths) {
+    const before = await readFile(path, 'utf8');
+    const pkg = JSON.parse(before);
+    const label = pkg.name ?? path;
+
+    if (pkg.version !== undefined && pkg.version !== version) {
+      changes.push(`${label}: version ${pkg.version} -> ${version}`);
+      pkg.version = version;
+    }
+    for (const field of DEP_FIELDS) {
+      const deps = pkg[field];
+      if (deps === undefined) continue;
+      for (const name of Object.keys(deps)) {
+        // Only what this repository publishes, and only a pin that has actually moved. A
+        // `workspace:` protocol or a range would be a bug `publish-order.mjs` reports, so it is
+        // replaced here too rather than quietly preserved.
+        if (!internal.has(name) || deps[name] === version) continue;
+        changes.push(`${label}: ${field}.${name} ${deps[name]} -> ${version}`);
+        deps[name] = version;
+      }
+    }
+
+    // Re-serialised with the trailing newline npm itself writes, so a bump is a diff of the lines
+    // that changed rather than of the whole file.
+    const after = `${JSON.stringify(pkg, null, 2)}\n`;
+    if (after !== before && !check) await writeFile(path, after);
+  }
+
+  if (changes.length === 0) {
+    console.log(`already at ${version} — nothing to change`);
+  } else {
+    for (const line of changes) console.log(`  ${line}`);
+    console.log(`${check ? 'would change' : 'changed'} ${changes.length} field(s) to ${version}`);
+  }
+
+  if (lock && !check) {
+    // `npm ci` fails on a lockfile that disagrees with the manifests, so a bump meant for a commit
+    // has to bring it along. `--ignore-scripts` because nothing here needs a build, and
+    // `--package-lock-only` because nothing here needs node_modules touched either.
+    console.log('reconciling package-lock.json');
+    execFileSync('npm', ['install', '--package-lock-only', '--ignore-scripts'], {
+      cwd: root,
+      stdio: 'inherit',
+      shell: process.platform === 'win32',
+    });
+  }
+}
+
+await main();

--- a/scripts/set-version.test.ts
+++ b/scripts/set-version.test.ts
@@ -1,0 +1,189 @@
+import { execFile } from 'node:child_process';
+import { cp, mkdtemp, readFile, rm, writeFile, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const run = promisify(execFile);
+const repo = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+/**
+ * The version bump, which is the one edit a release cannot get wrong.
+ *
+ * Twelve packages name each other by exact version, so moving a version means moving every pin that
+ * names it — thirty-eight fields across thirteen manifests at the time of writing. Every release
+ * before this script was a hand-written commit doing that, and `npm version --workspaces` does not
+ * help: it moves each package's own `version` and leaves its dependents pointing at the old one.
+ *
+ * The failure this guards is not a red test later. A pin left behind publishes
+ * `orcareplay@0.2.4` depending on `@orcareplay/core@0.2.3`, and npm never allows a version to be
+ * re-published — so it is wrong on the registry permanently. `publish-order.mjs` is the other half
+ * of the guard and every release runs it; this pins the shape it is checking.
+ */
+describe('set-version', () => {
+  let work: string;
+
+  /** A copy of the real manifests, so the assertions are about this repository's actual graph. */
+  beforeEach(async () => {
+    work = await mkdtemp(join(tmpdir(), 'orca-setver-'));
+    await cp(join(repo, 'package.json'), join(work, 'package.json'));
+    await mkdir(join(work, 'scripts'), { recursive: true });
+    await cp(join(repo, 'scripts', 'set-version.mjs'), join(work, 'scripts', 'set-version.mjs'));
+    await cp(
+      join(repo, 'scripts', 'publish-order.mjs'),
+      join(work, 'scripts', 'publish-order.mjs'),
+    );
+    await cp(join(repo, 'packages'), join(work, 'packages'), {
+      recursive: true,
+      filter: (src) => !src.includes('node_modules') && !src.includes(`${'dist'}`),
+    });
+  });
+
+  afterEach(async () => {
+    await rm(work, { recursive: true, force: true });
+  });
+
+  const setVersion = (...args: string[]) =>
+    run(process.execPath, [join(work, 'scripts', 'set-version.mjs'), ...args], { cwd: work });
+
+  const manifest = async (rel: string) =>
+    JSON.parse(await readFile(join(work, rel), 'utf8')) as {
+      version?: string;
+      dependencies?: Record<string, string>;
+    };
+
+  it('moves every version and every internal pin together', async () => {
+    await setVersion('1.2.3');
+
+    const cli = await manifest('packages/cli/package.json');
+    expect(cli.version).toBe('1.2.3');
+    // The pins are the half `npm version` leaves behind.
+    for (const [name, range] of Object.entries(cli.dependencies ?? {})) {
+      if (!name.startsWith('@orcareplay/')) continue;
+      expect(range, `${name} was left naming the old version`).toBe('1.2.3');
+    }
+    expect((await manifest('packages/core/package.json')).version).toBe('1.2.3');
+    expect((await manifest('package.json')).version).toBe('1.2.3');
+  });
+
+  it('leaves a third-party dependency alone', async () => {
+    // `@orcareplay/schema` rather than the CLI: the CLI ships with no runtime dependency at all,
+    // so it cannot show that an outside range survives. Both the root's devDependencies and
+    // schema's `ajv` are checked, because the fields are walked separately.
+    const schema = 'packages/schema/package.json';
+    const before = (await manifest(schema)).dependencies ?? {};
+    const outside = Object.entries(before).filter(([n]) => !n.startsWith('@orcareplay/'));
+    expect(outside.length, 'schema has no external dependency to check').toBeGreaterThan(0);
+    const rootDev = (
+      JSON.parse(await readFile(join(work, 'package.json'), 'utf8')) as {
+        devDependencies?: Record<string, string>;
+      }
+    ).devDependencies;
+
+    await setVersion('1.2.3');
+
+    const after = (await manifest(schema)).dependencies ?? {};
+    for (const [name, range] of outside) expect(after[name], name).toBe(range);
+    const rootAfter = (
+      JSON.parse(await readFile(join(work, 'package.json'), 'utf8')) as {
+        devDependencies?: Record<string, string>;
+      }
+    ).devDependencies;
+    expect(rootAfter, 'a devDependency on prettier is not a version to bump').toEqual(rootDev);
+  });
+
+  it('satisfies publish-order, which is what a release gates on', async () => {
+    for (const version of ['1.2.3', '0.2.4-main.90fc463']) {
+      await setVersion(version);
+      // Exits non-zero and names the offender if any pin disagrees.
+      const { stdout } = await run(process.execPath, [join(work, 'scripts', 'publish-order.mjs')], {
+        cwd: work,
+      });
+      expect(stdout.trim().split(/\r?\n/).length, 'every package should be publishable').toBe(12);
+    }
+  });
+
+  it('accepts a prerelease, because that is what the next channel publishes', async () => {
+    await setVersion('0.2.4-main.90fc463');
+    expect((await manifest('packages/cli/package.json')).version).toBe('0.2.4-main.90fc463');
+    expect((await manifest('packages/cli/package.json')).dependencies?.['@orcareplay/core']).toBe(
+      '0.2.4-main.90fc463',
+    );
+  });
+
+  it('refuses a range, and build metadata, rather than publishing something unfixable', async () => {
+    // A range would resolve to whatever is latest; build metadata is ignored when npm compares
+    // versions, so two different trees could claim the same version on the registry.
+    for (const bad of ['^1.2.3', '1.2', 'latest', '1.2.3+build']) {
+      await expect(setVersion(bad), `"${bad}" should be refused`).rejects.toThrow();
+    }
+    // And nothing was written on the way to refusing.
+    expect((await manifest('packages/cli/package.json')).version).toBe(
+      (await manifest('package.json')).version,
+    );
+  });
+
+  /**
+   * The lockfile half, asserted on what is committed rather than on a re-resolve.
+   *
+   * An internal dependency must appear in `package-lock.json` as a link to the workspace, never as
+   * something to fetch. 0.2.1 shipped with two entries resolving `@orcareplay/*` from the registry,
+   * because `npm version` writes the lockfile at the one moment when the versions have moved and
+   * the pins have not — so npm stopped seeing them as satisfiable workspace links and recorded the
+   * *previous release* instead. Those copies then shadow the source and `tsc` checks the CLI
+   * against last release's `.d.ts`.
+   *
+   * `set-version.mjs --lock` cannot reproduce that, because it fixes the pins before it touches the
+   * lockfile. This guards the outcome anyway: it is cheap, it does not care how the file was
+   * produced, and re-resolving here to prove it would add a minute to the suite.
+   */
+  it('the committed lockfile links internal packages instead of fetching them', async () => {
+    const lock = await readFile(join(repo, 'package-lock.json'), 'utf8');
+    const fetched = [...lock.matchAll(/registry\.npmjs\.org\/(@orcareplay\/[\w-]+)/g)].map(
+      (m) => m[1],
+    );
+    expect(
+      [...new Set(fetched)],
+      'these are resolved from the registry and must be workspace links',
+    ).toEqual([]);
+  });
+
+  it('is idempotent, and says so', async () => {
+    await setVersion('1.2.3');
+    const first = await readFile(join(work, 'packages/cli/package.json'), 'utf8');
+    const { stdout } = await setVersion('1.2.3');
+    expect(stdout).toContain('nothing to change');
+    expect(await readFile(join(work, 'packages/cli/package.json'), 'utf8')).toBe(first);
+  });
+
+  it('--check writes nothing', async () => {
+    const before = await readFile(join(work, 'packages/cli/package.json'), 'utf8');
+    const { stdout } = await setVersion('9.9.9', '--check');
+    expect(stdout).toContain('would change');
+    expect(await readFile(join(work, 'packages/cli/package.json'), 'utf8')).toBe(before);
+  });
+
+  it('round-trips, so a release that is rolled back leaves no trace', async () => {
+    const before = await readFile(join(work, 'packages/cli/package.json'), 'utf8');
+    const original = (await manifest('packages/cli/package.json')).version!;
+    await setVersion('0.2.4-main.90fc463');
+    await setVersion(original);
+    expect(await readFile(join(work, 'packages/cli/package.json'), 'utf8')).toBe(before);
+  });
+
+  it('rewrites a workspace protocol, which publish-order would reject', async () => {
+    // Not hypothetical: `workspace:*` is what npm/pnpm docs suggest, and it cannot be published.
+    const path = join(work, 'packages/cli/package.json');
+    const pkg = JSON.parse(await readFile(path, 'utf8'));
+    pkg.dependencies['@orcareplay/core'] = 'workspace:*';
+    await writeFile(path, `${JSON.stringify(pkg, null, 2)}\n`);
+
+    await setVersion('1.2.3');
+
+    expect((await manifest('packages/cli/package.json')).dependencies?.['@orcareplay/core']).toBe(
+      '1.2.3',
+    );
+  });
+});

--- a/scripts/set-version.test.ts
+++ b/scripts/set-version.test.ts
@@ -126,6 +126,33 @@ describe('set-version', () => {
   });
 
   /**
+   * A numeric prerelease identifier with a leading zero, which npm rewrites rather than refuses.
+   *
+   * `0.2.4-main.0123456` is invalid semver, and `npm publish` does not say so. It runs the manifest
+   * through `@npmcli/package-json`'s `fix()`, which cleans the *version* to `0.2.4-main.123456`
+   * with a warning and leaves every dependency pin naming `0.2.4-main.0123456`. Measured with
+   * npm's own library:
+   *
+   *     fix() version : 0.2.4-main.123456
+   *     fix() dep pin : 0.2.4-main.0123456
+   *
+   * So twelve packages would go out at one version while declaring dependencies on another that
+   * does not exist, and npm never lets a version be replaced — the channel would be permanently
+   * unresolvable. A short sha does this whenever its first seven characters are all digits and
+   * start with a zero, about one commit in 270, which is why `publish-next.yml` prefixes the sha
+   * with a letter as well.
+   */
+  it('refuses a leading-zero numeric prerelease, which npm would silently rewrite', async () => {
+    for (const bad of ['0.2.4-main.0123456', '0.2.4-01', '1.2.3-0.0123', '01.2.3']) {
+      await expect(setVersion(bad), `"${bad}" should be refused`).rejects.toThrow();
+    }
+    // The shapes that are legal must still pass, or the guard is just refusing prereleases.
+    for (const good of ['0.2.4-main.g0123456', '0.2.4-main.123456', '0.2.4-main.0abc123']) {
+      await expect(setVersion(good), `"${good}" should be accepted`).resolves.toBeTruthy();
+    }
+  });
+
+  /**
    * The lockfile half, asserted on what is committed rather than on a re-resolve.
    *
    * An internal dependency must appear in `package-lock.json` as a link to the workspace, never as

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -24,7 +24,10 @@ export default defineConfig({
     },
   },
   test: {
-    include: ['packages/*/test/**/*.test.ts'],
+    // `scripts/` too, because the release scripts are code with no package to live in, and a test
+    // that is never collected is worse than no test: `set-version.test.ts` guards an edit that is
+    // permanent on npm if it goes wrong, and would have sat here green and unrun.
+    include: ['packages/*/test/**/*.test.ts', 'scripts/**/*.test.ts'],
     environment: 'node',
     testTimeout: 30_000,
     hookTimeout: 30_000,


### PR DESCRIPTION
<!-- orca-cr-summary:start -->
<!-- orca-code-review-summary -->
<!-- orca-cr-state: {"p0":0,"p1":0,"p2":0,"p3":0,"push":3} -->

## Orca-Code-Review — push 3

| Severity | Count | Δ vs previous push |
|---|---|---|
| P0 | 0 | 0 |
| P1 | 0 | -1 |
| P2 | 0 | 0 |
| P3 | 0 | 0 |

✅ no blocking findings
<!-- orca-cr-summary:end -->

npm has been a snapshot of whichever commit someone last tagged by hand. Today `latest` and main's `package.json` **both say 0.2.3**, while main is **15 commits and 5681 lines ahead** of `v0.2.3` — the version number matches and the code does not, which is worse than an obvious lag. What is missing from npm includes #50–#64: `orca quickstart`, the framework checks, the OpenCode catalog capture, and the whole credential-sanitising series.

## Two channels

| | what it is | who gets it |
| --- | --- | --- |
| `latest` | a version someone decided to release | `npm i orcareplay` |
| `next` | main, once a day, as `0.2.4-main.<sha>` | `npm i orcareplay@next` |

`next` is safe for a reason worth stating: every version on it is a **prerelease**, which npm excludes from `npm i orcareplay` even though `0.2.4-main.abc1234` sorts *above* `0.2.3`. `--tag next` never moves `latest`. So main is always installable and nobody is opted in by accident.

The same shape `typescript` uses: `latest` is `7.0.2` while `next` is `7.1.0-dev.20260909.1`, and `npm i typescript` still gets `7.0.2`.

## Daily, not per merge — because a version is not free

npm serves a *packument* (the metadata for every version of a package) on each install, and it grows with the version count:

| package | versions | packument |
| --- | --- | --- |
| `orcareplay` | 7 | 20 KB |
| `typescript` | 3820 | **15.6 MB** |

Roughly 4 KB each, paid by everyone who installs — including people who only ever ask for `latest`. Publishing per merge at this repository's rate (~8 pull requests a day) adds ~2900 versions a year and lands in that second row inside twelve months. Daily is an eighth of it, and it is what `typescript` does for its own `-dev` builds.

**04:00 UTC — noon in Beijing.** GitHub's cron is UTC only and best-effort (commonly minutes late, droppable under load), so it is documented as "some time after noon" rather than as a clock. `workflow_dispatch` is there for when a day is too long to wait.

A schedule has to work out two things, so a `pick` job does:

- **which commit** — main at 04:00 may be one whose checks are still running, or red. It takes the newest commit on main that CI actually passed and checks *that* sha out, with full history, because the newest green commit need not be the tip.
- **whether to publish at all** — on a day when nothing merged, the version it would publish is already on the registry. It asks npm rather than keeping state, so it stays right across a re-run and a hand-run minutes after the schedule.

## `release.yml` gains the other half

A version bump reaching main **is** the release: it publishes `latest` and creates the tag itself, so a hand-pushed tag is no longer the trigger. An ordinary merge still releases nothing, decided by a `decide` job that costs seconds instead of the whole suite. A `v*` tag still works, unchanged.

A release is now a pull request that changes a version number:

```console
node scripts/set-version.mjs 0.3.0 --lock
```

## Why a script for what looks like one edit

Twelve packages name each other by **exact** version, so a bump is **38 fields across 13 manifests** — and `npm version --workspaces` moves each package's own `version` while leaving its dependants naming the previous release. Publish that and `orcareplay@0.3.0` depends on `@orcareplay/core@0.2.0`, which npm will never let anyone replace.

`RELEASING.md` documented the `sed` and the `git checkout package-lock.json` dance this replaces, including *why*: `npm version` writes the lockfile at the one moment when the versions have moved and the pins have not, which is how 0.2.1 shipped with correct manifests and two poisoned lockfile entries. `--lock` fixes the pins first and reconciles the lockfile after, so that window does not exist.

## What I verified rather than assumed

- The `pick` logic run against this repository resolves `90fc463`, derives `0.2.4-main.90fc463`, answers `publish=true`; the same sha a second day derives the same version, which npm already has, so it answers `false`.
- All **12 packages dry-run publish** at `0.2.4-main.90fc463` under `--tag next`, in dependency order, CLI last.
- `set-version.mjs --lock` leaves **zero** `registry.npmjs.org/@orcareplay` entries in the lockfile (the 0.2.1 invariant), and `npm ci` passes on the result.
- The round trip back to `0.2.3` restores every file **byte for byte**.
- **10 new tests**; removing the pin rewriting fails 4 of them, including the `publish-order.mjs` gate.
- `publish-order.mjs` had to be relaxed to accept a prerelease — its check exists to forbid a *range*, and `0.2.4-main.abc1234` is exactly one version. Confirmed by trying it: with the old regex all 12 packages were rejected as "must be an exact version"; a range (`^0.2.4-main.…`) still is. Build metadata (`+…`) stays forbidden, because npm ignores it when comparing versions.
- `vitest.config.ts` now collects `scripts/**/*.test.ts`. Without it the new test would have sat there green and unrun — the failure #62 fixed one layer out.
- Full suite: **2026 passed / 23 failed**, failure set identical to main's baseline on this machine (Windows: POSIX modes, SIGTERM, symlinks). conformance 57 events 0 failures; neutrality 0; fidelity 0 regressions.

Both publishing workflows are `concurrency`-grouped and **queue rather than cancel**: the publish loop walks twelve packages one at a time, and a run cancelled half way leaves some of them on the registry at a version the rest do not name — the one state npm will not let anyone fix.

## Notes before merging

- A `schedule` trigger only takes effect **once it is on the default branch**, so the daily run starts after this merges.
- It reuses the existing `NPM_TOKEN`; no new secret.
- `latest` stays at `0.2.3` until someone bumps a version. This PR deliberately does not, and **nothing has been published** — npm still shows `{"latest":"0.2.3"}` and no `next` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)