### PR TITLE
honour --model on TLS-intercepted forks

### DIFF
--- a/packages/cli/test/grok-bot-e2e.test.ts
+++ b/packages/cli/test/grok-bot-e2e.test.ts
@@ -7,7 +7,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { TraceReader } from '@orcareplay/core';
+import { TraceReader, listRuns } from '@orcareplay/core';
 import { RunCa } from '@orcareplay/proxy';
 import { parseArgs } from '../src/args.js';
 import { Output } from '../src/out.js';
@@ -304,5 +304,36 @@ if (process.env.ORCA_TEST_RESULT_OUT) {
     expect(replay.exitCode).toBe(0);
     expect(replay.matchedExact).toBe(1);
     expect(replay.unmatched).toBe(0);
+  });
+
+  /**
+   * Issue #49: `orca replay --from 1 --model <other>` on a TLS-intercepted recording accepted
+   * the flag, echoed it, and called the recorded model. `replayed=0 live=0` meant substitution
+   * never ran. Forking from before the only exchange is a legitimate thing to ask for.
+   */
+  it('honours --model on a fork of a TLS-intercepted recording', async () => {
+    const recorded = await record();
+    expect(recorded.modelExchanges).toBe(1);
+    const before = xai.calls.length;
+    lines.length = 0;
+
+    const fork = await replayCommand(
+      parseArgs(['replay', recorded.runId, '--from', '1', '--model', 'grok-4-fast']),
+      out,
+      workspace,
+    );
+
+    expect(fork.exitCode).toBe(0);
+    expect(fork.liveCalls).toBeGreaterThan(0);
+    expect(xai.calls.length).toBeGreaterThan(before);
+    const live = xai.calls[xai.calls.length - 1] as { body: { model?: string } };
+    expect(live.body.model).toBe('grok-4-fast');
+
+    const forkDir = (await listRuns(workspace)).find((r) => r.runId === fork.forkRunId)?.dir;
+    expect(forkDir, 'the fork wrote a run of its own').toBeDefined();
+    const events = await (await TraceReader.open(forkDir!)).events();
+    const request = events.find((e) => e.type === 'model.request');
+    expect(request?.attrs?.model).toBe('grok-4-fast');
+    expect(lines.join('')).toMatch(/live=1/);
   });
 });

--- a/packages/proxy/src/intercept.ts
+++ b/packages/proxy/src/intercept.ts
@@ -132,6 +132,34 @@ export interface InterceptResponse {
   body: string;
 }
 
+/**
+ * Forward this decrypted request to the origin, but with a different body.
+ *
+ * The CONNECT target stays the recorded host — a TLS-intercepted harness is still talking to the
+ * origin it named — while a fork's `--model` has to change what that origin is asked. Returning a
+ * full {@link InterceptResponse} would answer from orca and never reach the origin; returning
+ * nothing would reach it with the recorded model. This is the third option that `--model` needs.
+ */
+export interface InterceptForward {
+  outboundBody: Buffer;
+}
+
+export type InterceptDecision = InterceptResponse | InterceptForward;
+
+export function isInterceptResponse(decision: InterceptDecision): decision is InterceptResponse {
+  return 'status' in decision;
+}
+
+/**
+ * A rewritten body is uncompressed JSON even when the client sent gzip/zstd. The origin must not
+ * be told the old encoding, or it will try to inflate plaintext and the substitution is lost.
+ */
+function applyRewrittenBody(headers: Record<string, unknown>, body: Buffer): void {
+  delete headers['content-encoding'];
+  delete headers['content-length'];
+  headers['content-length'] = String(body.length);
+}
+
 /** Decode a recorded body, whichever of the two forms it was stored in. */
 export function readRecordedBody(body: string): Buffer {
   return body.startsWith(BINARY_BODY_PREFIX)
@@ -263,10 +291,17 @@ export interface TlsInterceptOptions {
    */
   trustedOriginCerts?: readonly string[];
   maxCapturedBytes?: number;
-  /** Answer a decrypted request from a recording. Undefined falls through to the live origin. */
+  /**
+   * Answer a decrypted request from a recording, or rewrite it before the origin sees it.
+   *
+   * Undefined falls through to the live origin with the client's bytes unchanged. An
+   * {@link InterceptResponse} is served locally and never opens an origin connection. An
+   * {@link InterceptForward} still opens one, with a substituted body — the `--model` path on a
+   * TLS-intercepted fork.
+   */
   onRequest?: (
     request: NetRequest,
-  ) => InterceptResponse | undefined | Promise<InterceptResponse | undefined>;
+  ) => InterceptDecision | undefined | Promise<InterceptDecision | undefined>;
   onNetExchange?: (exchange: NetExchange) => void;
   onTunnel?: (tunnel: TunnelRecord) => void;
   onFailure?: (failure: InterceptFailure) => void;
@@ -543,6 +578,7 @@ export function attachTlsIntercept(
     const responseBody = new Capture(maxCaptured);
     const contentEncoding =
       typeof headers['content-encoding'] === 'string' ? headers['content-encoding'] : undefined;
+    let rewrittenBody: Buffer | undefined;
 
     // Replay answers from the recording and must never reach the origin. The HTTP/1.1 twin has
     // consulted this hook since interception existed; without the same call here, a run recorded
@@ -550,7 +586,7 @@ export function attachTlsIntercept(
     // real model calls, on the caller's own credential, during what the operator ran offline.
     if (options.onRequest) {
       for await (const chunk of stream) requestBody.add(Buffer.from(chunk as Buffer));
-      const reply = await options.onRequest({
+      const decision = await options.onRequest({
         host: target.host,
         port: target.port,
         method,
@@ -559,12 +595,16 @@ export function attachTlsIntercept(
         requestBytes: requestBody.buffer(),
         requestTruncated: requestBody.truncated,
       });
-      if (reply) {
+      if (decision && isInterceptResponse(decision)) {
         if (stream.destroyed) return;
-        stream.respond({ ':status': reply.status, ...(reply.headers ?? {}) });
-        stream.end(reply.body);
+        stream.respond({ ':status': decision.status, ...(decision.headers ?? {}) });
+        stream.end(decision.body);
         counters.intercepted += 1;
         return;
+      }
+      if (decision) {
+        rewrittenBody = decision.outboundBody;
+        applyRewrittenBody(outbound, rewrittenBody);
       }
       // The bounded capture size is also the maximum replayable request size: forwarding a
       // truncated body upstream is worse than refusing clearly, which is what HTTP/1.1 does.
@@ -603,15 +643,19 @@ export function attachTlsIntercept(
         // skipped there -- and an exception in this callback would take the process down with the
         // exchange unrecorded. server.ts already decodes inside a try/catch for the same reason.
         let recordedRequest: string;
-        try {
-          recordedRequest = decodeBody(requestBody.buffer(), contentEncoding);
-        } catch (err) {
-          options.onFailure?.({
-            host: target.host,
-            port: target.port,
-            reason: `request body left opaque: ${String(err)}`,
-          });
-          recordedRequest = requestBody.text();
+        if (rewrittenBody) {
+          recordedRequest = recordableBody(rewrittenBody);
+        } else {
+          try {
+            recordedRequest = decodeBody(requestBody.buffer(), contentEncoding);
+          } catch (err) {
+            options.onFailure?.({
+              host: target.host,
+              port: target.port,
+              reason: `request body left opaque: ${String(err)}`,
+            });
+            recordedRequest = requestBody.text();
+          }
         }
         const decoded = recordableResponseBody(
           responseBody,
@@ -668,7 +712,7 @@ export function attachTlsIntercept(
 
       if (options.onRequest) {
         // The hook above consumed the body, so replay the bytes it read rather than the stream.
-        upstream.end(requestBody.buffer());
+        upstream.end(rewrittenBody ?? requestBody.buffer());
       } else {
         stream.on('data', (chunk: Buffer) => {
           requestBody.add(chunk);
@@ -770,12 +814,13 @@ export function attachTlsIntercept(
     outboundHeaders.host = req.headers.host ?? target.host;
 
     const requestBody = new Capture(maxCaptured);
+    let rewrittenBody: Buffer | undefined;
 
     // Replay has to decide before opening an origin connection. Buffer only when that hook is in
     // use; the recording path below retains the original streaming behaviour and bounded capture.
     if (options.onRequest) {
       for await (const chunk of req) requestBody.add(Buffer.from(chunk as Buffer));
-      const reply = await options.onRequest({
+      const decision = await options.onRequest({
         host: target.host,
         port: target.port,
         method: req.method ?? 'GET',
@@ -784,11 +829,15 @@ export function attachTlsIntercept(
         requestBytes: requestBody.buffer(),
         requestTruncated: requestBody.truncated,
       });
-      if (reply) {
-        res.writeHead(reply.status, reply.headers ?? {});
-        res.end(reply.body);
+      if (decision && isInterceptResponse(decision)) {
+        res.writeHead(decision.status, decision.headers ?? {});
+        res.end(decision.body);
         counters.intercepted += 1;
         return;
+      }
+      if (decision) {
+        rewrittenBody = decision.outboundBody;
+        applyRewrittenBody(outboundHeaders, rewrittenBody);
       }
     }
 
@@ -810,7 +859,7 @@ export function attachTlsIntercept(
       if (requestBody.truncated) {
         upstream.destroy(new Error(`request exceeded capture limit of ${maxCaptured} bytes`));
       } else {
-        upstream.end(requestBody.buffer());
+        upstream.end(rewrittenBody ?? requestBody.buffer());
       }
     } else {
       req.on('data', (chunk: Buffer) => requestBody.add(chunk));
@@ -841,20 +890,24 @@ export function attachTlsIntercept(
         // A body orca cannot decode is still an exchange worth having, and an exception thrown in
         // this callback would take the process down with it. Same guard, same reason, as h2.
         let recordedRequest: string;
-        try {
-          recordedRequest = decodeBody(
-            requestBody.buffer(),
-            typeof req.headers['content-encoding'] === 'string'
-              ? req.headers['content-encoding']
-              : undefined,
-          );
-        } catch (err) {
-          options.onFailure?.({
-            host: target.host,
-            port: target.port,
-            reason: `request body left opaque: ${String(err)}`,
-          });
-          recordedRequest = requestBody.text();
+        if (rewrittenBody) {
+          recordedRequest = recordableBody(rewrittenBody);
+        } else {
+          try {
+            recordedRequest = decodeBody(
+              requestBody.buffer(),
+              typeof req.headers['content-encoding'] === 'string'
+                ? req.headers['content-encoding']
+                : undefined,
+            );
+          } catch (err) {
+            options.onFailure?.({
+              host: target.host,
+              port: target.port,
+              reason: `request body left opaque: ${String(err)}`,
+            });
+            recordedRequest = requestBody.text();
+          }
         }
         const decoded = recordableResponseBody(
           responseBody,

--- a/packages/proxy/src/server.ts
+++ b/packages/proxy/src/server.ts
@@ -34,6 +34,7 @@ import { decodeForwardPath, type ForwardPath } from './forward.js';
 import {
   attachTlsIntercept,
   decodeBody,
+  type InterceptDecision,
   type InterceptResponse,
   type NetExchange,
   type NetRequest,
@@ -42,7 +43,9 @@ import {
 import { RequestMatcher, type Divergence } from './matching.js';
 
 export type {
+  InterceptDecision,
   InterceptFailure,
+  InterceptForward,
   InterceptResponse,
   NetExchange,
   NetRequest,
@@ -588,8 +591,18 @@ export async function createProxy(options: ProxyOptions): Promise<ProxyHandle> {
    * Replay hook for requests inside an intercepted TLS session. The ordinary HTTP proxy reaches
    * `handle()` below, but the TLS interceptor has already terminated the outer CONNECT and needs
    * the same matcher before it opens an origin connection.
+   *
+   * Live calls used to return `undefined` here, which forwarded the client's bytes unchanged —
+   * so `orca replay --from N --model X` on a TLS-intercepted recording echoed `model=X` and then
+   * called the recorded model. `replayed=0 live=0` was the tell: `goLive` never ran, substitution
+   * never had a chance. Same-provider `--model` now rewrites the body and still talks to the
+   * intercepted origin (the only origin that origin's credential can reach). A cross-provider
+   * target would have to leave that host, which this path cannot do; that fails loudly instead of
+   * succeeding with the old model.
    */
-  function onInterceptedRequest(request: NetRequest): InterceptResponse | undefined {
+  function onInterceptedRequest(
+    request: NetRequest,
+  ): InterceptDecision | undefined | Promise<InterceptDecision | undefined> {
     const path = request.path.split('?')[0] ?? '/';
     const dialect = selectDialect(dialects, path);
     if (!dialect || request.method !== 'POST' || request.requestTruncated) return undefined;
@@ -616,7 +629,59 @@ export async function createProxy(options: ProxyOptions): Promise<ProxyHandle> {
       };
     }
     if (result?.error) return replayError(result.error);
-    return undefined;
+    return liveIntercepted(dialect, request, rawBody);
+  }
+
+  /**
+   * A decrypted model call the recording will not serve — past the fork point, or unmatched on a
+   * hybrid / `--loose` run. Counted as live the way `handle()` → `goLive` is, so `fork.done`
+   * `live=N` is the number of exchanges the fork actually owned.
+   */
+  function liveIntercepted(
+    dialect: Dialect,
+    request: NetRequest,
+    rawBody: string,
+  ): InterceptDecision | undefined {
+    if (options.forkModel === undefined) {
+      stats.liveCalls += 1;
+      return undefined;
+    }
+
+    const target = dialect.ownsModel(options.forkModel)
+      ? dialect
+      : (dialects.find((d) => d.ownsModel(options.forkModel!)) ?? dialect);
+    const crossProvider = target.id !== dialect.id;
+
+    if (crossProvider) {
+      return replayError(
+        `--model ${options.forkModel} is served by ${target.id}, not the intercepted ` +
+          `${dialect.id} origin ${request.host}:${request.port}. A TLS-intercepted fork cannot ` +
+          `leave the host the recording talked to. Pick a model that origin serves`,
+      );
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(rawBody);
+    } catch (err) {
+      return replayError(`unparseable request body: ${String(err)}`);
+    }
+    const outboundBody = Buffer.from(
+      JSON.stringify(dialect.withModel(parsed, options.forkModel)),
+      'utf8',
+    );
+    stats.liveCalls += 1;
+    const origin = `https://${request.host}${request.port === 443 ? '' : `:${request.port}`}`;
+    const recordable = recordableOrigin(origin);
+    options.onRoute?.({
+      model: options.forkModel,
+      target: target.id,
+      recorded: dialect.id,
+      ...(recordable === undefined ? {} : { origin: recordable }),
+      crossProvider: false,
+      reason: `served by the recorded dialect ${dialect.id}`,
+    });
+    return { outboundBody };
   }
 
   function tryReplay(

--- a/packages/proxy/test/tls-intercept.test.ts
+++ b/packages/proxy/test/tls-intercept.test.ts
@@ -388,6 +388,8 @@ describe('TLS interception', () => {
   let originSawAuth: string | undefined;
   /** The same, for the headers a provider attributes traffic by. */
   let originSawAttribution: Record<string, string | undefined>;
+  /** Body of a `/v1/chat/completions` the origin received, for `--model` substitution. */
+  let originSawChatBody: string | undefined;
 
   beforeEach(async () => {
     runDir = await mkdtemp(join(tmpdir(), 'orca-mitm-run-'));
@@ -399,6 +401,7 @@ describe('TLS interception', () => {
     modelExchanges = [];
     originSawAuth = undefined;
     originSawAttribution = {};
+    originSawChatBody = undefined;
 
     model = await startOrigin(originCa, (req, res) => {
       const chunks: Buffer[] = [];
@@ -492,6 +495,7 @@ describe('TLS interception', () => {
           return;
         }
         if (req.url === '/v1/chat/completions') {
+          originSawChatBody = body;
           res.writeHead(200, { 'content-type': 'application/json' });
           res.end(
             JSON.stringify({
@@ -1543,5 +1547,109 @@ describe('TLS interception', () => {
     });
     expect(handle.stats().intercepted).toBe(1);
     expect(handle.stats().tunnelled).toBe(1);
+  });
+
+  /**
+   * `--model` on a TLS-intercepted fork. Issue #49: the flag was accepted and echoed, then the
+   * intercepted live path forwarded the recorded model unchanged, and `live=0` because `goLive`
+   * never ran. Same-provider substitution has to rewrite the body and still talk to the CONNECT
+   * target — that origin's credential cannot follow us to a vendor default.
+   */
+  const interceptedChat = {
+    model: 'grok-4',
+    messages: [{ role: 'user', content: 'hello' }],
+  };
+
+  async function postInterceptedChat(
+    handle: ProxyHandle,
+    body: typeof interceptedChat = interceptedChat,
+  ): Promise<ProxiedResponse> {
+    return through({
+      proxyPort: handle.port,
+      host: '127.0.0.1',
+      port: model.port,
+      trust: [runCa.certPem],
+      method: 'POST',
+      path: '/v1/chat/completions',
+      body: JSON.stringify(body),
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+
+  it('substitutes --model on a TLS-intercepted live call and counts it as live', async () => {
+    const routes: Array<{ model: string; origin?: string }> = [];
+    proxy = await createProxy({
+      mode: 'hybrid',
+      exchanges: [],
+      forkAt: 0,
+      forkModel: 'grok-4-fast',
+      onExchange: (e) => void modelExchanges.push(e),
+      onRoute: (d) => void routes.push(d),
+      tls: {
+        ca: runCa,
+        hosts: [`127.0.0.1:${model.port}`],
+        trustedOriginCerts: [originCa.certPem],
+        onNetExchange: (e) => void netExchanges.push(e),
+      },
+    });
+
+    const response = await postInterceptedChat(proxy);
+    expect(response.status).toBe(200);
+    expect(JSON.parse(originSawChatBody ?? '{}').model).toBe('grok-4-fast');
+    expect(proxy.stats().liveCalls).toBe(1);
+    expect(modelExchanges[0]?.canonicalRequest.model).toBe('grok-4-fast');
+    expect(routes).toEqual([
+      expect.objectContaining({
+        model: 'grok-4-fast',
+        recorded: 'openai',
+        target: 'openai',
+        crossProvider: false,
+        origin: `https://127.0.0.1:${model.port}`,
+      }),
+    ]);
+  });
+
+  it('counts a TLS-intercepted live call even when --model is unchanged', async () => {
+    proxy = await createProxy({
+      mode: 'hybrid',
+      exchanges: [],
+      forkAt: 0,
+      onExchange: (e) => void modelExchanges.push(e),
+      tls: {
+        ca: runCa,
+        hosts: [`127.0.0.1:${model.port}`],
+        trustedOriginCerts: [originCa.certPem],
+        onNetExchange: (e) => void netExchanges.push(e),
+      },
+    });
+
+    const response = await postInterceptedChat(proxy);
+    expect(response.status).toBe(200);
+    expect(JSON.parse(originSawChatBody ?? '{}').model).toBe('grok-4');
+    expect(proxy.stats().liveCalls).toBe(1);
+    expect(modelExchanges).toHaveLength(1);
+  });
+
+  it('refuses a cross-provider --model on a TLS-intercepted fork instead of calling the old one', async () => {
+    proxy = await createProxy({
+      mode: 'hybrid',
+      exchanges: [],
+      forkAt: 0,
+      forkModel: 'claude-haiku-4-5',
+      onExchange: (e) => void modelExchanges.push(e),
+      tls: {
+        ca: runCa,
+        hosts: [`127.0.0.1:${model.port}`],
+        trustedOriginCerts: [originCa.certPem],
+        onNetExchange: (e) => void netExchanges.push(e),
+      },
+    });
+
+    const response = await postInterceptedChat(proxy);
+    expect(response.status).toBe(400);
+    expect(response.body).toMatch(/claude-haiku-4-5/);
+    expect(response.body).toMatch(/cannot leave the host/i);
+    expect(originSawChatBody).toBeUndefined();
+    expect(proxy.stats().liveCalls).toBe(0);
   });
 });


### PR DESCRIPTION
<!-- orca-cr-summary:start -->
<!-- orca-code-review-summary -->
<!-- orca-cr-state: {"p0":0,"p1":0,"p2":0,"p3":0,"push":1} -->

## Orca-Code-Review — push 1

| Severity | Count |
|---|---|
| P0 | 0 |
| P1 | 0 |
| P2 | 0 |
| P3 | 0 |

✅ no blocking findings
<!-- orca-cr-summary:end -->

## What this changes

`orca replay --from N --model X` on a TLS-intercepted recording now substitutes the model on live intercepted calls (same provider, same CONNECT origin). A cross-provider `--model` fails with a 400 instead of silently calling the recorded model.

## Why

Fixes #49. The intercept live path returned `undefined` from `onInterceptedRequest`, which forwarded the client's bytes unchanged. The fork line echoed `model=X` and printed `replayed=0 live=0` because `goLive` never ran, so substitution never had a chance. Hermes via `--tls-intercept` is the capture that surfaces it; any `capture: transport` adapter is the same path.

Same-provider `--model` rewrites the decrypted body and still talks to the intercepted origin — the only origin that origin's credential can reach. Live calls are counted. Leaving that host for a different provider's model is impossible on this path, so we fail loudly instead of succeeding with the recorded model.

## Tests

- `packages/proxy/test/tls-intercept.test.ts`: substitutes same-provider `--model` and counts `liveCalls`; counts live even without `--model`; refuses cross-provider `--model` without contacting the origin.
- `packages/cli/test/grok-bot-e2e.test.ts`: end-to-end fork of a TLS-intercepted `exec` recording honours `--model` on the origin and in the fork trace.

`npm run check` — format, typecheck, 2066 tests passed / 14 skipped.

## Checklist

- [x] `npm run check` passes locally
- [x] Tests were written before the implementation
- [x] Spec and schema updated together, if the trace format changed (no format change)
- [x] No new runtime dependencies (or justified above)
- [x] Commits signed off (`git commit -s`)