### PR TITLE
test: check LlamaIndex and Mastra, and pin what LlamaIndex refuses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,12 @@ jobs:
       # failed, so a contributor can run the suite without all of them.
       - run: >
           pip install openai anthropic litellm langgraph langchain-openai browser-use
-          crewai openai-agents openhands-sdk
+          crewai openai-agents openhands-sdk llama-index-core llama-index-llms-openai
+      # Mastra is the one framework here that is JS, and it is 130 MB — more than this repo's whole
+      # dependency tree. `--no-save` keeps it out of package.json so it costs this job and nothing
+      # else: no npm ci anywhere else gets slower, and a contributor who has not run this line gets
+      # a skip rather than a failure, exactly as the pip line above behaves.
+      - run: npm install --no-save @mastra/core @ai-sdk/openai
       # `--require-all`, because installing them above was never what enforced it. Two checks were
       # added without a line here and CI stayed green on the skips, while the README said "in CI"
       # about both. A skip is now a failure on this runner, so forgetting the line above fails
@@ -77,6 +82,11 @@ jobs:
         working-directory: .
         env:
           OPENAI_API_KEY: unused-but-crewai-wants-one
+      # Same shape, same reason: LlamaIndex refuses any model name outside a list compiled into it,
+      # before a request is made. That is a real limit on pointing it at a gateway, `docs/integrations.md`
+      # now says so, and this is what fails when it stops being true.
+      - run: python test/integrations/agents/llama_index_model_names.py
+        working-directory: .
 
   python-sdk:
     name: python sdk

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -114,6 +114,42 @@ no longer applies.
 
 ---
 
+## LlamaIndex
+
+```console
+orca record generic-openai -- python your_agent.py
+```
+
+The one framework here that does **not** read `OPENAI_BASE_URL`. Measured, both ways:
+
+| set | `llm._get_client().base_url` |
+|---|---|
+| `OPENAI_BASE_URL` | `https://api.openai.com/v1/` — ignored |
+| `OPENAI_API_BASE` | the value you set — honoured |
+
+`generic-openai` sets both, which is why this works without you doing anything. It is worth knowing
+because it is also why `orca record exec` does not: that adapter redirects nothing on purpose.
+
+**Measured:** recorded and replayed at `exact=1 divergences=0`.
+
+### The model name has to be one LlamaIndex knows
+
+`OpenAI(model=…)` is validated against a list compiled into `llama_index.llms.openai.utils`, and
+anything outside it raises `ValueError: Unknown model '…'`. There is no `context_window` argument to
+supply instead. So the usual gateway case — a model name the vendor never published, a local model,
+an internal router — does not work, and no orca setting changes that, because nothing has reached
+the wire when it fails.
+
+Where it raises is worth knowing too: **not** in the constructor. `OpenAI(model='my-gateway-model')`
+returns fine and the error arrives from `.metadata`, which the chat path reads on every call — so it
+surfaces at the first message rather than at setup.
+
+`test/integrations/agents/llama_index_model_names.py` pins all of this, including the absence of
+`context_window`: if LlamaIndex adds one, that becomes the recommended answer and this section is
+wrong until it is rewritten.
+
+---
+
 ## Aider
 
 ```console
@@ -233,6 +269,25 @@ the one place every JS client agrees on.
 
 **Measured:** an agent posting to a hardcoded `https://api.openai.com/v1/chat/completions`,
 recorded and replayed at `exact=1 divergences=0`.
+
+---
+
+## Mastra
+
+```console
+orca record node -- node your_agent.mjs
+```
+
+Mastra takes its model from `@ai-sdk/openai`, so it inherits that provider's behaviour exactly: the
+origin is a constructor argument and the environment is not consulted. The `node` adapter's fetch
+preload is what captures it.
+
+**Measured:** an `Agent` calling `generate()`, recorded and replayed at `exact=1 divergences=0` with
+the origin stopped.
+
+Worth having as its own check rather than leaning on the Vercel AI SDK one above: a preload that
+works against a bare `fetch` can still be defeated by a framework that wraps or replaces it, and
+that is not something to find out from a user.
 
 ---
 

--- a/test/integrations/agents/llama_index_agent.py
+++ b/test/integrations/agents/llama_index_agent.py
@@ -1,0 +1,27 @@
+"""LlamaIndex's own OpenAI LLM, which reads the older base-URL variable and not the new one.
+
+Worth a check rather than a claim, and for a sharper reason than most of this corpus. LlamaIndex
+does not read `OPENAI_BASE_URL` at all — measured, not assumed:
+
+    OPENAI_BASE_URL set   →  client.base_url == https://api.openai.com/v1/     (ignored)
+    OPENAI_API_BASE set   →  client.base_url == http://127.0.0.1:8888/v1/      (honoured)
+
+`generic-openai` happens to set both, with a comment saying pre-1.0 SDKs and ports need the older
+name. This check is what turns that comment into something that fails when it stops being true:
+drop `OPENAI_API_BASE` from the adapter and every other check here still passes, because every
+other framework reads the new name.
+
+The model name is a real one rather than `stub-1` because LlamaIndex refuses anything outside its
+own built-in list — `ValueError: Unknown model 'stub-1'`, raised from `openai_modelname_to_contextsize`
+before a request is ever made, and there is no `context_window` argument to bypass it. That is a
+property of LlamaIndex, not of orca, and `llama_index_model_names.py` is what stops the claim
+drifting. The stub echoes whatever model it is given, so the name changes nothing here.
+"""
+
+from llama_index.core.llms import ChatMessage
+from llama_index.llms.openai import OpenAI
+
+llm = OpenAI(model="gpt-4o-mini")
+print("base_url:", llm._get_client().base_url)
+reply = llm.chat([ChatMessage(role="user", content="hello")])
+print("GOT:", reply.message.content)

--- a/test/integrations/agents/llama_index_model_names.py
+++ b/test/integrations/agents/llama_index_model_names.py
@@ -1,0 +1,67 @@
+"""Which model names LlamaIndex's OpenAI LLM accepts, and when it decides.
+
+Not a recording check — nothing here talks to a model. It pins a claim `docs/integrations.md`
+makes, for the same reason the CrewAI one exists: a sentence about model names in someone else's
+library is exactly the kind of thing that is true when written and false two releases later, and
+we have already shipped that mistake once.
+
+The claim: LlamaIndex validates the model name against a list compiled into
+`llama_index.llms.openai.utils`, and refuses anything outside it *before any request is made*. So
+a name your gateway understands but OpenAI never published — the usual case when pointing
+LlamaIndex at a proxy, a local model, or an internal router — does not work, and no orca setting
+changes that, because nothing has reached the wire yet.
+
+Where it raises matters as much as that it raises. The check is not in the constructor: `OpenAI(...)`
+returns fine, and the ValueError arrives from `openai_modelname_to_contextsize` when `.metadata` is
+first read, which the chat path does on every call. A user therefore sees it at the first message
+rather than at setup, and there is no `context_window` argument to supply instead — asserted below,
+because if LlamaIndex adds one, that becomes the recommended workaround and the docs should say so.
+"""
+
+from llama_index.core.llms import ChatMessage
+from llama_index.llms.openai import OpenAI
+
+# Names from LlamaIndex's own list. These must keep working or the integration check is wrong too.
+KNOWN = ["gpt-4o-mini", "gpt-4.1-mini"]
+
+# What a gateway or a local model is actually called. None of these is in any OpenAI list.
+UNKNOWN = ["stub-1", "my-gateway-model", "llama-3.1-70b"]
+
+
+def accepts(name: str) -> tuple[bool, str]:
+    """Construct and read metadata, which is what the chat path does before sending anything."""
+    try:
+        llm = OpenAI(model=name, api_key="unused")
+        llm.metadata  # noqa: B018 - reading it is the operation under test
+        return True, ""
+    except Exception as exc:  # noqa: BLE001 - any refusal counts
+        return False, type(exc).__name__
+
+
+failures = []
+
+for name in KNOWN:
+    ok, why = accepts(name)
+    print(f"  {name:22} {'accepted' if ok else 'refused':9} {'ok' if ok else 'UNEXPECTED ' + why}")
+    if not ok:
+        failures.append(f"{name} should be accepted")
+
+for name in UNKNOWN:
+    ok, why = accepts(name)
+    print(f"  {name:22} {'accepted' if ok else 'refused':9} {'UNEXPECTED' if ok else 'ok — ' + why}")
+    if ok:
+        failures.append(f"{name} was accepted; LlamaIndex no longer gates on its own model list")
+
+# The constructor itself must stay permissive, or the sentence above about *where* it raises is
+# wrong — and that sentence is the difference between "fails at setup" and "fails at first message".
+try:
+    OpenAI(model="my-gateway-model", api_key="unused")
+except Exception as exc:  # noqa: BLE001
+    failures.append(f"the constructor now refuses too ({type(exc).__name__}); the docs describe the old behaviour")
+
+if "context_window" in OpenAI.model_fields:
+    failures.append("OpenAI now takes context_window — that is a supported escape hatch and the docs should recommend it")
+
+if failures:
+    raise SystemExit("LlamaIndex disagreed with the docs: " + "; ".join(failures))
+print("GOT: every case matches what docs/integrations.md says")

--- a/test/integrations/agents/mastra_agent.mjs
+++ b/test/integrations/agents/mastra_agent.mjs
@@ -1,0 +1,20 @@
+/**
+ * A Mastra agent, which is the Vercel AI SDK case with a framework on top of it.
+ *
+ * Mastra takes its model from `@ai-sdk/openai`, and that provider takes its origin as a
+ * constructor argument rather than from the environment — so base-URL injection reaches nothing
+ * here and the capture is the `NODE_OPTIONS` fetch hook, the same layer `hardcoded_origin.mjs`
+ * covers. This check is the framework-shaped version of that one: it is worth having both, because
+ * a hook that works on a bare `fetch` can still be defeated by a library that wraps it.
+ */
+import { openai } from '@ai-sdk/openai';
+import { Agent } from '@mastra/core/agent';
+
+const agent = new Agent({
+  name: 'stub-agent',
+  instructions: 'Answer in one short sentence.',
+  model: openai('stub-1'),
+});
+
+const res = await agent.generate('hello');
+console.log('GOT:', res.text);

--- a/test/integrations/run.mjs
+++ b/test/integrations/run.mjs
@@ -12,6 +12,7 @@
  *   node test/integrations/run.mjs --require-all # a skip is a failure, which is what CI wants
  */
 import { execFile, spawn } from 'node:child_process';
+import { createRequire } from 'node:module';
 import { cp, mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
@@ -106,6 +107,31 @@ const CHECKS = [
     exchanges: 1,
   },
   {
+    id: 'mastra',
+    what: 'Mastra, whose model provider takes its origin in code rather than from the environment',
+    adapter: 'node',
+    run: ['node', 'agents/mastra_agent.mjs'],
+    needsNode: '@mastra/core/agent',
+    /**
+     * Run from the agent's place in the repo rather than the copy in the temp directory.
+     *
+     * ESM resolves a bare specifier from the *importing file's* location, not from the working
+     * directory, and `NODE_PATH` does not apply to it. A copy under the system temp directory
+     * therefore cannot see `@mastra/core` however the environment is arranged. Running the
+     * original leaves the recording where every other check puts it — the run directory follows
+     * the working directory, which is still the temp one.
+     */
+    fromRepo: true,
+    exchanges: 1,
+  },
+  {
+    id: 'llama-index',
+    what: "LlamaIndex's own OpenAI LLM, which reads the older base-URL variable and not the new one",
+    run: ['python', 'agents/llama_index_agent.py'],
+    needs: 'llama_index.llms.openai',
+    exchanges: 1,
+  },
+  {
     id: 'fetch-hook',
     what: 'a JS agent with its origin compiled in',
     adapter: 'node',
@@ -119,6 +145,22 @@ async function installed(module) {
   if (module === undefined) return true;
   try {
     await exec('python', ['-c', `import ${module}`], { timeout: 30_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The same question for a JS dependency.
+ *
+ * Resolved rather than imported: importing runs the package's top-level code, and a check that is
+ * only asking whether something is present should not be able to fail because of what it does.
+ */
+function installedNode(specifier) {
+  if (specifier === undefined) return true;
+  try {
+    createRequire(join(here, 'agents', 'x.mjs')).resolve(specifier);
     return true;
   } catch {
     return false;
@@ -167,6 +209,7 @@ async function orca(argv, cwd) {
 
 async function runCheck(check) {
   if (!(await installed(check.needs))) return { skipped: `${check.needs} is not installed` };
+  if (!installedNode(check.needsNode)) return { skipped: `${check.needsNode} is not installed` };
 
   const dir = await mkdtemp(join(tmpdir(), `orca-int-${check.id}-`));
   const origin = await startOrigin();
@@ -183,7 +226,9 @@ async function runCheck(check) {
         '--upstream-anthropic',
         `http://127.0.0.1:${origin.port}`,
         '--',
-        ...check.run,
+        ...(check.fromRepo
+          ? [check.run[0], join(here, ...check.run.slice(1).join('/').split('/'))]
+          : check.run),
       ],
       dir,
     );


### PR DESCRIPTION
<!-- orca-cr-summary:start -->
<!-- orca-code-review-summary -->
<!-- orca-cr-state: {"p0":0,"p1":0,"p2":0,"p3":0,"push":1} -->

## Orca-Code-Review — push 1

| Severity | Count |
|---|---|
| P0 | 0 |
| P1 | 0 |
| P2 | 0 |
| P3 | 0 |

✅ no blocking findings
<!-- orca-cr-summary:end -->

`docs/integrations.md` opens by saying every number on it comes from `test/integrations/run.mjs`,
which runs in CI, "so a claim on this page fails a build rather than ageing quietly". Two frameworks
were verified by hand months apart and never made it into that file. This adds them, and one of
them turned out to be load-bearing.

## LlamaIndex is the one framework here that ignores `OPENAI_BASE_URL`

Measured, both ways:

| set | `llm._get_client().base_url` |
|---|---|
| `OPENAI_BASE_URL` | `https://api.openai.com/v1/` — **ignored** |
| `OPENAI_API_BASE` | the value — honoured |

`generic-openai` already sets both, with a comment saying pre-1.0 SDKs and ports need the older
name. **Nothing enforced that comment.** Every other check in the matrix reads the new name, so
deleting `OPENAI_API_BASE` from the adapter would have left the whole suite green and silently
broken LlamaIndex for anyone using it. Now one check goes red.

### It also refuses model names, and where it refuses them matters

`OpenAI(model=…)` is validated against a list compiled into `llama_index.llms.openai.utils`;
anything outside it raises `ValueError: Unknown model '…'`. So the ordinary gateway case — a model
name the vendor never published, a local model, an internal router — does not work, and no orca
setting changes that, because nothing has reached the wire when it fails.

The raise is **not** in the constructor. `OpenAI(model='my-gateway-model')` returns fine and the
error arrives from `.metadata`, which the chat path reads on every call — so a user meets it at the
first message, not at setup. There is no `context_window` argument to supply instead.

`llama_index_model_names.py` pins all three facts, the way `crewai_model_names.py` pins the CrewAI
ones and for the same reason — that paragraph has been wrong twice already. It also asserts
`context_window` is *still absent*: if LlamaIndex adds one, that becomes the recommended workaround
and this section is wrong until someone rewrites it.

## Mastra is the Vercel AI SDK case with a framework on top

Captured by the `NODE_OPTIONS` fetch preload, not by base-URL injection — `@ai-sdk/openai` takes its
origin as a constructor argument. Worth its own check rather than leaning on `hardcoded_origin.mjs`:
a preload that works against a bare `fetch` can still be defeated by a framework that wraps or
replaces it, and that is not something to find out from a user.

## Two mechanical notes for the reviewer

**`fromRepo`** runs an agent from its place in the repo instead of the copy in the temp directory.
ESM resolves a bare specifier from the *importing file's* location and `NODE_PATH` does not apply to
it, so a copy under the system temp directory cannot see `@mastra/core` however the environment is
arranged. The run directory still follows the working directory, so the recording lands exactly
where every other check puts it.

**Mastra is `npm install --no-save` in the integrations job**, not a devDependency. It is 130 MB —
larger than this repo's entire dependency tree — and one check is not worth doubling `npm ci`
everywhere else, forever. A contributor who has not run that line gets a skip, which is how the
`pip install` line above it already behaves.

## Verification

- both checks: record → **origin stopped** → replay, `exact=1 divergences=0`
- full matrix green (13 checks) with every framework installed
- the model-name guard mutation-tested: claim a gated name is ungated and it exits 1 with
  `LlamaIndex no longer gates on its own model list`
- full `vitest run` matches the clean baseline line for line
- **the CI dependency set re-resolved from scratch** with `pip install --dry-run`, because adding
  LlamaIndex next to CrewAI is exactly the kind of thing that quietly breaks a pin. It resolves:
  pydantic lands on 2.12.5, inside CrewAI's `<2.13` ceiling, with crewai 1.15.21 and litellm 1.100.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
