### PR TITLE
fix(test): eleven Windows failures, one of them a real bug

### DIFF
--- a/packages/cli/test/compare.test.ts
+++ b/packages/cli/test/compare.test.ts
@@ -17,17 +17,35 @@ const here = dirname(fileURLToPath(import.meta.url));
 const FAKE_AGENT = join(here, 'fixtures', 'fake-agent.mjs');
 
 describe('compare without --models', () => {
-  it('tells you both ways to supply models when none are available', async () => {
+  /**
+   * An empty config, supplied rather than assumed.
+   *
+   * `compareCommand` falls back to `readConfig()`, which reads the *real* `~/.config/orca`. On a
+   * machine where anyone has run `orca setup` that config has models in it, so this test never
+   * reached the branch it names — it got as far as "no runs recorded" instead and failed on the
+   * wrong error. Nothing to do with the platform; CI passes only because CI has no config.
+   */
+  async function withEmptyConfig<T>(fn: (cwd: string) => Promise<T>): Promise<T> {
     const home = await mkdtemp(join(tmpdir(), 'orca-cmp-cfg-'));
+    const previous = process.env.XDG_CONFIG_HOME;
+    process.env.XDG_CONFIG_HOME = join(home, 'config');
+    try {
+      return await fn(home);
+    } finally {
+      if (previous === undefined) delete process.env.XDG_CONFIG_HOME;
+      else process.env.XDG_CONFIG_HOME = previous;
+      await rm(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
+    }
+  }
+
+  it('tells you both ways to supply models when none are available', async () => {
     const lines: string[] = [];
     const out = new Output({ write: (l) => void lines.push(l), isTTY: false });
-    try {
+    await withEmptyConfig(async (home) => {
       await expect(compareCommand(parseArgs(['compare', 'last']), out, home)).rejects.toThrow(
         /orca setup/,
       );
-    } finally {
-      await rm(home, { recursive: true, force: true });
-    }
+    });
   });
 });
 
@@ -72,9 +90,18 @@ describe('compare', () => {
   }
 
   it('needs models, and says how to give them', async () => {
-    await expect(compareCommand(parseArgs(['compare', 'last']), out, workspace)).rejects.toThrow(
-      /--models/,
-    );
+    // Same reason as the block above: without an empty config this reads the developer's own
+    // `orca setup` models, never reaches the branch, and fails on "no runs recorded" instead.
+    const previous = process.env.XDG_CONFIG_HOME;
+    process.env.XDG_CONFIG_HOME = join(workspace, 'empty-config');
+    try {
+      await expect(compareCommand(parseArgs(['compare', 'last']), out, workspace)).rejects.toThrow(
+        /--models/,
+      );
+    } finally {
+      if (previous === undefined) delete process.env.XDG_CONFIG_HOME;
+      else process.env.XDG_CONFIG_HOME = previous;
+    }
   });
 
   it('forks every model from the SAME parent run, not from the previous fork', async () => {

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -29,15 +29,22 @@ describe('config', () => {
     await rm(home, { recursive: true, force: true });
   });
 
-  it('stores the file where only its owner can read it', async () => {
-    // It holds an API key. 0600 is the same bar ~/.aws/credentials and ~/.npmrc set, and the
-    // directory has to match or the file's mode is decoration.
-    await writeConfig({ gateway: { url: 'https://gw.example', api_key: 'sk-secret' } }, env);
+  // POSIX only. Windows has no mode bits: `chmod 0o600` is a no-op on NTFS and `stat` answers
+  // 0o666 whatever was asked for, so this asserts something the platform cannot provide. Skipped
+  // rather than loosened — the guarantee is real where it can be made, and a test that accepted
+  // 0o666 would stop noticing if it were lost on Linux too.
+  it.skipIf(process.platform === 'win32')(
+    'stores the file where only its owner can read it',
+    async () => {
+      // It holds an API key. 0600 is the same bar ~/.aws/credentials and ~/.npmrc set, and the
+      // directory has to match or the file's mode is decoration.
+      await writeConfig({ gateway: { url: 'https://gw.example', api_key: 'sk-secret' } }, env);
 
-    const path = configPath(env);
-    expect((await stat(path)).mode & 0o777).toBe(0o600);
-    expect((await stat(join(home, 'orca'))).mode & 0o777).toBe(0o700);
-  });
+      const path = configPath(env);
+      expect((await stat(path)).mode & 0o777).toBe(0o600);
+      expect((await stat(join(home, 'orca'))).mode & 0o777).toBe(0o700);
+    },
+  );
 
   it('round-trips what was written', async () => {
     await writeConfig(

--- a/packages/cli/test/generated-esm.test.ts
+++ b/packages/cli/test/generated-esm.test.ts
@@ -1,0 +1,87 @@
+import { readFile, readdir } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const TEST_DIRS = [
+  here,
+  join(here, '..', '..', 'core', 'test'),
+  join(here, '..', '..', 'adapters', 'test'),
+  join(here, '..', '..', 'proxy', 'test'),
+  join(here, '..', '..', 'fs-capture', 'test'),
+];
+
+/**
+ * A path written into generated ESM has to be a `file://` URL.
+ *
+ * Node's loader accepts only `file:`, `data:` and `node:` specifiers, and on Windows a bare
+ * absolute path is neither — `ERR_UNSUPPORTED_ESM_URL_SCHEME`. So the module never loads, the child
+ * dies before its first statement, and the test that spawned it reports whatever follows from
+ * nothing having run.
+ *
+ * That last part is why this is worth a guard of its own rather than a note. Eight tests failed
+ * this way on Windows for as long as anyone had been running them there, and every one of them
+ * reported a *count*:
+ *
+ *     expected 1 to be +0
+ *     expected [] to have a length of 1
+ *
+ * Nothing in those messages points at a loader error, so the failures read as a capture bug on
+ * Windows and sat unexplained. `pathToFileURL` was already the convention elsewhere in the
+ * repository; two places had simply not used it.
+ */
+describe('a path written into generated ESM is a file:// URL', () => {
+  /** Every `.test.ts` we can reach, since the hazard is not specific to one package. */
+  async function testFiles(): Promise<string[]> {
+    const found: string[] = [];
+    for (const dir of TEST_DIRS) {
+      const entries = await readdir(dir, { withFileTypes: true }).catch(() => []);
+      for (const e of entries) {
+        if (e.isFile() && e.name.endsWith('.test.ts')) found.push(join(dir, e.name));
+      }
+    }
+    return found;
+  }
+
+  it('is true of every import specifier a test writes into a module', async () => {
+    const offenders: string[] = [];
+    for (const file of await testFiles()) {
+      // This file's own samples are the shape being guarded against, on purpose.
+      if (file.endsWith('generated-esm.test.ts')) continue;
+      const source = await readFile(file, 'utf8');
+      // An `import ... from` inside a template literal, whose specifier is an interpolation.
+      for (const m of source.matchAll(/import[^\n`]*?from\s*['"]?\$\{([^}]+)\}/g)) {
+        const expr = m[1]!;
+        // `pathToFileURL(...).href` inline is one fix; the other is a constant that already holds
+        // a URL, which reads here as a bare identifier. Resolve those against their declaration
+        // rather than reporting a name — otherwise the guard flags the very fix it asks for.
+        if (/pathToFileURL|\.href|file:\/\//.test(expr)) continue;
+        const named = /^(?:JSON\.stringify\()?\s*([A-Za-z_$][\w$]*)\s*\)?$/.exec(expr.trim());
+        if (named !== null) {
+          const decl = new RegExp(`const ${named[1]}\\s*=([^;]*);`).exec(source);
+          if (decl !== null && /pathToFileURL|\.href|file:\/\//.test(decl[1]!)) continue;
+        }
+        offenders.push(`${file.split(/[\\/]/).pop()}: \${${expr.slice(0, 60)}}`);
+      }
+    }
+    expect(
+      offenders,
+      'these write a bare path as an ESM specifier, which Windows rejects outright',
+    ).toEqual([]);
+  });
+
+  it('catches the shape it is written for', async () => {
+    // The guard is only worth having if it would have caught the original. Both real occurrences
+    // looked like one of these.
+    const bad = [
+      "`import { Orca } from '${join(here, 'dist', 'api.js')}';`",
+      'const s = `import { x } from ${JSON.stringify(SOME_PATH)};`',
+    ];
+    for (const sample of bad) {
+      const hits = [...sample.matchAll(/import[^\n`]*?from\s*['"]?\$\{([^}]+)\}/g)];
+      expect(hits.length, sample).toBe(1);
+      expect(/pathToFileURL|\.href/.test(hits[0]![1]!)).toBe(false);
+    }
+  });
+});

--- a/packages/cli/test/grok-bot-e2e.test.ts
+++ b/packages/cli/test/grok-bot-e2e.test.ts
@@ -4,7 +4,7 @@ import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import type { AddressInfo } from 'node:net';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { promisify } from 'node:util';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { TraceReader } from '@orcareplay/core';
@@ -17,7 +17,15 @@ import { replayCommand } from '../src/commands/replay.js';
 const run = promisify(execFile);
 const here = dirname(fileURLToPath(import.meta.url));
 const IDE_PARENT = join(here, 'fixtures', 'ide-parent.mjs');
-const PROXY_CALL = join(here, 'fixtures', 'proxy-call.mjs');
+/**
+ * As a `file://` URL, because it is written into a generated `.mjs` as an import specifier.
+ *
+ * A bare absolute path works on POSIX and is rejected outright on Windows:
+ * `ERR_UNSUPPORTED_ESM_URL_SCHEME — on Windows, absolute paths must be valid file:// URLs`. The bot
+ * then failed to start, the recording came back empty, and all six tests in this file reported the
+ * counts that follow from nothing having run rather than the loader error that caused it.
+ */
+const PROXY_CALL = pathToFileURL(join(here, 'fixtures', 'proxy-call.mjs')).href;
 
 /**
  * A Grok bot, and any other agent whose origin is a string in its own source.

--- a/packages/cli/test/review-regressions.test.ts
+++ b/packages/cli/test/review-regressions.test.ts
@@ -2,7 +2,7 @@ import { execFile } from 'node:child_process';
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { promisify } from 'node:util';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { canonicalToAnthropicRequest, responsesToCanonicalRequest } from '@orcareplay/providers';
@@ -108,7 +108,9 @@ describe('the embedded API never lets an agent write to the caller’s stdout', 
     const file = join(workspace, 'drive.mjs');
     await writeFile(
       file,
-      `import { Orca } from '${join(here, '..', 'dist', 'api.js')}';\n` +
+      // A `file://` URL, not a bare path: written into a generated `.mjs`, an absolute Windows
+      // path is rejected by the ESM loader outright and the child dies before its first statement.
+      `import { Orca } from '${pathToFileURL(join(here, '..', 'dist', 'api.js')).href}';\n` +
         `const orca = new Orca({ cwd: ${JSON.stringify(workspace)} });\n${script}`,
     );
     const { stdout } = await run(process.execPath, [file], { cwd: workspace });

--- a/packages/core/test/blobs.test.ts
+++ b/packages/core/test/blobs.test.ts
@@ -96,12 +96,19 @@ describe('BlobStore.put', () => {
     expect(ref.bytes).toBe(3);
   });
 
-  it('writes blobs unreadable by other users — a trace is sensitive material', async () => {
-    const ref = await store.put('secret-ish');
-    const hex = ref.$blob.slice('sha256:'.length);
-    const s = await stat(join(dir, 'blobs', hex.slice(0, 2), hex));
-    expect(s.mode & 0o777).toBe(0o600);
-  });
+  // POSIX only. Windows has no mode bits: `chmod 0o600` is a no-op on NTFS and `stat` answers
+  // 0o666 whatever was asked for, so this asserts something the platform cannot provide. Skipped
+  // rather than loosened — the guarantee is real where it can be made, and a test that accepted
+  // 0o666 would stop noticing if it were lost on Linux too.
+  it.skipIf(process.platform === 'win32')(
+    'writes blobs unreadable by other users — a trace is sensitive material',
+    async () => {
+      const ref = await store.put('secret-ish');
+      const hex = ref.$blob.slice('sha256:'.length);
+      const s = await stat(join(dir, 'blobs', hex.slice(0, 2), hex));
+      expect(s.mode & 0o777).toBe(0o600);
+    },
+  );
 
   it('stores an empty blob', async () => {
     const ref = await store.put('');

--- a/packages/core/test/writer.test.ts
+++ b/packages/core/test/writer.test.ts
@@ -401,7 +401,11 @@ describe('TraceWriter.close', () => {
     expect(await w.close(0)).toEqual(first);
   });
 
-  it('keeps every file it writes owner-only', async () => {
+  // POSIX only. Windows has no mode bits: `chmod 0o600` is a no-op on NTFS and `stat` answers
+  // 0o666 whatever was asked for, so this asserts something the platform cannot provide. Skipped
+  // rather than loosened — the guarantee is real where it can be made, and a test that accepted
+  // 0o666 would stop noticing if it were lost on Linux too.
+  it.skipIf(process.platform === 'win32')('keeps every file it writes owner-only', async () => {
     const w = await TraceWriter.create(runs, INIT);
     await w.append({ type: 'note', actor: 'orca' });
     await w.close();


### PR DESCRIPTION
<!-- orca-cr-summary:start -->
<!-- orca-code-review-summary -->
<!-- orca-cr-state: {"p0":0,"p1":0,"p2":0,"p3":0,"push":1} -->

## Orca-Code-Review — push 1

| Severity | Count |
|---|---|
| P0 | 0 |
| P1 | 0 |
| P2 | 0 |
| P3 | 0 |

✅ no blocking findings
<!-- orca-cr-summary:end -->

The local test baseline on Windows has been 23 failures for as long as anyone has run it there. CI is green, so none of this was visible on Linux. This takes it to 10.

The cost was not the red — it was that every verification had to be diffed against a 23-item list instead of read as "green", and twice in one session that produced a wrong conclusion in both directions: a pre-existing failure read as newly introduced, and an introduced one read as pre-existing.

## The real bug: a bare path is not an ESM specifier

Eight failures, one cause, and none of the messages said so:

```
expected 1 to be +0
expected [] to have a length of 1 but got +0
```

Those are counts that follow from nothing having run. Two lines further into the output:

```
Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data, and node
are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs
```

`grok-bot-e2e.test.ts` and `review-regressions.test.ts` each write a generated `.mjs` and interpolate a path into its `import`. The child died before its first statement, the recording came back empty, and the assertions reported the emptiness.

`pathToFileURL` was already the convention here — `scaffold.test.ts` and `opencode-capture.ts` both use it. These two places had not.

**`generated-esm.test.ts` stops it recurring.** It reads every test file for an `import … from ${…}` inside a template literal and fails unless the expression is a `file://` URL, resolving a named constant against its declaration so the fix does not read as the bug. Mutation-tested: reverting either call turns it red and names the file.

## Not bugs: three POSIX permission assertions

```
expected 438 to be 384      // 0o666 vs 0o600
```

Windows has no mode bits — `chmod` is a no-op on NTFS and `stat` answers `0o666` whatever was asked. Skipped with `it.skipIf(process.platform === 'win32')`, the spelling already used in `shell-capture` and `shell-shim`.

Skipped rather than loosened: the guarantee is real where it can be made, and a test that accepted `0o666` would stop noticing if it were lost on Linux too.

## Not a platform problem at all: two tests read the developer's own config

```
expected [Function] to throw error matching /--models/
but got 'no runs recorded in C:\Users\...\.orca\runs'
```

`compareCommand` falls back to `readConfig()` with no argument, which reads the real `~/.config/orca/config.json`. On any machine where someone has run `orca setup`, that file has models in it, so these two tests never reached the branch they are named for. CI passes because CI has no config — which is exactly why a test that depends on its absence should supply that absence rather than assume it.

Both now point `XDG_CONFIG_HOME` at an empty directory.

Fixing them made a third failure visible that the early error had been masking (`forks every model from the SAME parent run` now reaches its own assertion). It was already in the baseline under a different message; left for its own commit rather than folded in here.

## Verification

| | |
|---|---|
| Windows baseline | **23 → 10**, and **zero new failures** against the original list |
| full suite | 2028 passing |
| `generated-esm.test.ts` | 2/2, mutation-tested both ways |
| conformance / fidelity / neutrality | clean |
| integration matrix | unchanged |

Every one of the eleven passes on Linux, which is why CI never saw them and why CI is unaffected by this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)