### PR TITLE
release 0.2.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "orcareplay-monorepo",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "orcareplay-monorepo",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
@@ -1848,30 +1848,30 @@
     },
     "packages/adapters": {
       "name": "@orcareplay/adapters",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@orcareplay/node-instrument": "0.2.3",
-        "@orcareplay/plugin-api": "0.2.3",
-        "@orcareplay/proxy": "0.2.3",
-        "@orcareplay/shell-shim": "0.2.3"
+        "@orcareplay/node-instrument": "0.2.4",
+        "@orcareplay/plugin-api": "0.2.4",
+        "@orcareplay/proxy": "0.2.4",
+        "@orcareplay/shell-shim": "0.2.4"
       }
     },
     "packages/cli": {
       "name": "orcareplay",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@orcareplay/adapters": "0.2.3",
-        "@orcareplay/core": "0.2.3",
-        "@orcareplay/fs-capture": "0.2.3",
-        "@orcareplay/mcp-shim": "0.2.3",
-        "@orcareplay/plugin-api": "0.2.3",
-        "@orcareplay/providers": "0.2.3",
-        "@orcareplay/proxy": "0.2.3",
-        "@orcareplay/schema": "0.2.3",
-        "@orcareplay/shell-shim": "0.2.3",
-        "@orcareplay/viewer": "0.2.3"
+        "@orcareplay/adapters": "0.2.4",
+        "@orcareplay/core": "0.2.4",
+        "@orcareplay/fs-capture": "0.2.4",
+        "@orcareplay/mcp-shim": "0.2.4",
+        "@orcareplay/plugin-api": "0.2.4",
+        "@orcareplay/providers": "0.2.4",
+        "@orcareplay/proxy": "0.2.4",
+        "@orcareplay/schema": "0.2.4",
+        "@orcareplay/shell-shim": "0.2.4",
+        "@orcareplay/viewer": "0.2.4"
       },
       "bin": {
         "orca": "dist/cli.js",
@@ -1883,24 +1883,24 @@
     },
     "packages/core": {
       "name": "@orcareplay/core",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@orcareplay/plugin-api": "0.2.3",
-        "@orcareplay/schema": "0.2.3"
+        "@orcareplay/plugin-api": "0.2.4",
+        "@orcareplay/schema": "0.2.4"
       }
     },
     "packages/fs-capture": {
       "name": "@orcareplay/fs-capture",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@orcareplay/schema": "0.2.3"
+        "@orcareplay/schema": "0.2.4"
       }
     },
     "packages/mcp-shim": {
       "name": "@orcareplay/mcp-shim",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "Apache-2.0",
       "bin": {
         "orca-mcp-shim": "dist/cli.js"
@@ -1908,37 +1908,37 @@
     },
     "packages/node-instrument": {
       "name": "@orcareplay/node-instrument",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "Apache-2.0"
     },
     "packages/plugin-api": {
       "name": "@orcareplay/plugin-api",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "Apache-2.0"
     },
     "packages/providers": {
       "name": "@orcareplay/providers",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@orcareplay/plugin-api": "0.2.3",
-        "@orcareplay/schema": "0.2.3"
+        "@orcareplay/plugin-api": "0.2.4",
+        "@orcareplay/schema": "0.2.4"
       }
     },
     "packages/proxy": {
       "name": "@orcareplay/proxy",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@orcareplay/core": "0.2.3",
-        "@orcareplay/plugin-api": "0.2.3",
-        "@orcareplay/providers": "0.2.3",
-        "@orcareplay/schema": "0.2.3"
+        "@orcareplay/core": "0.2.4",
+        "@orcareplay/plugin-api": "0.2.4",
+        "@orcareplay/providers": "0.2.4",
+        "@orcareplay/schema": "0.2.4"
       }
     },
     "packages/schema": {
       "name": "@orcareplay/schema",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.17.1",
@@ -1947,18 +1947,18 @@
     },
     "packages/shell-shim": {
       "name": "@orcareplay/shell-shim",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@orcareplay/schema": "0.2.3"
+        "@orcareplay/schema": "0.2.4"
       }
     },
     "packages/viewer": {
       "name": "@orcareplay/viewer",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@orcareplay/schema": "0.2.3"
+        "@orcareplay/schema": "0.2.4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -26,5 +26,5 @@
     "typescript": "^5.7.0",
     "vitest": "^4.1.11"
   },
-  "version": "0.2.3"
+  "version": "0.2.4"
 }

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orcareplay/adapters",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "type": "module",
   "license": "Apache-2.0",
   "repository": {
@@ -17,9 +17,9 @@
     "dist"
   ],
   "dependencies": {
-    "@orcareplay/node-instrument": "0.2.3",
-    "@orcareplay/plugin-api": "0.2.3",
-    "@orcareplay/proxy": "0.2.3",
-    "@orcareplay/shell-shim": "0.2.3"
+    "@orcareplay/node-instrument": "0.2.4",
+    "@orcareplay/plugin-api": "0.2.4",
+    "@orcareplay/proxy": "0.2.4",
+    "@orcareplay/shell-shim": "0.2.4"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "orcareplay",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "mcpName": "io.github.Continuum-AI-Corp/orcareplay",
   "type": "module",
   "license": "Apache-2.0",
@@ -38,15 +38,15 @@
     "directory": "packages/cli"
   },
   "dependencies": {
-    "@orcareplay/schema": "0.2.3",
-    "@orcareplay/plugin-api": "0.2.3",
-    "@orcareplay/core": "0.2.3",
-    "@orcareplay/proxy": "0.2.3",
-    "@orcareplay/providers": "0.2.3",
-    "@orcareplay/adapters": "0.2.3",
-    "@orcareplay/fs-capture": "0.2.3",
-    "@orcareplay/viewer": "0.2.3",
-    "@orcareplay/mcp-shim": "0.2.3",
-    "@orcareplay/shell-shim": "0.2.3"
+    "@orcareplay/schema": "0.2.4",
+    "@orcareplay/plugin-api": "0.2.4",
+    "@orcareplay/core": "0.2.4",
+    "@orcareplay/proxy": "0.2.4",
+    "@orcareplay/providers": "0.2.4",
+    "@orcareplay/adapters": "0.2.4",
+    "@orcareplay/fs-capture": "0.2.4",
+    "@orcareplay/viewer": "0.2.4",
+    "@orcareplay/mcp-shim": "0.2.4",
+    "@orcareplay/shell-shim": "0.2.4"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orcareplay/core",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "type": "module",
   "license": "Apache-2.0",
   "repository": {
@@ -17,7 +17,7 @@
     "dist"
   ],
   "dependencies": {
-    "@orcareplay/plugin-api": "0.2.3",
-    "@orcareplay/schema": "0.2.3"
+    "@orcareplay/plugin-api": "0.2.4",
+    "@orcareplay/schema": "0.2.4"
   }
 }

--- a/packages/fs-capture/package.json
+++ b/packages/fs-capture/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orcareplay/fs-capture",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "type": "module",
   "license": "Apache-2.0",
   "repository": {
@@ -17,6 +17,6 @@
     "dist"
   ],
   "dependencies": {
-    "@orcareplay/schema": "0.2.3"
+    "@orcareplay/schema": "0.2.4"
   }
 }

--- a/packages/mcp-shim/package.json
+++ b/packages/mcp-shim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orcareplay/mcp-shim",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "type": "module",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/node-instrument/package.json
+++ b/packages/node-instrument/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orcareplay/node-instrument",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "type": "module",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/plugin-api/package.json
+++ b/packages/plugin-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orcareplay/plugin-api",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "type": "module",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orcareplay/providers",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "type": "module",
   "license": "Apache-2.0",
   "repository": {
@@ -17,7 +17,7 @@
     "dist"
   ],
   "dependencies": {
-    "@orcareplay/plugin-api": "0.2.3",
-    "@orcareplay/schema": "0.2.3"
+    "@orcareplay/plugin-api": "0.2.4",
+    "@orcareplay/schema": "0.2.4"
   }
 }

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orcareplay/proxy",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "type": "module",
   "license": "Apache-2.0",
   "repository": {
@@ -17,9 +17,9 @@
     "dist"
   ],
   "dependencies": {
-    "@orcareplay/plugin-api": "0.2.3",
-    "@orcareplay/schema": "0.2.3",
-    "@orcareplay/core": "0.2.3",
-    "@orcareplay/providers": "0.2.3"
+    "@orcareplay/plugin-api": "0.2.4",
+    "@orcareplay/schema": "0.2.4",
+    "@orcareplay/core": "0.2.4",
+    "@orcareplay/providers": "0.2.4"
   }
 }

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orcareplay/schema",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "type": "module",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/shell-shim/package.json
+++ b/packages/shell-shim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orcareplay/shell-shim",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "type": "module",
   "license": "Apache-2.0",
   "repository": {
@@ -17,6 +17,6 @@
     "dist"
   ],
   "dependencies": {
-    "@orcareplay/schema": "0.2.3"
+    "@orcareplay/schema": "0.2.4"
   }
 }

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orcareplay/viewer",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "type": "module",
   "license": "Apache-2.0",
   "repository": {
@@ -17,6 +17,6 @@
     "dist"
   ],
   "dependencies": {
-    "@orcareplay/schema": "0.2.3"
+    "@orcareplay/schema": "0.2.4"
   }
 }


### PR DESCRIPTION
<!-- orca-cr-summary:start -->
<!-- orca-code-review-summary -->
<!-- orca-cr-state: {"p0":0,"p1":0,"p2":0,"p3":0,"push":1} -->

## Orca-Code-Review — push 1

| Severity | Count |
|---|---|
| P0 | 0 |
| P1 | 0 |
| P2 | 0 |
| P3 | 0 |

✅ no blocking findings
<!-- orca-cr-summary:end -->

Merging this publishes `0.2.4` to npm as `latest` and creates `v0.2.4`. Nothing else in the diff.

`latest` has been stuck on 0.2.3 while main moved 15 commits ahead — the version number matched and the code did not. This ships #50–#66: `orca quickstart`, the framework support checks, OpenCode catalog capture, the credential-sanitising series, and the publishing automation itself.

First release made with `scripts/set-version.mjs` instead of by hand:

```console
node scripts/set-version.mjs 0.2.4 --lock
```

## Checked before pushing

| | |
| --- | --- |
| fields moved | 38, across 13 manifests |
| every internal pin | `0.2.4` |
| `publish-order.mjs` | clean, 12 packages in order |
| lockfile invariant | `registry.npmjs.org/@orcareplay` count **0** (the 0.2.1 poisoning) |
| `npm ci` on the new lockfile | green |
| full suite | 2033 passed / 23 failed, failure set identical to main's baseline |
| conformance / neutrality | clean |
| diff shape | 14 files, 77 lines each way — same as the hand-written `release 0.2.3` |

## The automation this exercises

Already verified in production on the #66 merge and a dispatched dry run:

- `release.yml`'s `decide` answered `main is at 0.2.3, which is already tagged — nothing to release` and skipped the release job, in seconds.
- `Publish next` ran end to end: `pick` succeeded (so `actions: read` is right), chose main's tip `8812949`, derived `0.2.4-main.g8812949`, moved 38 fields and packed all 12 — **12 dry-run lines, 0 publishing lines**, npm untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)